### PR TITLE
Implement microstrip dispersion pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- Correct microstrip results by enabling Kirschning--Jansen modal dispersion by
+  default. Set `dispersion=None` on `MicrostripLine` to retain the quasi-static
+  pipeline explicitly.
+- Add the Hammerstad--Jensen microstrip formulation and selectable complex
+  (ADS-like) and real (QUCS-like) permittivity conventions.

--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -91,6 +91,9 @@ from pmrf.models.components.lines.formulations import (
     TescheCoaxialFormulation as TescheCoaxialFormulation,
     AbstractMicrostripFormulation as AbstractMicrostripFormulation,
     WheelerMicrostripFormulation as WheelerMicrostripFormulation,
+    HammerstadJensenMicrostripFormulation as HammerstadJensenMicrostripFormulation,
+    AbstractMicrostripDispersion as AbstractMicrostripDispersion,
+    KirschningJansen as KirschningJansen,
     QuasiStaticResult as QuasiStaticResult,
 )
 

--- a/pmrf/models/components/lines/base.py
+++ b/pmrf/models/components/lines/base.py
@@ -49,6 +49,31 @@ class ImmittanceResult(eqx.Module):
         w = jnp.asarray(w)
         return cls(Z=R + 1j * w * L, Y=G + 1j * w * C, w=w)
 
+    @classmethod
+    def from_zc_gamma(cls, zc, gamma, w) -> "ImmittanceResult":
+        r"""Invert characteristic impedance and propagation constant exactly.
+
+        The per-unit-length quantities are the exact bijection
+        $$Z = \gamma Z_c \qquad Y = \frac{\gamma}{Z_c}.$$
+
+        A passive line must have non-negative series resistance and shunt
+        conductance. Violating that condition indicates that an empirical
+        formulation has been evaluated outside its physical regime.
+        """
+        Z = gamma * zc
+        Y = gamma / zc
+        # Exact lossless products can leave round-off-sized negative real parts.
+        # Reject physical negativity while allowing that numerical noise floor.
+        z_tol = 64 * jnp.finfo(jnp.real(Z).dtype).eps * jnp.maximum(jnp.abs(Z), 1)
+        y_tol = 64 * jnp.finfo(jnp.real(Y).dtype).eps * jnp.maximum(jnp.abs(Y), 1)
+        Z = eqx.error_if(
+            Z, jnp.any(jnp.real(Z) < -z_tol), "inversion produced Re(Z) < 0"
+        )
+        Y = eqx.error_if(
+            Y, jnp.any(jnp.real(Y) < -y_tol), "inversion produced Re(Y) < 0"
+        )
+        return cls(Z=Z, Y=Y, w=jnp.asarray(w))
+
     @property
     def R(self) -> jnp.ndarray:
         """Series resistance per unit length in ohm/m."""

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -315,7 +315,6 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
     """
 
     def quasi_static(self, freq: Frequency, *, w, h, t, ep_r, zs) -> QuasiStaticResult:
-        del zs
         u = w / h
         thickness = None if t is None else t / h
 
@@ -432,7 +431,6 @@ class KirschningJansen(AbstractMicrostripDispersion):
     def disperse(
         self, freq: Frequency, *, ep_eff_0, zc_0, ep_r, w, w_eff, h, t
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
-        del t
         # ADS applies the effective width in its complex-permittivity path;
         # QUCS applies the physical width in its real-permittivity path.
         dispersion_width = w_eff if jnp.iscomplexobj(ep_r) else w

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -269,3 +269,230 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
 
         return QuasiStaticResult(ep_eff=ep_eff, zc=zc, w_eff=w_eff)
 
+
+class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
+    r"""
+    Hammerstad--Jensen quasi-static microstrip formulation.
+
+    **Mathematical Formulation**
+
+    For normalized width $u=W/H$, the impedance of the homogeneous geometry is
+    $$Z_L(u) = \frac{Z_0}{2\pi}\ln\left[\frac{F(u)}{u}
+    + \sqrt{1 + \left(\frac{2}{u}\right)^2}\right]$$
+    $$F(u) = 6 + (2\pi - 6)\exp\left[-(30.666/u)^{0.7528}\right].$$
+
+    With normalized thickness $t_n=T/H$, finite conductor thickness changes the
+    normalized widths in air and in the dielectric:
+    $$\Delta u_1 = \frac{t_n}{\pi}\ln\left[1 + \frac{4e}{t_n}
+    \tanh^2\left(\sqrt{6.517u}\right)\right]$$
+    $$\Delta u_r = \frac{\Delta u_1}{2}\left[1 +
+    \operatorname{sech}\left(\sqrt{\varepsilon_r-1}\right)\right],
+    \qquad u_1=u+\Delta u_1,\quad u_r=u+\Delta u_r.$$
+
+    The empirical exponents are
+    $$a = 1 + \frac{1}{49}\ln\left[\frac{u_r^4+(u_r/52)^2}
+    {u_r^4+0.432}\right] + \frac{1}{18.7}\ln\left[1+(u_r/18.1)^3\right]$$
+    $$b = 0.564\left(\frac{\varepsilon_r-0.9}{\varepsilon_r+3}\right)^{0.053}.$$
+    Defining
+    $$e = \frac{\varepsilon_r + 1}{2}
+    + \frac{\varepsilon_r - 1}{2}(1 + 10/u_r)^{-ab},$$
+    the returned quantities are
+    $$Z_c=\frac{Z_L(u_r)}{\sqrt{e}},\qquad
+    \varepsilon_e=e\left[\frac{Z_L(u_1)}{Z_L(u_r)}\right]^2,
+    \qquad W_{eff}=u_rH,$$
+    where $e$ denotes the bracketed permittivity expression before its
+    thickness correction.
+
+    The fractional power in $b$ is evaluated through the principal logarithm.
+    The dielectric constraint $\Re(\varepsilon_r)>1$ keeps its argument away
+    from the negative-real branch cut for passive materials.
+
+    References
+    ----------
+    Hammerstad, E., & Jensen, O. (1980). Accurate Models for Microstrip
+    Computer-Aided Design. IEEE MTT-S International Microwave Symposium Digest,
+    407-409.
+    """
+
+    def quasi_static(self, freq: Frequency, *, w, h, t, ep_r, zs) -> QuasiStaticResult:
+        del zs
+        u = w / h
+        thickness = None if t is None else t / h
+
+        du1 = 0.0
+        if thickness is not None:
+            du1 = thickness / jnp.pi * jnp.log(
+                1 + 4 * jnp.e / thickness * jnp.tanh(jnp.sqrt(6.517 * u)) ** 2
+            )
+
+        dur = du1 * (1 + 1 / jnp.cosh(jnp.sqrt(ep_r - 1))) / 2
+        u1 = u + du1
+        ur = u + dur
+
+        zr = self._homogeneous_impedance(ur)
+        z1 = self._homogeneous_impedance(u1)
+
+        a = (
+            1
+            + jnp.log((ur**4 + (ur / 52) ** 2) / (ur**4 + 0.432)) / 49
+            + jnp.log(1 + (ur / 18.1) ** 3) / 18.7
+        )
+        b_argument = (ep_r - 0.9) / (ep_r + 3)
+        b = 0.564 * jnp.exp(0.053 * jnp.log(b_argument))
+        e = (ep_r + 1) / 2 + (ep_r - 1) / 2 * (1 + 10 / ur) ** (-a * b)
+
+        zc = zr / jnp.sqrt(e)
+        ep_eff = e * (z1 / zr) ** 2
+        w_eff = ur * h
+        return QuasiStaticResult(ep_eff=ep_eff, zc=zc, w_eff=w_eff)
+
+    @staticmethod
+    def _homogeneous_impedance(u):
+        z0 = jnp.sqrt(mu_0 / epsilon_0)
+        f_u = 6 + (2 * jnp.pi - 6) * jnp.exp(-(30.666 / u) ** 0.7528)
+        return z0 / (2 * jnp.pi) * jnp.log(f_u / u + jnp.sqrt(1 + (2 / u) ** 2))
+
+
+class AbstractMicrostripDispersion(eqx.Module):
+    """Abstract modal-dispersion formulation for an inhomogeneous microstrip."""
+
+    @abstractmethod
+    def disperse(
+        self, freq: Frequency, *, ep_eff_0, zc_0, ep_r, w, w_eff, h, t
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        r"""Return frequency-dependent $(\varepsilon_e, Z_c)$."""
+        raise NotImplementedError
+
+
+class KirschningJansen(AbstractMicrostripDispersion):
+    r"""
+    Kirschning--Jansen modal dispersion for microstrip.
+
+    **Mathematical Formulation**
+
+    The model expresses the dispersed effective permittivity as
+    $$\varepsilon_e(f) = \varepsilon_r
+    - \frac{\varepsilon_r-\varepsilon_e(0)}{1 + P(f)},$$
+    where $P=P_1P_2(0.1844+P_3P_4)^{1.5763}f_n^{1.5763}$ and the $P_i$
+    are
+    $$P_1=0.27488+\left[0.6315+\frac{0.525}{(1+0.0157f_n)^{20}}\right]u
+    -0.065683e^{-8.7513u}$$
+    $$P_2=0.33622(1-e^{-0.03442\varepsilon_r}),\quad
+    P_3=0.0363e^{-4.6u}[1-e^{-(f_n/38.7)^{4.97}}]$$
+    $$P_4=1+2.751[1-e^{-(\varepsilon_r/15.916)^8}].$$
+    The normalized frequency is
+    $f_n=f[\mathrm{Hz}]H[\mathrm{m}]10^{-6}$ (GHz-mm).
+    Following the ADS and QUCS conventions, the normalized width is
+    $$u=\begin{cases}W_{eff}/H,&\text{complex permittivity},\\
+    W/H,&\text{real permittivity}.\end{cases}$$
+
+    Characteristic impedance is corrected by
+    $$Z_c(f)=Z_c(0)\left(\frac{R_{13}}{R_{14}}\right)^{R_{17}},$$
+    with
+    $$R_1=\min(0.03891\varepsilon_r^{1.4},20),\quad
+    R_2=\min(0.2671u^7,20),\quad R_3=4.766e^{-3.228u^{0.641}}$$
+    $$R_4=0.016+(0.0514\varepsilon_r)^{4.524},\quad
+    R_5=(f_n/28.843)^{12},\quad R_6=\min(22.20u^{1.92},20)$$
+    $$R_7=1.206-0.3144e^{-R_1}(1-e^{-R_2})$$
+    $$R_8=1+1.275\left[1-e^{-0.004625R_3\varepsilon_r^{1.674}
+    (f_n/18.365)^{2.745}}\right]$$
+    $$R_9=\frac{5.086R_4R_5e^{-R_6}}{(0.3838+0.386R_4)(1+1.2992R_5)}
+    \frac{(\varepsilon_r-1)^6}{1+10(\varepsilon_r-1)^6}$$
+    $$R_{10}=0.00044\varepsilon_r^{2.136}+0.0184,\quad
+    R_{11}=\frac{(f_n/19.47)^6}{1+0.0962(f_n/19.47)^6},\quad
+    R_{12}=\frac{1}{1+0.00245u^2}$$
+    $$R_{13}=0.9408\varepsilon_e(f)^{R_8}-0.9603,\quad
+    R_{14}=(0.9408-R_9)\varepsilon_e(0)^{R_8}-0.9603$$
+    $$R_{15}=0.707R_{10}(f_n/12.3)^{1.097},\quad
+    R_{16}=1+0.0503\varepsilon_r^2R_{11}[1-e^{-(u/15)^6}]$$
+    $$R_{17}=R_7\left[1-\frac{1.1241R_{12}}{R_{16}}
+    e^{-0.026f_n^{1.15656}-R_{15}}\right].$$
+
+    The papers validate the fit from $\varepsilon_r=2.2$, while modal
+    dispersion must vanish at the homogeneous $\varepsilon_r=1$ limit. In the
+    extrapolation interval ParamRF therefore applies the smooth weight
+    $$x=\operatorname{clip}\left(\frac{\Re(\varepsilon_r)-1}{1.2},0,1\right),
+    \qquad q=x^2(3-2x),$$
+    $$\varepsilon_e=(1-q)\varepsilon_e(0)+q\varepsilon_{e,KJ},\qquad
+    Z_c=(1-q)Z_c(0)+qZ_{c,KJ}.$$
+    This extension is not part of the cited empirical fit; it supplies a
+    continuous, differentiable connection to its required homogeneous limit.
+
+    References
+    ----------
+    Kirschning, M., & Jansen, R. H. (1982). Accurate Model for Effective
+    Dielectric Constant of Microstrip with Validity up to Millimeter-Wave
+    Frequencies. Electronics Letters, 18(6), 272-273.
+
+    Jansen, R. H., & Kirschning, M. (1983). Arguments and an Accurate Model for
+    the Power-Current Formulation of Microstrip Characteristic Impedance.
+    Archiv fuer Elektronik und Uebertragungstechnik, 37, 108-112.
+    """
+
+    def disperse(
+        self, freq: Frequency, *, ep_eff_0, zc_0, ep_r, w, w_eff, h, t
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        del t
+        # ADS applies the effective width in its complex-permittivity path;
+        # QUCS applies the physical width in its real-permittivity path.
+        dispersion_width = w_eff if jnp.iscomplexobj(ep_r) else w
+        u = dispersion_width / h
+        fn = freq.f * h * 1e-6
+
+        p1 = (
+            0.27488
+            + (0.6315 + 0.525 / (1 + 0.0157 * fn) ** 20) * u
+            - 0.065683 * jnp.exp(-8.7513 * u)
+        )
+        p2 = 0.33622 * (1 - jnp.exp(-0.03442 * ep_r))
+        p3 = 0.0363 * jnp.exp(-4.6 * u) * (1 - jnp.exp(-(fn / 38.7) ** 4.97))
+        p4 = 1 + 2.751 * (1 - jnp.exp(-(ep_r / 15.916) ** 8))
+        p_f = p1 * p2 * ((0.1844 + p3 * p4) * fn) ** 1.5763
+        ep_eff = ep_r - (ep_r - ep_eff_0) / (1 + p_f)
+
+        r1_raw = 0.03891 * ep_r**1.4
+        r1 = jnp.where(jnp.real(r1_raw) < 20, r1_raw, 20)
+        r2 = jnp.minimum(0.2671 * u**7, 20)
+        r3 = 4.766 * jnp.exp(-3.228 * u**0.641)
+        r4 = 0.016 + (0.0514 * ep_r) ** 4.524
+        r5 = (fn / 28.843) ** 12
+        r6 = jnp.minimum(22.20 * u**1.92, 20)
+        r7 = 1.206 - 0.3144 * jnp.exp(-r1) * (1 - jnp.exp(-r2))
+        r8 = 1 + 1.275 * (
+            1 - jnp.exp(-0.004625 * r3 * ep_r**1.674 * (fn / 18.365) ** 2.745)
+        )
+        r9 = (
+            5.086
+            * r4
+            * r5
+            / (0.3838 + 0.386 * r4)
+            * jnp.exp(-r6)
+            / (1 + 1.2992 * r5)
+            * (ep_r - 1) ** 6
+            / (1 + 10 * (ep_r - 1) ** 6)
+        )
+        r10 = 0.00044 * ep_r**2.136 + 0.0184
+        r11 = (fn / 19.47) ** 6 / (1 + 0.0962 * (fn / 19.47) ** 6)
+        r12 = 1 / (1 + 0.00245 * u**2)
+        r13 = 0.9408 * ep_eff**r8 - 0.9603
+        r14 = (0.9408 - r9) * ep_eff_0**r8 - 0.9603
+        r15 = 0.707 * r10 * (fn / 12.3) ** 1.097
+        r16 = 1 + 0.0503 * ep_r**2 * r11 * (1 - jnp.exp(-(u / 15) ** 6))
+        r17 = r7 * (
+            1
+            - 1.1241
+            * r12
+            / r16
+            * jnp.exp(-0.026 * fn**1.15656 - r15)
+        )
+        zc = zc_0 * (r13 / r14) ** r17
+
+        # The published fit starts at epsilon_r=2.2, while modal dispersion must
+        # vanish at the homogeneous epsilon_r=1 limit. Smoothly introduce the
+        # empirical correction over that extrapolation interval. The smoothstep
+        # has zero slope at both ends, keeping values and gradients continuous.
+        fit_fraction = jnp.clip((jnp.real(ep_r) - 1) / 1.2, 0, 1)
+        modal_weight = fit_fraction**2 * (3 - 2 * fit_fraction)
+        ep_eff = ep_eff_0 + modal_weight * (ep_eff - ep_eff_0)
+        zc = zc_0 + modal_weight * (zc - zc_0)
+        return ep_eff, zc

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -1,7 +1,9 @@
 """
 Physical transmission lines (general, coaxial, microstrip)
 """
-from scipy.constants import c
+from typing import Literal
+
+from scipy.constants import c, epsilon_0, mu_0
 import jax.numpy as jnp
 
 from pmrf.frequency import Frequency
@@ -19,10 +21,21 @@ from pmrf.parameters import Param, param, as_param
 from pmrf.models.components.lines.base import AbstractImmittanceLine, ImmittanceResult
 from pmrf.models.components.lines.formulations import (
     AbstractCoaxialFormulation,
+    AbstractMicrostripDispersion,
     AbstractMicrostripFormulation,
+    KirschningJansen,
     TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
 )
+
+
+EpsilonConvention = Literal["complex", "real"]
+
+
+def _as_epsilon_convention(value: str) -> EpsilonConvention:
+    if value not in ("complex", "real"):
+        raise ValueError("epsilon_convention must be 'complex' or 'real'")
+    return value
 
 # -----------------------------------------------------------------------------
 # Lines
@@ -287,9 +300,29 @@ class MicrostripLine(AbstractImmittanceLine):
     
     Uses :class:`WheelerMicrostripFormulation` for the default mathematical formulation.
 
-    The formulation returns a :class:`QuasiStaticResult`, which
-    :meth:`QuasiStaticResult.to_immittance` turns into an immittance using the
-    conductor's surface impedance.
+    The quasi-static formulation returns a :class:`QuasiStaticResult`. With
+    modal dispersion disabled, :meth:`QuasiStaticResult.to_immittance` converts
+    it directly; otherwise the dispersed modal quantities are inverted exactly.
+
+    **Mathematical Formulation**
+
+    The line evaluates material permittivity, a quasi-static formulation, and
+    then the optional modal-dispersion formulation. Under the complex
+    convention the material loss is carried directly by effective permittivity:
+    $$\gamma_m=\frac{j\omega}{c}\sqrt{\varepsilon_e(f)}.$$
+    Under the real convention, QUCS-like dielectric attenuation is added to a
+    real phase constant:
+    $$\alpha_d=\frac{\pi f}{c}\frac{\varepsilon_r}{\varepsilon_r-1}
+    \frac{\varepsilon_e(0)-1}{\sqrt{\varepsilon_e(0)}}\tan\delta,
+    \qquad \beta=\frac{\omega}{c}\sqrt{\varepsilon_e(f)}.$$
+
+    For a finite-thickness conductor, Wheeler's incremental-inductance
+    correction adds
+    $$\alpha_c=\frac{\Re(Z_s)}{\Re(Z_{c,loss})W}
+    \exp\left[-1.2\left(\frac{\Re(Z_{c,loss})}{Z_0}\right)^{0.7}\right].$$
+    The resulting modal quantities are inverted exactly into the line's
+    internal currency:
+    $$Z=\gamma Z_c,\qquad Y=\frac{\gamma}{Z_c}.$$
     
     Example
     --------
@@ -323,9 +356,30 @@ class MicrostripLine(AbstractImmittanceLine):
         The material of the trace and ground plane. A scalar resistivity in
         ohm-meters is coerced into a :class:`~pmrf.materials.BulkConductor`.
     t : Param | None, default=None
-        Thickness of the conductor. Not yet used, provided for future compatibility.
+        Thickness of the conductor. Wheeler requires ``None``; thickness-aware
+        formulations such as Hammerstad--Jensen use a positive value.
     formulation : AbstractMicrostripFormulation, default=WheelerMicrostripFormulation()
         The closed-form physics used to compute the quasi-static solution.
+    dispersion : AbstractMicrostripDispersion | None, default=KirschningJansen()
+        The modal-dispersion correction. ``None`` disables modal dispersion and
+        preserves the quasi-static immittance path.
+    epsilon_convention : {'complex', 'real'}, default='complex'
+        Whether the quasi-static and modal formulas consume the full complex
+        material permittivity or only its real part. The real convention adds
+        dielectric attenuation separately.
+
+    References
+    ----------
+    Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
+    IRE, 30(9), 412-424.
+
+    Kirschning, M., & Jansen, R. H. (1982). Accurate Model for Effective
+    Dielectric Constant of Microstrip with Validity up to Millimeter-Wave
+    Frequencies. Electronics Letters, 18(6), 272-273.
+
+    Jansen, R. H., & Kirschning, M. (1983). Arguments and an Accurate Model for
+    the Power-Current Formulation of Microstrip Characteristic Impedance.
+    Archiv fuer Elektronik und Uebertragungstechnik, 37, 108-112.
     """
     #: Width of the microstrip trace
     w: Param = param(default=3e-3, constraint=Positive())
@@ -343,26 +397,94 @@ class MicrostripLine(AbstractImmittanceLine):
         default_factory=BulkConductor, converter=as_conductor
     )
     
-    #: Thickness of the conductor. Not yet used, provided for future compatibility.
+    #: Thickness of the conductor
     t: Param | None = field(default=None, converter=lambda x: as_param(x, constraint=Positive()) if x is not None else None)
     
     #: The underlying physics formulation
     formulation: AbstractMicrostripFormulation = field(default_factory=WheelerMicrostripFormulation)
-    
-    def __post_init__(self):
-        if self.t is not None:
-            raise ValueError("Thickness not yet supported in `MicrostripLine`")
+
+    #: The modal-dispersion formulation, or None to disable it
+    dispersion: AbstractMicrostripDispersion | None = field(default_factory=KirschningJansen)
+
+    #: Permittivity convention used by the empirical formulas
+    epsilon_convention: EpsilonConvention = field(
+        default="complex", static=True, converter=_as_epsilon_convention
+    )
 
     def immittance(self, freq: Frequency) -> ImmittanceResult:
         zs = self.conductor.surface_impedance(freq)
+        material_ep_r = self.dielectric.epsilon_r(freq)
+        formula_ep_r = (
+            material_ep_r if self.epsilon_convention == "complex" else jnp.real(material_ep_r)
+        )
 
         quasi_static = self.formulation.quasi_static(
             freq,
             w=self.w,
             h=self.h,
             t=self.t,
-            ep_r=self.dielectric.epsilon_r(freq),
+            ep_r=formula_ep_r,
             zs=zs,
         )
 
-        return quasi_static.to_immittance(freq, zs)
+        if self.dispersion is None and self.epsilon_convention == "complex":
+            return quasi_static.to_immittance(freq, zs)
+
+        if self.dispersion is None:
+            ep_eff, zc = quasi_static.ep_eff, quasi_static.zc
+        else:
+            ep_eff, zc = self.dispersion.disperse(
+                freq,
+                ep_eff_0=quasi_static.ep_eff,
+                zc_0=quasi_static.zc,
+                ep_r=formula_ep_r,
+                w=self.w,
+                w_eff=quasi_static.w_eff,
+                h=self.h,
+                t=self.t,
+            )
+
+        if self.epsilon_convention == "complex":
+            gamma = 1j * freq.w * jnp.sqrt(ep_eff) / c
+        else:
+            gamma = self._real_convention_gamma(
+                freq, material_ep_r, ep_eff, quasi_static.ep_eff
+            )
+
+        # Wheeler's incremental-inductance rule. With no finite conductor
+        # thickness scikit-rf defines this empirical correction as zero.
+        if self.t is not None:
+            z0 = jnp.sqrt(mu_0 / epsilon_0)
+            loss_zc = zc if self.epsilon_convention == "complex" else quasi_static.zc
+            current_distribution = jnp.exp(-1.2 * (jnp.real(loss_zc) / z0) ** 0.7)
+            gamma = gamma + (
+                jnp.real(zs) / (jnp.real(loss_zc) * self.w) * current_distribution
+            )
+
+        return ImmittanceResult.from_zc_gamma(zc, gamma, freq.w)
+
+    @staticmethod
+    def _real_convention_gamma(freq, material_ep_r, ep_eff, loss_ep_eff):
+        ep_r_real = jnp.real(material_ep_r)
+        ep_eff_real = jnp.real(ep_eff)
+        loss_ep_eff_real = jnp.real(loss_ep_eff)
+        tan_delta = -jnp.imag(material_ep_r) / ep_r_real
+
+        delta_ep_r = ep_r_real - 1
+        safe_delta = jnp.where(jnp.abs(delta_ep_r) > 1e-14, delta_ep_r, 1.0)
+        filling = jnp.where(
+            jnp.abs(delta_ep_r) > 1e-14,
+            (loss_ep_eff_real - 1) / safe_delta,
+            0.0,
+        )
+        alpha_dielectric = (
+            jnp.pi
+            * ep_r_real
+            * filling
+            / jnp.sqrt(loss_ep_eff_real)
+            * tan_delta
+            * freq.f
+            / c
+        )
+        beta = freq.w * jnp.sqrt(ep_eff_real) / c
+        return alpha_dielectric + 1j * beta

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -1,6 +1,8 @@
 import pytest
 import numpy as np
+import jax
 import jax.numpy as jnp
+import equinox as eqx
 from pmrf.frequency import Frequency
 
 from scipy.constants import c, mu_0, epsilon_0
@@ -134,6 +136,7 @@ def test_microstrip_line_impedance(basic_freq):
         h=1.6e-3,
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
         conductor=BulkConductor(rho=0.0),
+        dispersion=None,
         length=0.1,
     )
     
@@ -202,6 +205,7 @@ def test_microstrip_line_matches_skrf(basic_freq):
         h=H,
         dielectric=ConstantDielectric(ep_r=ep_r, tand=0.0),
         conductor=BulkConductor(rho=0.0),
+        dispersion=None,
         length=0.1,
     )
     media = MLine(
@@ -243,6 +247,16 @@ def test_immittance_rlgc_at_dc():
     assert jnp.allclose(imm.C, 100e-12)
 
 
+def test_immittance_inversion_rejects_non_passive_result():
+    """Exact (Zc, gamma) inversion surfaces non-physical empirical output."""
+    from pmrf.models import ImmittanceResult
+
+    with pytest.raises(eqx.EquinoxRuntimeError, match=r"Re\(Z\) < 0"):
+        ImmittanceResult.from_zc_gamma(
+            zc=jnp.array([50.0]), gamma=jnp.array([-1.0 + 1j]), w=jnp.array([1.0])
+        )
+
+
 def test_dispersive_dielectric_is_grid_independent():
     """
     A dispersive material is a function of frequency alone, so the same line
@@ -281,3 +295,242 @@ def test_microstrip_formulation_takes_plain_arrays(basic_freq):
     assert result.ep_eff.shape == (npoints,)
     assert jnp.all(jnp.real(result.zc) > 40.0)
     assert jnp.allclose(result.w_eff, 3.0e-3)
+
+
+def test_lossy_microstrip_preserves_dispersed_zc_and_phase():
+    """The dispersed modal solution survives exact immittance inversion."""
+    from pmrf.models import HammerstadJensenMicrostripFormulation, KirschningJansen
+
+    freq = Frequency(start=1.0, stop=50.0, npoints=51, unit="GHz")
+    formulation = HammerstadJensenMicrostripFormulation()
+    dispersion = KirschningJansen()
+    line = MicrostripLine(
+        w=0.2e-3,
+        h=0.5e-3,
+        t=18e-6,
+        dielectric=ConstantDielectric(ep_r=10.0, tand=0.05),
+        conductor=BulkConductor(rho=1e-6),
+        formulation=formulation,
+        dispersion=dispersion,
+        length=0.1,
+    )
+
+    ep_r = line.dielectric.epsilon_r(freq)
+    zs = line.conductor.surface_impedance(freq)
+    quasi_static = formulation.quasi_static(
+        freq, w=line.w, h=line.h, t=line.t, ep_r=ep_r, zs=zs
+    )
+    ep_eff, expected_zc = dispersion.disperse(
+        freq,
+        ep_eff_0=quasi_static.ep_eff,
+        zc_0=quasi_static.zc,
+        ep_r=ep_r,
+        w=line.w,
+        w_eff=quasi_static.w_eff,
+        h=line.h,
+        t=line.t,
+    )
+
+    zc, gamma_length = line.zc_and_gammaL(freq)
+    gamma = gamma_length / line.length
+
+    assert jnp.allclose(zc, expected_zc, rtol=1e-12, atol=1e-12)
+    expected_beta = jnp.imag(1j * freq.w * jnp.sqrt(ep_eff) / c)
+    assert jnp.allclose(jnp.imag(gamma), expected_beta, rtol=1e-12, atol=1e-12)
+
+
+def test_microstrip_without_dispersion_preserves_quasi_static_immittance():
+    """Disabling stage three reproduces the pre-dispersion pipeline exactly."""
+    freq = Frequency(start=1.0, stop=20.0, npoints=21, unit="GHz")
+    line = MicrostripLine(
+        w=3e-3,
+        h=1.6e-3,
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
+        conductor=BulkConductor(rho=1.72e-8),
+        dispersion=None,
+        length=0.1,
+    )
+
+    ep_r = line.dielectric.epsilon_r(freq)
+    zs = line.conductor.surface_impedance(freq)
+    quasi_static = line.formulation.quasi_static(
+        freq, w=line.w, h=line.h, t=line.t, ep_r=ep_r, zs=zs
+    )
+
+    actual = line.immittance(freq)
+    expected = quasi_static.to_immittance(freq, zs)
+    assert jnp.array_equal(actual.Z, expected.Z)
+    assert jnp.array_equal(actual.Y, expected.Y)
+
+
+def test_microstrip_defaults_to_kirschning_jansen():
+    """Modal dispersion is the accuracy-oriented microstrip default."""
+    from pmrf.models import KirschningJansen
+
+    assert isinstance(MicrostripLine(length=0.1).dispersion, KirschningJansen)
+
+
+def test_hammerstad_jensen_finite_thickness_matches_skrf():
+    """The thickness-aware quasi-static formulation agrees with scikit-rf."""
+    from skrf.media import MLine
+    from pmrf.models import HammerstadJensenMicrostripFormulation
+
+    freq = Frequency(start=1.0, stop=10.0, npoints=10, unit="GHz")
+    formulation = HammerstadJensenMicrostripFormulation()
+    ep_r = jnp.full(freq.npoints, 4.3)
+    result = formulation.quasi_static(
+        freq, w=1e-3, h=1e-3, t=35e-6, ep_r=ep_r, zs=jnp.zeros(freq.npoints)
+    )
+    media = MLine(
+        freq.to_skrf(),
+        w=1e-3,
+        h=1e-3,
+        t=35e-6,
+        ep_r=4.3,
+        tand=0.0,
+        rho=1.68e-8,
+        rough=0.0,
+        model="hammerstadjensen",
+        disp="none",
+        diel="frequencyinvariant",
+    )
+
+    assert jnp.allclose(result.zc, media.z0_characteristic, rtol=1e-12)
+    assert jnp.allclose(result.ep_eff, media.ep_reff, rtol=1e-12)
+    assert jnp.allclose(result.w_eff, media.w_eff, rtol=1e-12)
+
+
+@pytest.mark.parametrize("ep_r", [2.2, 4.3, 10.0])
+@pytest.mark.parametrize("width_height", [0.1, 1.0, 10.0])
+def test_kirschning_jansen_matches_skrf(ep_r, width_height):
+    """Kirschning--Jansen agrees with its independent scikit-rf implementation."""
+    from skrf.media import MLine
+    from pmrf.models import HammerstadJensenMicrostripFormulation
+
+    freq = Frequency(start=0.1, stop=50.0, npoints=101, unit="GHz")
+    h = 1e-3
+    line = MicrostripLine(
+        w=width_height * h,
+        h=h,
+        dielectric=ConstantDielectric(ep_r=ep_r, tand=0.0),
+        conductor=BulkConductor(rho=0.0),
+        formulation=HammerstadJensenMicrostripFormulation(),
+        length=0.1,
+    )
+    media = MLine(
+        freq.to_skrf(),
+        w=width_height * h,
+        h=h,
+        ep_r=ep_r,
+        tand=0.0,
+        rho=0.0,
+        rough=0.0,
+        model="hammerstadjensen",
+        disp="kirschningjansen",
+        diel="frequencyinvariant",
+        compatibility_mode=None,
+    )
+
+    zc, gamma_length = line.zc_and_gammaL(freq)
+    assert jnp.allclose(zc, media.z0_characteristic, rtol=1e-3)
+    assert jnp.allclose(gamma_length / line.length, media.gamma, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    ("convention", "compatibility_mode"),
+    [("complex", None), ("real", "qucs")],
+)
+def test_microstrip_epsilon_convention_matches_skrf(convention, compatibility_mode):
+    """Both documented permittivity conventions match their scikit-rf modes."""
+    from skrf.media import MLine
+    from pmrf.models import HammerstadJensenMicrostripFormulation
+
+    freq = Frequency(start=1.0, stop=50.0, npoints=51, unit="GHz")
+    line = MicrostripLine(
+        w=1e-3,
+        h=1e-3,
+        t=35e-6,
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
+        conductor=BulkConductor(rho=1.68e-8),
+        formulation=HammerstadJensenMicrostripFormulation(),
+        epsilon_convention=convention,
+        length=0.1,
+    )
+    media = MLine(
+        freq.to_skrf(),
+        w=1e-3,
+        h=1e-3,
+        t=35e-6,
+        ep_r=4.3,
+        tand=0.02,
+        rho=1.68e-8,
+        rough=0.0,
+        model="hammerstadjensen",
+        disp="kirschningjansen",
+        diel="frequencyinvariant",
+        compatibility_mode=compatibility_mode,
+    )
+
+    zc, gamma_length = line.zc_and_gammaL(freq)
+    assert jnp.allclose(zc, media.z0_characteristic, rtol=1e-3)
+    assert jnp.allclose(gamma_length / line.length, media.gamma, rtol=1e-3)
+
+
+def test_real_epsilon_convention_retains_loss_without_modal_dispersion():
+    """The convention switch is independent of enabling modal dispersion."""
+    freq = Frequency(start=1.0, stop=10.0, npoints=10, unit="GHz")
+    line = MicrostripLine(
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
+        conductor=BulkConductor(rho=0.0),
+        dispersion=None,
+        epsilon_convention="real",
+        length=0.1,
+    )
+
+    assert jnp.all(line.immittance(freq).G > 0)
+
+
+def test_microstrip_rejects_unknown_epsilon_convention():
+    with pytest.raises(ValueError, match="epsilon_convention"):
+        MicrostripLine(epsilon_convention="hybrid", length=0.1)
+
+
+def test_microstrip_near_air_has_finite_conductance_and_gradient():
+    """The old filling-factor singularity cannot return at εr approaching one."""
+    freq = Frequency(start=1.0, stop=5.0, npoints=5, unit="GHz")
+
+    def response(ep_r):
+        line = MicrostripLine(
+            w=1e-3,
+            h=1e-3,
+            dielectric=ConstantDielectric(ep_r=ep_r, tand=0.02),
+            conductor=BulkConductor(rho=0.0),
+            length=0.1,
+        )
+        return jnp.real(line.s(freq)[-1, 0, 0])
+
+    near_air = MicrostripLine(
+        w=1e-3,
+        h=1e-3,
+        dielectric=ConstantDielectric(ep_r=1.0 + 1e-12, tand=0.02),
+        conductor=BulkConductor(rho=0.0),
+        length=0.1,
+    )
+    near_air_g = near_air.immittance(freq).G
+    slightly_above = MicrostripLine(
+        w=1e-3,
+        h=1e-3,
+        dielectric=ConstantDielectric(ep_r=1.0 + 2e-12, tand=0.02),
+        conductor=BulkConductor(rho=0.0),
+        length=0.1,
+    ).immittance(freq).G
+    assert jnp.all(jnp.isfinite(near_air_g))
+    assert jnp.allclose(near_air_g, slightly_above, rtol=1e-10, atol=1e-12)
+
+    gradients = jax.vmap(jax.grad(response))(jnp.linspace(1.0 + 1e-12, 12.0, 25))
+    assert jnp.all(jnp.isfinite(gradients))
+
+
+def test_coaxial_line_has_no_modal_dispersion_field():
+    """Homogeneously filled coax has no modal-dispersion stage."""
+    assert not hasattr(CoaxialLine(length=0.1), "dispersion")


### PR DESCRIPTION
Closes #62

## Summary

- add Kirschning–Jansen modal dispersion as the microstrip default
- add the finite-thickness Hammerstad–Jensen formulation
- invert dispersed characteristic impedance and propagation constant exactly into immittance with passivity checks
- add complex and real permittivity conventions, near-air continuity, and scikit-rf validation
- document the physics and record the result change in the changelog

## Verification

- `.venv/bin/python -P -m pytest` — 380 passed, 28 skipped
- `.venv/bin/python -c "import pmrf"`
- two-axis standards/spec review — no findings