### PR TITLE
Implement complete Tesche coaxial formulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Complete Tesche coaxial conductor physics across the low-frequency regime,
+  and pass evaluated material properties to pure coaxial formulations.
 - Correct microstrip results by enabling Kirschning--Jansen modal dispersion by
   default. Set `dispersion=None` on `MicrostripLine` to retain the quasi-static
   pipeline explicitly.

--- a/pmrf/materials/conductor.py
+++ b/pmrf/materials/conductor.py
@@ -22,13 +22,8 @@ from pmrf.utils import field
 class AbstractConductor(Module):
     r"""Abstract base class for a conductor material.
 
-    The surface impedance interface is deliberately geometry-free, in ohm per
-    square, which is the right currency for planar lines. Coaxial lines are the
-    exception: the Schelkunoff solution needs the conductor radius inside a
-    Bessel function ratio, and Tesche's equivalent circuit needs the internal
-    inductance of a specific rod or tube. Those formulations consume
-    :meth:`sigma` plus the radius directly, and :meth:`surface_impedance`
-    covers planar lines and the coaxial high-frequency limit.
+    The material interfaces are geometry-free. Geometry-aware formulations
+    receive these evaluated quantities together with their geometry.
     """
 
     @abstractmethod
@@ -38,6 +33,10 @@ class AbstractConductor(Module):
     @abstractmethod
     def sigma(self, freq: Frequency) -> jnp.ndarray:
         """Bulk conductivity in S/m, for formulations that need it directly."""
+
+    @abstractmethod
+    def mu(self, freq: Frequency) -> jnp.ndarray:
+        """Absolute permeability in H/m, for formulations that need it directly."""
 
     @abstractmethod
     def skin_depth(self, freq: Frequency) -> jnp.ndarray:
@@ -132,6 +131,9 @@ class BulkConductor(AbstractConductor):
 
     def sigma(self, freq: Frequency) -> jnp.ndarray:
         return (1.0 / self.rho) * jnp.ones(freq.npoints)
+
+    def mu(self, freq: Frequency) -> jnp.ndarray:
+        return (mu_0 * self.mu_r) * jnp.ones(freq.npoints)
 
     def skin_depth(self, freq: Frequency) -> jnp.ndarray:
         # Guard DC, where the skin depth is infinite, using the double-`where`

--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -95,6 +95,8 @@ from pmrf.models.components.lines.formulations import (
     AbstractMicrostripDispersion as AbstractMicrostripDispersion,
     KirschningJansen as KirschningJansen,
     QuasiStaticResult as QuasiStaticResult,
+    DielectricProperties as DielectricProperties,
+    ConductorProperties as ConductorProperties,
 )
 
 from pmrf.models.components.lumped import (

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -7,14 +7,108 @@ parameter: it can be checked directly against the equations of the paper it
 comes from, and contributed without learning the material taxonomy.
 """
 from abc import abstractmethod
+from typing import NamedTuple
 
 from scipy.constants import c, mu_0, epsilon_0
 import jax.numpy as jnp
 import equinox as eqx
 
 from pmrf.frequency import Frequency
-from pmrf.materials import AbstractConductor
 from pmrf.models.components.lines.base import ImmittanceResult
+
+
+class DielectricProperties(NamedTuple):
+    """Evaluated, geometry-free dielectric properties.
+
+    Parameters
+    ----------
+    ep_r : array-like
+        Complex relative permittivity.
+    mu_r : array-like
+        Relative permeability.
+    """
+
+    #: Complex relative permittivity
+    ep_r: jnp.ndarray
+    #: Relative permeability
+    mu_r: jnp.ndarray
+
+
+class ConductorProperties(NamedTuple):
+    """Evaluated, geometry-free conductor properties.
+
+    Parameters
+    ----------
+    zs : array-like
+        Surface impedance in ohm per square.
+    sigma : array-like
+        Bulk conductivity in S/m.
+    mu_r : array-like
+        Relative permeability.
+    """
+
+    #: Surface impedance in ohm per square
+    zs: jnp.ndarray
+    #: Bulk conductivity in S/m
+    sigma: jnp.ndarray
+    #: Relative permeability
+    mu_r: jnp.ndarray
+
+
+def _tesche_internal_impedance(zs_over_radius, rdc, lint, w):
+    """Evaluate Tesche's equivalent circuit after geometry terms are known."""
+    safe_w = jnp.where(w > 0, w, 1.0)
+    zhf = zs_over_radius / (2 * jnp.pi)
+    z = rdc + zhf / (1 + zhf / (1j * safe_w * lint))
+    return jnp.where(w > 0, z, rdc)
+
+
+def rod_internal_impedance(zs, sigma, mu_r, radius, w):
+    r"""Return Tesche's eq. (11)--(14) impedance for a solid conductor.
+
+    Parameters
+    ----------
+    zs, sigma, mu_r : array-like
+        Surface impedance, conductivity and relative permeability.
+    radius : float
+        Conductor radius in meters.
+    w : array-like
+        Angular frequency in rad/s.
+
+    Returns
+    -------
+    array-like
+        Series impedance per unit length in ohm/m.
+    """
+    rdc = 1 / (jnp.pi * radius**2 * sigma)
+    lint = mu_0 * mu_r / (8 * jnp.pi)
+    return _tesche_internal_impedance(zs / radius, rdc, lint, w)
+
+
+def tube_internal_impedance(zs, sigma, mu_r, radius, thickness, w):
+    r"""Return Tesche's eq. (13)--(14) impedance for a tubular conductor.
+
+    Parameters
+    ----------
+    zs, sigma, mu_r : array-like
+        Surface impedance, conductivity and relative permeability.
+    radius, thickness : float
+        Inner radius and wall thickness in meters.
+    w : array-like
+        Angular frequency in rad/s.
+
+    Returns
+    -------
+    array-like
+        Series impedance per unit length in ohm/m.
+    """
+    rdc = 1 / (2 * jnp.pi * radius * thickness * sigma)
+    q = (radius / (radius + thickness)) ** 2
+    lint = mu_0 * mu_r / (2 * jnp.pi) * (
+        jnp.log1p(thickness / radius) / (1 - q) ** 2
+        + (q - 3) / (4 * (1 - q))
+    )
+    return _tesche_internal_impedance(zs / radius, rdc, lint, w)
 
 
 class QuasiStaticResult(eqx.Module):
@@ -91,15 +185,12 @@ class AbstractCoaxialFormulation(eqx.Module):
     """
     Abstract base class for a closed-form coaxial line formulation.
 
-    A formulation is pure numerics: every argument other than `conductor`
-    arrives as an already-evaluated array, so it can be exercised directly
-    against its published equations with no ParamRF objects in sight. Coaxial
-    lines are the documented exception on `conductor`, because the internal
-    impedance of a rod or tube depends on the conductor radius as well as on the
-    surface impedance.
+    A formulation is pure numerics: all material arguments arrive as evaluated
+    arrays in small property records, so it can be exercised directly against
+    its published equations with no ParamRF objects in sight.
     """
     @abstractmethod
-    def immittance(self, freq: Frequency, *, d_in, d_out, ep_r, mu_r, conductor: AbstractConductor) -> ImmittanceResult:
+    def immittance(self, freq: Frequency, *, d_in, d_out, dielectric: DielectricProperties, conductor: ConductorProperties) -> ImmittanceResult:
         r"""
         Calculates the per-unit-length immittance of the line.
 
@@ -111,12 +202,10 @@ class AbstractCoaxialFormulation(eqx.Module):
             Inner conductor diameter in meters.
         d_out : ArrayLike
             Outer conductor inner diameter in meters.
-        ep_r : jnp.ndarray
-            Complex relative permittivity of the dielectric, shape ``(npoints,)``.
-        mu_r : ArrayLike
-            Relative permeability of the dielectric.
-        conductor : AbstractConductor
-            The conductor material of both conductors.
+        dielectric : DielectricProperties
+            Evaluated relative permittivity and permeability.
+        conductor : ConductorProperties
+            Evaluated surface impedance, conductivity and relative permeability.
 
         Returns
         -------
@@ -128,7 +217,7 @@ class AbstractCoaxialFormulation(eqx.Module):
 
 class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     r"""
-    Coaxial line formulation using the Tesche high-frequency approximation.
+    Coaxial line formulation using Tesche's equivalent-circuit approximation.
 
     **Mathematical Formulation**
 
@@ -140,14 +229,15 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     Y = \frac{j\omega 2\pi\varepsilon}{\ln(b/a)}$$
 
     which is $G + j\omega C$ with $C = 2\pi\Re(\varepsilon)/\ln(b/a)$ and
-    $G = -2\pi\omega\Im(\varepsilon)/\ln(b/a)$. The internal impedance of the two
-    conductors adds their surface impedance $Z_s$ over their circumferences:
-    $$Z = j\omega L' + Z_s\left(\frac{1}{2\pi a} + \frac{1}{2\pi b}\right)$$
-
-    Where $a$ is the inner radius and $b$ is the outer radius. In the strong
-    skin-effect regime $Z_s = \sqrt{\omega\mu\rho/2}\,(1 + j)$, so the real part
-    is Tesche's skin resistance and the imaginary part is $\omega$ times his skin
-    inductance.
+    $G = -2\pi\omega\Im(\varepsilon)/\ln(b/a)$. For each conductor, Tesche's
+    equivalent circuit is
+    $$R_{dc} = \frac{1}{\pi a^2\sigma},\quad
+    L_{int} = \frac{\mu}{8\pi},\quad
+    Z = R_{dc} + \frac{Z_{hf}}{1 + Z_{hf}/(j\omega L_{int})},\quad
+    Z_{hf} = \frac{Z_s}{2\pi a}.$$
+    The outer shield is treated as infinitely thick because only its inner
+    diameter is part of :class:`CoaxialLine`; the finite-wall form is available
+    in :func:`tube_internal_impedance`.
 
     References
     ----------
@@ -158,23 +248,25 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     Schelkunoff, S. A. (1934). The Electromagnetic Theory of Coaxial Transmission Lines
     and Cylindrical Shields. Bell System Technical Journal, 13(4), 532-579.
     """
-    def immittance(self, freq: Frequency, *, d_in, d_out, ep_r, mu_r, conductor: AbstractConductor) -> ImmittanceResult:
-        eps = epsilon_0 * ep_r
-        mu = mu_0 * mu_r
+    def immittance(self, freq: Frequency, *, d_in, d_out, dielectric: DielectricProperties, conductor: ConductorProperties) -> ImmittanceResult:
+        eps = epsilon_0 * dielectric.ep_r
+        mu = mu_0 * dielectric.mu_r
         w = freq.w
 
         a, b = d_in / 2, d_out / 2
-        lnbOvera = jnp.log(b / a)
+        ln_b_over_a = jnp.log(b / a)
 
-        L_ext = jnp.ones(freq.npoints) * mu / (2 * jnp.pi) * lnbOvera
+        L_ext = jnp.ones(freq.npoints) * mu / (2 * jnp.pi) * ln_b_over_a
 
-        # Internal impedance of the two conductors, per unit length: the surface
-        # impedance in ohm per square spread over each circumference.
-        zs = conductor.surface_impedance(freq)
-        Z_int = zs * (1 / (2 * jnp.pi * a) + 1 / (2 * jnp.pi * b))
+        # The model exposes only the shield's inner diameter, so its wall is
+        # treated as infinitely thick, matching the usual coaxial idealisation.
+        Z_int = rod_internal_impedance(conductor.zs, conductor.sigma, conductor.mu_r, a, w)
+        # In the infinite-wall limit the tube's dc resistance vanishes and its
+        # internal inductance diverges, leaving only the high-frequency term.
+        Z_int = Z_int + conductor.zs / (2 * jnp.pi * b)
 
         Z = 1j * w * L_ext + Z_int
-        Y = 1j * w * 2 * jnp.pi * eps / lnbOvera
+        Y = 1j * w * 2 * jnp.pi * eps / ln_b_over_a
 
         return ImmittanceResult(Z=Z, Y=Y, w=w)
 

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -23,6 +23,8 @@ from pmrf.models.components.lines.formulations import (
     AbstractCoaxialFormulation,
     AbstractMicrostripDispersion,
     AbstractMicrostripFormulation,
+    ConductorProperties,
+    DielectricProperties,
     KirschningJansen,
     TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
@@ -288,9 +290,14 @@ class CoaxialLine(AbstractImmittanceLine):
             freq,
             d_in=self.d_in,
             d_out=self.d_out,
-            ep_r=self.dielectric.epsilon_r(freq),
-            mu_r=self.mu_r,
-            conductor=self.conductor,
+            dielectric=DielectricProperties(
+                self.dielectric.epsilon_r(freq), self.mu_r * jnp.ones(freq.npoints)
+            ),
+            conductor=ConductorProperties(
+                self.conductor.surface_impedance(freq),
+                self.conductor.sigma(freq),
+                self.conductor.mu(freq) / mu_0,
+            ),
         )
     
     

--- a/tests/test_materials/test_conductor.py
+++ b/tests/test_materials/test_conductor.py
@@ -33,6 +33,10 @@ def test_bulk_sigma_and_skin_depth(freq):
     )
 
 
+def test_bulk_permeability(freq):
+    assert jnp.allclose(BulkConductor(1.68e-8, mu_r=4.0).mu(freq), 4.0 * mu_0)
+
+
 def test_bulk_from_sigma(freq):
     assert jnp.allclose(BulkConductor.from_sigma(5.8e7).rho, 1 / 5.8e7)
 

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -16,7 +16,13 @@ from pmrf.models import (
     MicrostripLine, 
     FloatingLine
 )
-from pmrf.materials import BulkConductor, ConstantDielectric, DjordjevicSarkar
+from pmrf.materials import BulkConductor, ConstantDielectric, DjordjevicSarkar, RoughConductor
+from pmrf.models.components.lines.formulations import (
+    ConductorProperties,
+    DielectricProperties,
+    TescheCoaxialFormulation,
+    tube_internal_impedance,
+)
 
 @pytest.fixture
 def basic_freq():
@@ -156,12 +162,31 @@ def test_material_coercion():
     assert jnp.allclose(line.dielectric.ep_r.value, 2.25)
 
 
-def test_coaxial_line_matches_skrf(basic_freq):
-    """Validate the coaxial immittance against scikit-rf's Tesche coaxial media."""
+def test_coaxial_formulation_takes_plain_arrays(basic_freq):
+    """A coaxial formulation is callable without ParamRF objects."""
+    npoints = basic_freq.npoints
+    result = TescheCoaxialFormulation().immittance(
+        basic_freq,
+        d_in=0.9e-3,
+        d_out=2.95e-3,
+        dielectric=DielectricProperties(np.full(npoints, 2.25 - 0.00225j), np.ones(npoints)),
+        conductor=ConductorProperties(
+            np.full(npoints, 0.01 + 0.01j),
+            np.full(npoints, 1 / 1.72e-8),
+            np.ones(npoints),
+        ),
+    )
+    assert result.Z.shape == (npoints,)
+    assert result.Y.shape == (npoints,)
+
+
+def test_coaxial_line_matches_skrf_tesche_wideband():
+    """Validate Tesche's complete equivalent circuit over the full sweep."""
     skrf = pytest.importorskip("skrf")
     from skrf.media import Coaxial
 
     d_in, d_out, ep_r, tand, rho = 0.9e-3, 2.95e-3, 2.25, 1e-3, 1.72e-8
+    freq = Frequency.from_f(jnp.geomspace(1e3, 40e9, 101))
     line = CoaxialLine(
         d_in=d_in,
         d_out=d_out,
@@ -170,28 +195,48 @@ def test_coaxial_line_matches_skrf(basic_freq):
         length=0.5,
     )
     media = Coaxial(
-        basic_freq.to_skrf(),
+        freq.to_skrf(),
         Dint=d_in, Dout=d_out, epsilon_r=ep_r, tan_delta=tand, sigma=1 / rho,
         model='tesche',
     )
 
-    imm = line.immittance(basic_freq)
+    imm = line.immittance(freq)
 
-    # G and C agree to machine precision, L to 1e-6. R is looser for a known
-    # reason: scikit-rf implements Tesche's equivalent circuit, eq. (14),
-    # Z = Rdc + Zhf/(1 + Zhf/(jw*Lint)), which carries the DC resistance and the
-    # internal inductance of the rod. ParamRF implements only the Zhf term, the
-    # high-frequency asymptote, so the two converge as frequency rises and
-    # diverge without bound below the skin-depth transition. scikit-rf is the
-    # more complete model here; see the note on issue #63.
-    assert jnp.allclose(imm.R, media.R, rtol=1e-2)
+    assert jnp.allclose(imm.R, media.R, rtol=1e-6, atol=1e-12)
     assert jnp.allclose(imm.L, media.L, rtol=1e-6)
     assert jnp.allclose(imm.G, media.G, rtol=1e-12)
     assert jnp.allclose(imm.C, media.C, rtol=1e-12)
 
-    zc, gammaL = line.zc_and_gammaL(basic_freq)
+    zc, gammaL = line.zc_and_gammaL(freq)
     assert jnp.allclose(zc, media.z0_characteristic, rtol=1e-4)
     assert jnp.allclose(gammaL / 0.5, media.gamma, rtol=1e-4)
+
+
+def test_coaxial_internal_impedance_tube():
+    """Tube arithmetic follows Tesche's equation (13)."""
+    skrf = pytest.importorskip("skrf")
+    from skrf.media import Coaxial
+
+    freq = Frequency.from_f(jnp.array([1e9]))
+    sigma, mu = jnp.array([1e7]), jnp.ones(1)
+    zs = jnp.sqrt(1j * freq.w * mu_0 / sigma)
+    radius, thickness = 1e-3, 0.2e-3
+    reference = Coaxial(
+        freq.to_skrf(), Dint=2 * radius, Dout=4 * radius,
+        sigma=float(sigma[0]), tout=thickness, model="tesche",
+    )
+    expected = reference._conductor_impedance(radius, thickness, None)
+    actual = tube_internal_impedance(zs, sigma, mu, radius, thickness, freq.w)
+    assert jnp.allclose(actual, expected)
+
+
+def test_rough_conductor_is_passed_to_coaxial_formulation():
+    freq = Frequency.from_f(jnp.array([1e6, 1e9]))
+    smooth = CoaxialLine(conductor=BulkConductor(1.68e-8), length=0.1)
+    rough = CoaxialLine(
+        conductor=RoughConductor(1.68e-8, roughness=1e-6), length=0.1
+    )
+    assert jnp.all(rough.immittance(freq).R > smooth.immittance(freq).R)
 
 
 def test_microstrip_line_matches_skrf(basic_freq):


### PR DESCRIPTION
Closes #68

## Summary
- move coaxial formulations to evaluated dielectric/conductor property records
- add conductor permeability and Tesche rod/tube internal impedance helpers
- complete Tesche equation (14) across the 1 kHz–40 GHz range
- add wideband scikit-rf, tube, rough-conductor, and permeability coverage
- update the changelog and formulation documentation

## Verification
- `.venv/bin/python -m pytest -q`
- 384 passed, 28 skipped