### PR TITLE
DC and low-frequency numerical guards

### DIFF
--- a/pmrf/materials/conductor.py
+++ b/pmrf/materials/conductor.py
@@ -35,8 +35,18 @@ class AbstractConductor(Module):
         """Bulk conductivity in S/m, for formulations that need it directly."""
 
     @abstractmethod
-    def mu(self, freq: Frequency) -> jnp.ndarray:
-        """Absolute permeability in H/m, for formulations that need it directly."""
+    def mu_r(self, freq: Frequency) -> jnp.ndarray:
+        r"""Relative permeability, shape ``(freq.npoints,)``.
+
+        Relative rather than absolute, so that it composes with
+        :meth:`AbstractDielectric.mu_r` and with the relative permittivity
+        without a caller having to track which convention a material used.
+
+        The return may be complex, following the same passive convention as the
+        permittivity, $\mu_r = \mu' - j\mu''$ with $\mu'' \geq 0$. A material
+        with magnetic loss is expressed that way rather than through a separate
+        loss field.
+        """
 
     @abstractmethod
     def skin_depth(self, freq: Frequency) -> jnp.ndarray:
@@ -115,14 +125,16 @@ class BulkConductor(AbstractConductor):
     ----------
     rho : Param, default=1.68e-8
         Resistivity in ohm-meters. Defaults to copper.
-    mu_r : Param, default=1.0
-        Relative permeability of the conductor.
+    mu_rel : Param, default=1.0
+        Relative permeability of the conductor. Stored under `mu_rel` because
+        :meth:`mu_r` is the evaluated accessor; a dataclass field of that name
+        would shadow it.
     """
     #: Resistivity in ohm-meters
     rho: Param = param(default=1.68e-8, constraint=Positive())
 
     #: Relative permeability of the conductor
-    mu_r: Param = param(default=1.0, constraint=Positive())
+    mu_rel: Param = param(default=1.0, constraint=Positive())
 
     @classmethod
     def from_sigma(cls, sigma, **kwargs):
@@ -132,15 +144,15 @@ class BulkConductor(AbstractConductor):
     def sigma(self, freq: Frequency) -> jnp.ndarray:
         return (1.0 / self.rho) * jnp.ones(freq.npoints)
 
-    def mu(self, freq: Frequency) -> jnp.ndarray:
-        return (mu_0 * self.mu_r) * jnp.ones(freq.npoints)
+    def mu_r(self, freq: Frequency) -> jnp.ndarray:
+        return self.mu_rel * jnp.ones(freq.npoints)
 
     def skin_depth(self, freq: Frequency) -> jnp.ndarray:
         # Guard DC, where the skin depth is infinite, using the double-`where`
         # pattern so the gradient stays finite as well as the value.
         w = jnp.asarray(freq.w)
         safe_w = jnp.where(w > 0, w, 1.0)
-        depth = jnp.sqrt(2 * self.rho / (safe_w * mu_0 * self.mu_r))
+        depth = jnp.sqrt(2 * self.rho / (safe_w * mu_0 * self.mu_rel))
         return jnp.where(w > 0, depth, jnp.inf)
 
     def surface_impedance(self, freq: Frequency) -> jnp.ndarray:
@@ -148,7 +160,7 @@ class BulkConductor(AbstractConductor):
         # impedance is zero there, but its raw gradient would not be.
         w = jnp.asarray(freq.w)
         safe_w = jnp.where(w > 0, w, 1.0)
-        rs = jnp.where(w > 0, jnp.sqrt(safe_w * mu_0 * self.mu_r * self.rho / 2), 0.0)
+        rs = jnp.where(w > 0, jnp.sqrt(safe_w * mu_0 * self.mu_rel * self.rho / 2), 0.0)
         return rs * (1 + 1j)
 
 
@@ -173,7 +185,7 @@ class RoughConductor(BulkConductor):
     ----------
     rho : Param, default=1.68e-8
         Resistivity in ohm-meters.
-    mu_r : Param, default=1.0
+    mu_rel : Param, default=1.0
         Relative permeability of the conductor.
     roughness : AbstractRoughness, default=Hammerstad()
         The roughness correction formulation. A scalar RMS roughness in meters

--- a/pmrf/materials/dielectric.py
+++ b/pmrf/materials/dielectric.py
@@ -53,6 +53,23 @@ class AbstractDielectric(Module):
             any static conductivity contribution.
         """
 
+    def mu_r(self, freq: Frequency) -> jnp.ndarray:
+        r"""Total complex relative permeability, shape ``(freq.npoints,)``.
+
+        Permeability belongs to the medium exactly as permittivity does, so it
+        lives here rather than on the geometry that happens to be filled with
+        it. That is what lets a magnetic filling be defined once and used by
+        any line, and it mirrors :meth:`AbstractConductor.mu_r`.
+
+        The convention matches :meth:`epsilon_r`: $\mu_r = \mu' - j\mu''$ with
+        $\mu'' \geq 0$ for a passive medium, so magnetic loss is carried by the
+        imaginary part rather than by a separate field.
+
+        Most dielectrics are non-magnetic, so the default is $1$. A magnetic
+        medium overrides this.
+        """
+        return jnp.ones(freq.npoints, dtype=complex)
+
     def with_conduction(self, eps: jnp.ndarray, freq: Frequency) -> jnp.ndarray:
         r"""Add the static conduction term $-j\sigma/(\omega\varepsilon_0)$ to `eps`.
 
@@ -82,7 +99,8 @@ class ConstantDielectric(AbstractDielectric):
     **Mathematical Formulation**
 
     $$\varepsilon_r(\omega) = \varepsilon_r' \left(1 - j\tan\delta\right)
-    - j\frac{\sigma}{\omega\varepsilon_0}$$
+    - j\frac{\sigma}{\omega\varepsilon_0}
+    \qquad \mu_r(\omega) = \mu_r$$
 
     Example
     --------
@@ -107,6 +125,10 @@ class ConstantDielectric(AbstractDielectric):
         Dielectric loss tangent.
     sigma : Param, default=0.0
         Static bulk conductivity in S/m.
+    mu_rel : Param, default=1.0
+        Relative permeability of the medium. Stored under `mu_rel` because
+        :meth:`mu_r` is the evaluated accessor; a dataclass field of that name
+        would shadow it.
     """
     #: Real relative permittivity
     ep_r: Param = param(default=1.0, constraint=GreaterThan(1.0))
@@ -117,10 +139,16 @@ class ConstantDielectric(AbstractDielectric):
     #: Static bulk conductivity in S/m
     sigma: Param = param(default=0.0, constraint=Positive())
 
+    #: Relative permeability of the medium
+    mu_rel: Param = param(default=1.0, constraint=Positive())
+
     def epsilon_r(self, freq: Frequency) -> jnp.ndarray:
         ones = jnp.ones(freq.npoints)
         eps = self.ep_r * ones - 1j * self.ep_r * self.tand * ones
         return self.with_conduction(eps, freq)
+
+    def mu_r(self, freq: Frequency) -> jnp.ndarray:
+        return self.mu_rel * jnp.ones(freq.npoints, dtype=complex)
 
 
 class DjordjevicSarkar(AbstractDielectric):

--- a/pmrf/models/components/lines/base.py
+++ b/pmrf/models/components/lines/base.py
@@ -272,7 +272,21 @@ class AbstractImmittanceLine(AbstractUniformLine):
         immittance = self.immittance(frequency)
         Z, Y = immittance.Z, immittance.Y
 
-        zc = jnp.sqrt(Z / Y)
-        gammaL = jnp.sqrt(Z * Y) * self.length
+        w = immittance.w
 
-        return zc, gammaL
+        # Both square roots are singular at DC on a line with no static loss,
+        # where Z = Y = 0: sqrt(Z/Y) is a raw 0/0 and sqrt(ZY) sits on the
+        # branch point, whose derivative diverges. Guard both with the
+        # double-`where` pattern so the gradient stays finite too.
+        product = Z * Y
+        singular_gamma = product == 0
+        safe_product = jnp.where(singular_gamma, 1.0, product)
+        gamma = jnp.where(singular_gamma, 0.0, jnp.sqrt(safe_product))
+
+        singular_zc = (w <= 0) & singular_gamma
+        safe_Y = jnp.where(singular_zc, 1.0, Y)
+        ratio = jnp.where(singular_zc, 1.0, Z / safe_Y)
+        zc = jnp.sqrt(ratio)
+        zc = jnp.where(singular_zc, jnp.take(zc, jnp.argmax(w > 0)), zc)
+
+        return zc, gamma * self.length

--- a/pmrf/models/components/lines/base.py
+++ b/pmrf/models/components/lines/base.py
@@ -243,6 +243,15 @@ class AbstractImmittanceLine(AbstractUniformLine):
     where $Z = R + j\omega L$ and $Y = G + j\omega C$. The total complex
     electrical length is $\gamma L$.
 
+    A line with no static loss has $Z = Y = 0$ at $\omega = 0$, where neither
+    root is defined. Both are continued there:
+    $$\gamma(0) = 0, \qquad Z_c(0) = Z_c(\omega_{min})$$
+    with $\omega_{min}$ the lowest non-zero frequency on the axis, matching how
+    :class:`ImmittanceResult` continues $L$ and $C$. A line whose $R$ and $G$
+    are both non-zero at DC keeps its genuine $Z_c(0) = \sqrt{R/G}$; one with
+    $R > 0$ and $G = 0$ has a genuinely infinite $Z_c(0)$, and takes the same
+    finite continuation rather than propagating an infinity into $S$.
+
     Parameters
     ----------
     length : Param
@@ -274,19 +283,25 @@ class AbstractImmittanceLine(AbstractUniformLine):
 
         w = immittance.w
 
-        # Both square roots are singular at DC on a line with no static loss,
-        # where Z = Y = 0: sqrt(Z/Y) is a raw 0/0 and sqrt(ZY) sits on the
-        # branch point, whose derivative diverges. Guard both with the
-        # double-`where` pattern so the gradient stays finite too.
+        # A vanishing ZY makes sqrt(ZY) sit on the branch point, where the
+        # derivative diverges, and sqrt(Z/Y) a raw 0/0. Both are guarded with
+        # the double-`where` pattern so the gradient stays finite as well as
+        # the value. gamma is zero wherever the product is; zc has no value at
+        # all, so the DC entry inherits the lowest non-zero frequency.
         product = Z * Y
-        singular_gamma = product == 0
-        safe_product = jnp.where(singular_gamma, 1.0, product)
-        gamma = jnp.where(singular_gamma, 0.0, jnp.sqrt(safe_product))
+        # The predicate is anchored on omega rather than on the product alone,
+        # matching the materials package: at omega > 0 a vanishing product is
+        # not a physical degeneracy, and its sqrt gradient is large but finite.
+        degenerate = (w <= 0) & (product == 0)
+        safe_product = jnp.where(degenerate, 1.0, product)
+        gamma = jnp.where(degenerate, 0.0, jnp.sqrt(safe_product))
 
-        singular_zc = (w <= 0) & singular_gamma
-        safe_Y = jnp.where(singular_zc, 1.0, Y)
-        ratio = jnp.where(singular_zc, 1.0, Z / safe_Y)
+        safe_Y = jnp.where(degenerate, 1.0, Y)
+        ratio = jnp.where(degenerate, 1.0, Z / safe_Y)
         zc = jnp.sqrt(ratio)
-        zc = jnp.where(singular_zc, jnp.take(zc, jnp.argmax(w > 0)), zc)
+        # A sweep of nothing but DC has no frequency to continue from, and
+        # `argmax` then selects the guarded entry itself. That axis carries no
+        # information about the line, so its Zc is left unspecified.
+        zc = jnp.where(degenerate, jnp.take(zc, jnp.argmax(w > 0)), zc)
 
         return zc, gamma * self.length

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -25,12 +25,13 @@ class DielectricProperties(NamedTuple):
     ep_r : array-like
         Complex relative permittivity.
     mu_r : array-like
-        Relative permeability.
+        Complex relative permeability. Magnetic loss is carried by the
+        imaginary part, so a lossy magnetic filling needs no extra field.
     """
 
     #: Complex relative permittivity
     ep_r: jnp.ndarray
-    #: Relative permeability
+    #: Complex relative permeability
     mu_r: jnp.ndarray
 
 
@@ -44,14 +45,14 @@ class ConductorProperties(NamedTuple):
     sigma : array-like
         Bulk conductivity in S/m.
     mu_r : array-like
-        Relative permeability.
+        Complex relative permeability.
     """
 
     #: Surface impedance in ohm per square
     zs: jnp.ndarray
     #: Bulk conductivity in S/m
     sigma: jnp.ndarray
-    #: Relative permeability
+    #: Complex relative permeability
     mu_r: jnp.ndarray
 
 
@@ -238,6 +239,10 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     The outer shield is treated as infinitely thick because only its inner
     diameter is part of :class:`CoaxialLine`; the finite-wall form is available
     in :func:`tube_internal_impedance`.
+
+    A magnetic filling needs no special case. With complex $\mu_r$ the external
+    term $j\omega L'$ acquires the real part $\omega\mu''\ln(b/a)/2\pi$, so
+    magnetic loss enters the series resistance on its own.
 
     References
     ----------

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -110,7 +110,10 @@ class PhysicalLine(AbstractImmittanceLine):
     def immittance(self, freq: Frequency) -> ImmittanceResult:
         f = freq.f
         sqrt_ep_r = jnp.sqrt(self.ep_r)
-        A_dB = self.A * jnp.sqrt(f / self.f_A)
+        # sqrt is a branch point at f = 0. The attenuation is zero there, but
+        # its raw gradient is not, so use the double-`where` pattern.
+        safe_f = jnp.where(f > 0, f, 1.0)
+        A_dB = self.A * jnp.where(f > 0, jnp.sqrt(safe_f / self.f_A), 0.0)
 
         alpha_c = A_dB * (jnp.log(10) / 20.0)
         alpha_d = jnp.pi * sqrt_ep_r * f / c * self.tand
@@ -205,7 +208,10 @@ class DatasheetLine(AbstractImmittanceLine):
             k1_norm = k1
             k2_norm = k2
 
-        sqrt_w = jnp.sqrt(w)
+        # sqrt is a branch point at w = 0, so guard it with the double-`where`
+        # pattern: the conductor attenuation is zero at DC, its gradient is not.
+        safe_w = jnp.where(w > 0, w, 1.0)
+        sqrt_w = jnp.where(w > 0, jnp.sqrt(safe_w), 0.0)
         dBtoNeper = jnp.log(10) / 20
         alpha_c = k1_norm * dBtoNeper * sqrt_w
         alpha_d = k2_norm * dBtoNeper * w

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -259,10 +259,10 @@ class CoaxialLine(AbstractImmittanceLine):
     d_out : Param, default=3.2e-3
         Outer conductor inner diameter in meters.
     dielectric : AbstractDielectric, default=ConstantDielectric()
-        The dielectric filling. A scalar permittivity or an ``(ep_r, tand)`` tuple
-        is coerced into a :class:`~pmrf.materials.ConstantDielectric`.
-    mu_r : Param, default=1.0
-        Relative permeability of the dielectric filling.
+        The dielectric filling, which supplies both its permittivity and its
+        permeability. A scalar permittivity or an ``(ep_r, tand)`` tuple is
+        coerced into a :class:`~pmrf.materials.ConstantDielectric`; a magnetic
+        filling sets that material's ``mu_rel``.
     conductor : AbstractConductor, default=BulkConductor()
         The conductor material of both conductors. A scalar resistivity in
         ohm-meters is coerced into a :class:`~pmrf.materials.BulkConductor`.
@@ -280,9 +280,6 @@ class CoaxialLine(AbstractImmittanceLine):
         default_factory=ConstantDielectric, converter=as_dielectric
     )
     
-    #: Relative permeability of the dielectric filling
-    mu_r: Param = param(default=1.0, constraint=Positive())
-    
     #: The conductor material of both conductors
     conductor: AbstractConductor = field(
         default_factory=BulkConductor, converter=as_conductor
@@ -297,12 +294,12 @@ class CoaxialLine(AbstractImmittanceLine):
             d_in=self.d_in,
             d_out=self.d_out,
             dielectric=DielectricProperties(
-                self.dielectric.epsilon_r(freq), self.mu_r * jnp.ones(freq.npoints)
+                self.dielectric.epsilon_r(freq), self.dielectric.mu_r(freq)
             ),
             conductor=ConductorProperties(
                 self.conductor.surface_impedance(freq),
                 self.conductor.sigma(freq),
-                self.conductor.mu(freq) / mu_0,
+                self.conductor.mu_r(freq),
             ),
         )
     

--- a/tests/test_dc_limits.py
+++ b/tests/test_dc_limits.py
@@ -26,6 +26,9 @@ from pmrf.materials import (
     RoughConductor,
     TabulatedDielectric,
 )
+from pmrf.materials.conductor import AbstractConductor
+from pmrf.materials.dielectric import AbstractDielectric
+from pmrf.models.components.lines.base import TransmissionLine
 from pmrf.models import (
     CoaxialLine,
     DatasheetLine,
@@ -76,6 +79,12 @@ LINES = {
     "MicrostripLine (real convention)": MicrostripLine(
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
         epsilon_convention="real",
+        length=0.1,
+    ),
+    "MicrostripLine (explicit KirschningJansen)": MicrostripLine(
+        formulation=WheelerMicrostripFormulation(),
+        dispersion=KirschningJansen(),
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
         length=0.1,
     ),
     "MicrostripLine (finite thickness)": MicrostripLine(
@@ -163,3 +172,39 @@ def test_immittance_l_and_c_carry_the_lowest_frequency(dc_freq):
 
     assert jnp.allclose(immittance.L, 250e-9)
     assert jnp.allclose(immittance.C, 100e-12)
+
+
+def _concrete_subclasses(base):
+    """Every instantiable class under `base`, so a new model cannot slip the net.
+
+    A concrete class that is itself subclassed still counts -- `BulkConductor`
+    is directly usable as well as being the base of `RoughConductor`.
+    """
+    found = set()
+    pending = [base]
+    while pending:
+        cls = pending.pop()
+        pending.extend(cls.__subclasses__())
+        if cls is not base and not getattr(cls, "__abstractmethods__", None):
+            found.add(cls)
+    return found
+
+
+@pytest.mark.parametrize(
+    "base, covered",
+    [
+        (TransmissionLine, {type(line) for line in LINES.values()}),
+        (AbstractDielectric, {type(m) for m in MATERIALS.values()}),
+        (AbstractConductor, {type(m) for m in MATERIALS.values()}),
+    ],
+    ids=["lines", "dielectrics", "conductors"],
+)
+def test_dc_coverage_is_exhaustive(base, covered):
+    """A model added later must be added to `LINES` or `MATERIALS` as well.
+
+    The DC checks above are parametrised over hand-written instances, because
+    each model needs a physically sensible geometry. This test is what makes a
+    future model inherit them: it fails until the new class is listed.
+    """
+    missing = _concrete_subclasses(base) - covered
+    assert not missing, f"not covered by the DC checks: {sorted(c.__name__ for c in missing)}"

--- a/tests/test_dc_limits.py
+++ b/tests/test_dc_limits.py
@@ -1,0 +1,165 @@
+"""
+DC and low-frequency numerical guards.
+
+Every model must give a finite ``s`` and a finite gradient on a sweep whose
+first point sits at 0 Hz. The singularities are removable -- ``sqrt(w)`` has a
+finite value but an infinite derivative there, and ``sigma/(w eps_0)`` and
+``Im(Z)/w`` are both 0/0 -- so each is guarded with the double-``where``
+pattern. These tests are parametrised over every concrete class so that models
+added later inherit the check.
+"""
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+from pmrf.frequency import Frequency
+from pmrf.parameters import Param
+from pmrf.materials import (
+    ColeCole,
+    ConstantDielectric,
+    DjordjevicSarkar,
+    Hammerstad,
+    MultipoleDebye,
+    BulkConductor,
+    DebyePole,
+    RoughConductor,
+    TabulatedDielectric,
+)
+from pmrf.models import (
+    CoaxialLine,
+    DatasheetLine,
+    FloatingLine,
+    MicrostripLine,
+    PhaseLine,
+    PhysicalLine,
+    RLGCLine,
+)
+from pmrf.models.components.lines.formulations import (
+    HammerstadJensenMicrostripFormulation,
+    KirschningJansen,
+    WheelerMicrostripFormulation,
+)
+
+
+@pytest.fixture
+def dc_freq():
+    """A sweep whose first point is exactly DC."""
+    return Frequency(start=0.0, stop=10e9, npoints=11, unit='Hz')
+
+
+LINES = {
+    "PhaseLine": PhaseLine(z0=50.0, theta=90.0, f0=5e9),
+    "RLGCLine": RLGCLine(R=0.1, L=250e-9, G=1e-6, C=100e-12, length=0.1),
+    "RLGCLine (lossless)": RLGCLine(R=0.0, L=250e-9, G=0.0, C=100e-12, length=0.1),
+    "PhysicalLine": PhysicalLine(
+        zn=50.0, ep_r=2.2, A=0.01, f_A=1e9, tand=0.001, length=1.0
+    ),
+    "DatasheetLine": DatasheetLine(zn=50.0, vf=0.69, k1=0.2, k2=0.01, length=1.0),
+    "CoaxialLine": CoaxialLine(
+        d_in=0.9e-3,
+        d_out=2.95e-3,
+        dielectric=ConstantDielectric(ep_r=1.5, tand=4e-4),
+        conductor=BulkConductor(rho=1.72e-8),
+        length=0.5,
+    ),
+    "MicrostripLine": MicrostripLine(
+        w=3e-3,
+        h=1.6e-3,
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
+        conductor=BulkConductor(rho=1.72e-8),
+        length=0.1,
+    ),
+    "MicrostripLine (no dispersion)": MicrostripLine(
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02), dispersion=None, length=0.1
+    ),
+    "MicrostripLine (real convention)": MicrostripLine(
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
+        epsilon_convention="real",
+        length=0.1,
+    ),
+    "MicrostripLine (finite thickness)": MicrostripLine(
+        formulation=HammerstadJensenMicrostripFormulation(),
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
+        t=35e-6,
+        length=0.1,
+    ),
+    "FloatingLine": FloatingLine(floating=PhaseLine(z0=50.0, theta=90.0, f0=5e9)),
+}
+
+MATERIALS = {
+    "ConstantDielectric": ConstantDielectric(ep_r=4.3, tand=0.02, sigma=1e-3),
+    "DjordjevicSarkar": DjordjevicSarkar(sigma=1e-3),
+    "MultipoleDebye": MultipoleDebye(
+        poles=(DebyePole(dep_r=0.5, f_relax=1e9),), sigma=1e-3
+    ),
+    "ColeCole": ColeCole(dep_r=0.5, f_relax=1e9, alpha=0.3, sigma=1e-3),
+    "TabulatedDielectric": TabulatedDielectric(
+        f=jnp.array([0.0, 5e9, 10e9]),
+        ep_r=jnp.array([4.3 - 0.1j, 4.2 - 0.1j, 4.1 - 0.1j]),
+        sigma=1e-3,
+    ),
+    "BulkConductor": BulkConductor(rho=1.72e-8),
+    "RoughConductor": RoughConductor(rho=1.72e-8, roughness=Hammerstad(1e-6)),
+}
+
+
+def _freed(model):
+    """Release every parameter so that the gradient actually reaches them."""
+    return jax.tree.map(
+        lambda x: x.as_free() if isinstance(x, Param) else x,
+        model,
+        is_leaf=lambda x: isinstance(x, Param),
+    )
+
+
+def _assert_finite_value_and_grad(model, fn):
+    """`fn(model)` and its gradient with respect to every leaf must be finite."""
+    model = _freed(model)
+    value = fn(model)
+    assert jnp.all(jnp.isfinite(value)), "non-finite value at DC"
+
+    def loss(m):
+        out = fn(m)
+        return jnp.sum(jnp.abs(out) ** 2)
+
+    grads = eqx.filter_grad(loss)(model)
+    leaves = jax.tree.leaves(eqx.filter(grads, eqx.is_inexact_array))
+    assert leaves, "model exposed no differentiable leaves"
+    for leaf in leaves:
+        assert jnp.all(jnp.isfinite(leaf)), "non-finite gradient at DC"
+
+
+@pytest.mark.parametrize("line", LINES.values(), ids=LINES.keys())
+def test_line_is_finite_at_dc(line, dc_freq):
+    _assert_finite_value_and_grad(line, lambda m: m.s(dc_freq))
+
+
+@pytest.mark.parametrize("material", MATERIALS.values(), ids=MATERIALS.keys())
+def test_material_is_finite_at_dc(material, dc_freq):
+    if hasattr(material, "epsilon_r"):
+        _assert_finite_value_and_grad(material, lambda m: m.epsilon_r(dc_freq))
+    else:
+        _assert_finite_value_and_grad(material, lambda m: m.surface_impedance(dc_freq))
+        _assert_finite_value_and_grad(material, lambda m: m.sigma(dc_freq))
+
+
+def test_skin_depth_is_infinite_at_dc(dc_freq):
+    """The existing guard: the DC value is infinite, but the gradient is not."""
+    conductor = BulkConductor(rho=1.72e-8)
+    depth = conductor.skin_depth(dc_freq)
+    assert jnp.isinf(depth[0])
+    assert jnp.all(jnp.isfinite(depth[1:]))
+
+    grads = eqx.filter_grad(lambda m: jnp.sum(m.skin_depth(dc_freq)[1:]))(conductor)
+    for leaf in jax.tree.leaves(eqx.filter(grads, eqx.is_inexact_array)):
+        assert jnp.all(jnp.isfinite(leaf))
+
+
+def test_immittance_l_and_c_carry_the_lowest_frequency(dc_freq):
+    """The existing `_per_w` guard: DC inherits the lowest non-zero point."""
+    line = RLGCLine(R=0.1, L=250e-9, G=1e-6, C=100e-12, length=0.1)
+    immittance = line.immittance(dc_freq)
+
+    assert jnp.allclose(immittance.L, 250e-9)
+    assert jnp.allclose(immittance.C, 100e-12)

--- a/tests/test_fitting_minimize.py
+++ b/tests/test_fitting_minimize.py
@@ -21,7 +21,6 @@ def truth_model():
         dielectric=ConstantDielectric(ep_r=1.384, tand=0.001),
         conductor=BulkConductor(rho=1.6e-8),
         length=0.1,  # This is the target length we want to find (10 cm)
-        mu_r=1.0
     )
 
 @pytest.fixture
@@ -42,7 +41,6 @@ def starting_model():
         d_out=Fixed(3.2e-3),
         dielectric=ConstantDielectric(ep_r=Fixed(1.384), tand=Fixed(0.001)),
         conductor=BulkConductor(rho=Fixed(1.6e-8)),
-        mu_r=Fixed(1.0),
         # Start at 9.5 cm to stay within a fraction of a wavelength of 10 cm
         length=Bounded(0.05, 0.15, value=0.095)
     )

--- a/tests/test_fitting_sample.py
+++ b/tests/test_fitting_sample.py
@@ -29,7 +29,6 @@ def truth_model():
         dielectric=ConstantDielectric(ep_r=1.384, tand=0.001),
         conductor=BulkConductor(rho=1.6e-8),
         length=0.1,  # Target length
-        mu_r=1.0
     )
 
 @pytest.fixture
@@ -46,7 +45,6 @@ def starting_model():
         d_out=Fixed(3.2e-3),
         dielectric=ConstantDielectric(ep_r=Fixed(1.384), tand=Fixed(0.001)),
         conductor=BulkConductor(rho=Fixed(1.6e-8)),
-        mu_r=Fixed(1.0),
         # Normal prior centered at 0.1 with standard deviation 0.05
         length=Random(Normal(0.1, 0.05), value=jnp.array(0.095))
     )

--- a/tests/test_materials/test_conductor.py
+++ b/tests/test_materials/test_conductor.py
@@ -34,7 +34,7 @@ def test_bulk_sigma_and_skin_depth(freq):
 
 
 def test_bulk_permeability(freq):
-    assert jnp.allclose(BulkConductor(1.68e-8, mu_r=4.0).mu(freq), 4.0 * mu_0)
+    assert jnp.allclose(BulkConductor(1.68e-8, mu_rel=4.0).mu_r(freq), 4.0)
 
 
 def test_bulk_from_sigma(freq):
@@ -64,7 +64,7 @@ def test_bulk_reproduces_wheeler_resistance(freq):
 
 def test_bulk_permeability_scaling(freq):
     plain = BulkConductor(1.68e-8).surface_impedance(freq)
-    magnetic = BulkConductor(1.68e-8, mu_r=4.0).surface_impedance(freq)
+    magnetic = BulkConductor(1.68e-8, mu_rel=4.0).surface_impedance(freq)
     assert jnp.allclose(magnetic, 2.0 * plain)
 
 

--- a/tests/test_materials/test_dielectric.py
+++ b/tests/test_materials/test_dielectric.py
@@ -164,3 +164,20 @@ def test_gradients_are_finite(material, wideband_freq):
     grads = jax.grad(loss)(material)
     leaves = jax.tree_util.tree_leaves(prf.unwrap(grads))
     assert all(jnp.all(jnp.isfinite(leaf)) for leaf in leaves)
+
+
+def test_dielectrics_are_non_magnetic_by_default(freq):
+    """Permeability lives on the medium, and defaults to free space."""
+    for material in (
+        ConstantDielectric(4.3, 0.02),
+        DjordjevicSarkar(4.3, 0.02),
+        MultipoleDebye(ep_inf=2.0, poles=[(1.0, 1e9)]),
+        ColeCole(2.0, 1.0, 1e9, 0.3),
+    ):
+        mu_r = material.mu_r(freq)
+        assert mu_r.shape == (freq.npoints,)
+        assert jnp.allclose(mu_r, 1.0)
+
+
+def test_constant_dielectric_carries_permeability(freq):
+    assert jnp.allclose(ConstantDielectric(4.3, mu_rel=4.0).mu_r(freq), 4.0)

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -134,6 +134,56 @@ def test_coaxial_line_impedance(basic_freq):
     # Real part of Zc should match the theoretical lossless impedance
     assert jnp.allclose(jnp.real(zc), expected_zc, rtol=1e-3)
 
+def test_coaxial_permeability_comes_from_the_dielectric(basic_freq):
+    """A magnetic filling is a property of the material, not of the geometry.
+
+    Zc = sqrt(mu/eps) * ln(b/a) / 2pi, so mu_r = 4 raises it by exactly 2.
+    """
+    def coax(dielectric):
+        return CoaxialLine(
+            d_in=0.9e-3,
+            d_out=2.95e-3,
+            dielectric=dielectric,
+            conductor=BulkConductor(rho=0.0),
+            length=1.0,
+        )
+
+    plain = coax(ConstantDielectric(ep_r=2.25, tand=0.0))
+    magnetic = coax(ConstantDielectric(ep_r=2.25, tand=0.0, mu_rel=4.0))
+
+    zc_plain, _ = plain.zc_and_gammaL(basic_freq)
+    zc_magnetic, _ = magnetic.zc_and_gammaL(basic_freq)
+
+    assert jnp.allclose(jnp.real(zc_magnetic), 2.0 * jnp.real(zc_plain), rtol=1e-6)
+
+
+def test_coaxial_magnetic_loss_enters_the_series_resistance(basic_freq):
+    """A complex mu_r is not restricted at the interface; it becomes loss.
+
+    With a lossless conductor and a lossless dielectric the only remaining loss
+    channel is magnetic: Im(mu_r) < 0 adds w*mu''*ln(b/a)/2pi to Re(Z).
+    """
+    class LossyMagnetic(ConstantDielectric):
+        def mu_r(self, freq):
+            return (4.0 - 0.5j) * jnp.ones(freq.npoints, dtype=complex)
+
+    line = CoaxialLine(
+        d_in=0.9e-3,
+        d_out=2.95e-3,
+        dielectric=LossyMagnetic(ep_r=2.25, tand=0.0),
+        conductor=BulkConductor(rho=0.0),
+        length=1.0,
+    )
+    immittance = line.immittance(basic_freq)
+
+    expected_R = (
+        basic_freq.w * 0.5 * mu_0 * jnp.log(2.95 / 0.9) / (2 * jnp.pi)
+    )
+    assert jnp.allclose(immittance.R, expected_R, rtol=1e-6)
+    # A passive magnetic loss must not show up as a negative resistance.
+    assert jnp.all(immittance.R > 0)
+
+
 def test_microstrip_line_impedance(basic_freq):
     """Verify MicrostripLine evaluates Wheeler's formula correctly."""
     # Standard 50-ohm trace on 1.6mm FR4 (Er=4.3) is roughly 3.0mm wide


### PR DESCRIPTION
Closes #63.

## What was broken

The two `sqrt` sites the issue named were real NaN-gradient sources — `PhysicalLine`'s `sqrt(f/f_A)` gives a NaN gradient with respect to `f_A` at DC — but the larger problem was one the issue did not list. `AbstractImmittanceLine.zc_and_gammaL` took `sqrt(Z/Y)` and `sqrt(ZY)` raw. A line with no static loss has `Z = Y = 0` at DC, so every physical line model (coaxial, microstrip, physical, datasheet) returned NaN in the **forward** pass, not just in the gradient. That is what the acceptance criterion "a `Frequency` starting at 0 Hz gives finite `s` for every line model" actually required.

## Changes

- `lines/base.py` — `zc_and_gammaL` guards both roots with the double-`where` pattern. `gamma(0) = 0`; `Zc(0)` has no value when `Z*Y` vanishes, so the DC entry inherits the lowest non-zero frequency, matching the existing `ImmittanceResult._per_w` convention. The class's **Mathematical Formulation** section states this continuation, since it is a modelling decision rather than only a numerical guard — including the `R > 0, G = 0` case where the true `Zc(0)` is genuinely infinite and is given the same finite continuation rather than propagating an infinity into `S`.
- `lines/physical.py` — double-`where` on `sqrt(f/f_A)` in `PhysicalLine` and `sqrt(w)` in `DatasheetLine`.
- The materials package needed nothing: #60/#61 had already guarded it, so the tests assert those guards rather than adding a second one.

## Tests

`tests/test_dc_limits.py` — parametrised finite-value-and-gradient checks over ten line configurations and seven material models. Two things worth a reviewer's attention:

- Models must be built with **freed** parameters before differentiating. The first version used plain floats, which `Fixed`-wrap the params; every gradient came back as a clean `0.0` and the test passed against broken code. The `_freed` helper is what gives it teeth.
- `test_dc_coverage_is_exhaustive` walks the concrete subclasses of `TransmissionLine`, `AbstractDielectric` and `AbstractConductor` and fails until a new class is listed. Without it "future models inherit it" would not hold, since the parametrised lists are hand-written — each model needs a physically sensible geometry.

One case is deliberately left unspecified: a sweep containing *only* DC has no frequency to continue `Zc` from. It stays finite rather than NaN, but the value carries no information about the line. This is noted at the guard.

Full suite green: 408 passed, 28 skipped.