### PR TITLE
Substrate ergonomics and stripline generality check

### DIFF
--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -13,3 +13,4 @@ This chapter includes some basic examples to demonstrate ParamRF's core features
    derivatives_and_sweeps
    custom_models
    multiple_models_one_parameter_set
+   shared_substrates

--- a/docs/examples/shared_substrates.rst
+++ b/docs/examples/shared_substrates.rst
@@ -1,0 +1,84 @@
+Sharing a Substrate Between Traces
+==================================
+
+A board has one substrate and many traces on it. If each trace carried its own
+copy of the permittivity, fitting the board would fit the same physical quantity
+several times over, once per trace, with nothing keeping the answers consistent.
+
+ParamRF needs no special machinery for this. A :class:`pmrf.materials.Substrate`
+groups the height, dielectric, conductor and metallization thickness into one
+module, and a :class:`pmrf.models.AbstractBuilder` holding one substrate and
+injecting it into each line in ``build`` is what makes the sharing real.
+
+One Substrate, Two Traces
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. jupyter-execute::
+
+   import pmrf as prf
+   from pmrf.materials import ConstantDielectric, Substrate
+   from pmrf.models import AbstractBuilder, MicrostripLine
+
+   class Board(AbstractBuilder):
+       substrate: Substrate
+       w1: prf.Param
+       w2: prf.Param
+
+       def build(self):
+           return (
+               MicrostripLine(w=self.w1, substrate=self.substrate, length=0.1)
+               ** MicrostripLine(w=self.w2, substrate=self.substrate, length=0.2)
+           )
+
+   board = Board(
+       substrate=Substrate(h=1.6e-3, dielectric=ConstantDielectric(ep_r=4.3, tand=0.02)),
+       w1=1.0e-3,
+       w2=2.0e-3,
+   )
+   list(board.named_params())
+
+There is one ``ep_r``, not two. ``build`` is lazy and uncached, so the substrate
+is a leaf of the builder and both lines are reconstructed on every call from the
+same already-traced values. Fitting ``board`` therefore fits a single
+permittivity, shared by construction.
+
+The Contrast: A Shared ``Param`` Object
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Handing the *same* :class:`pmrf.Param` object to two separately-constructed
+lines looks like sharing, but is not:
+
+.. jupyter-execute::
+
+   ep_r = prf.Param(value=4.3)
+   lines = (
+       MicrostripLine(w=1e-3, h=1.6e-3, dielectric=ConstantDielectric(ep_r=ep_r), length=0.1)
+       ** MicrostripLine(w=2e-3, h=1.6e-3, dielectric=ConstantDielectric(ep_r=ep_r), length=0.2)
+   )
+   [name for name in lines.named_params() if name.endswith("ep_r")]
+
+PyTree flattening gives one leaf per line regardless of the object identity that
+went in, so the optimizer sees two independent permittivities that are free to
+drift apart. The builder pattern above is the one that dedupes.
+
+Two Idioms, One PyTree
+~~~~~~~~~~~~~~~~~~~~~~
+
+A line may be given a grouped ``substrate=``, or the loose ``h``,
+``dielectric``, ``conductor`` and ``t`` fields. Both build the same canonical
+:class:`pmrf.materials.Substrate`, so the two forms are the same model:
+
+.. jupyter-execute::
+
+   import jax
+
+   loose = MicrostripLine(w=3e-3, h=1.6e-3, dielectric=4.3, length=0.1)
+   grouped = MicrostripLine(w=3e-3, substrate=Substrate(h=1.6e-3, dielectric=4.3), length=0.1)
+
+   jax.tree_util.tree_structure(loose) == jax.tree_util.tree_structure(grouped)
+
+The loose form stays convenient for a single line; the grouped form is what a
+board shares. They may not be mixed in one call.
+
+A coaxial line has no substrate, and keeps its ``dielectric`` and ``conductor``
+fields directly.

--- a/pmrf/materials/__init__.py
+++ b/pmrf/materials/__init__.py
@@ -16,6 +16,10 @@ from pmrf.materials.dielectric import (
     TabulatedDielectric as TabulatedDielectric,
     as_dielectric as as_dielectric,
 )
+from pmrf.materials.substrate import (
+    Substrate as Substrate,
+    as_substrate as as_substrate,
+)
 from pmrf.materials.conductor import (
     AbstractConductor as AbstractConductor,
     AbstractRoughness as AbstractRoughness,
@@ -40,4 +44,6 @@ __all__ = [
     "Hammerstad",
     "RoughConductor",
     "as_conductor",
+    "Substrate",
+    "as_substrate",
 ]

--- a/pmrf/materials/substrate.py
+++ b/pmrf/materials/substrate.py
@@ -1,0 +1,101 @@
+"""
+Planar substrates: a dielectric sheet of known height, with its metallization.
+
+A substrate is a convenience grouping, not a mechanism. Engineers think "this
+trace is on Rogers 4350B", and the fields that make up that thought — the
+height, the dielectric, the conductor and its thickness — are exactly the ones
+every planar line already asks for individually.
+"""
+from __future__ import annotations
+
+from pmrf.constraints import Positive
+from pmrf.materials.conductor import AbstractConductor, BulkConductor, as_conductor
+from pmrf.materials.dielectric import AbstractDielectric, ConstantDielectric, as_dielectric
+from pmrf.modules.base import Module
+from pmrf.parameters import Param, as_param, param
+from pmrf.utils import field
+
+
+class Substrate(Module):
+    r"""
+    A dielectric sheet of a given height, with the conductor printed on it.
+
+    Sharing a substrate between traces needs no new machinery. A builder holds
+    one substrate and injects it into each line in :meth:`build`; because
+    ``build`` is lazy and uncached, the substrate is a leaf of the builder and
+    the lines are reconstructed per call from already-traced values:
+
+    >>> import pmrf as prf
+    >>> from pmrf.materials import Substrate
+    >>> from pmrf.models import AbstractBuilder, MicrostripLine
+    >>> class Board(AbstractBuilder):
+    ...     substrate: Substrate
+    ...     w1: prf.Param
+    ...     w2: prf.Param
+    ...     def build(self):
+    ...         return (MicrostripLine(w=self.w1, substrate=self.substrate, length=0.1)
+    ...              ** MicrostripLine(w=self.w2, substrate=self.substrate, length=0.2))
+    >>> board = Board(substrate=Substrate(h=1.6e-3, dielectric=4.3), w1=1e-3, w2=2e-3)
+    >>> [name for name in board.named_params() if name.endswith("ep_r")]
+    ['substrate.dielectric.ep_r']
+
+    One permittivity, not two. Passing the *same* :class:`~pmrf.Param` object to
+    two separately-constructed lines does **not** dedupe: PyTree flattening gives
+    two independent leaves, one per line. The builder is what makes the sharing
+    real.
+
+    Parameters
+    ----------
+    h : Param, default=1.6e-3
+        Height of the dielectric sheet in meters.
+    dielectric : AbstractDielectric, default=ConstantDielectric(ep_r=4.3)
+        The sheet material. A scalar permittivity or an ``(ep_r, tand)`` tuple is
+        coerced into a :class:`~pmrf.materials.ConstantDielectric`.
+    conductor : AbstractConductor, default=BulkConductor()
+        The metallization. A scalar resistivity in ohm-meters is coerced into a
+        :class:`~pmrf.materials.BulkConductor`.
+    t : Param | None, default=None
+        Thickness of the metallization in meters, or ``None`` for a
+        zero-thickness idealisation.
+    """
+    #: Height of the dielectric sheet
+    h: Param = param(default=1.6e-3, constraint=Positive())
+
+    #: The sheet material
+    dielectric: AbstractDielectric = field(
+        default_factory=lambda: ConstantDielectric(ep_r=4.3), converter=as_dielectric
+    )
+
+    #: The metallization
+    conductor: AbstractConductor = field(
+        default_factory=BulkConductor, converter=as_conductor
+    )
+
+    #: Thickness of the metallization
+    t: Param | None = field(
+        default=None,
+        converter=lambda x: as_param(x, constraint=Positive()) if x is not None else None,
+    )
+
+
+def as_substrate(value) -> Substrate:
+    """
+    Coerce a value into a :class:`Substrate`.
+
+    Accepts an existing :class:`Substrate` or a mapping of its fields.
+
+    Parameters
+    ----------
+    value : Any
+        The value to coerce.
+
+    Returns
+    -------
+    Substrate
+        The resulting substrate.
+    """
+    if isinstance(value, Substrate):
+        return value
+    if isinstance(value, dict):
+        return Substrate(**value)
+    raise TypeError(f"cannot interpret {value!r} as a Substrate")

--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -84,6 +84,7 @@ from pmrf.models.components.lines.physical import (
     DatasheetLine as DatasheetLine,
     CoaxialLine as CoaxialLine,
     MicrostripLine as MicrostripLine,
+    StriplineLine as StriplineLine,
 )
 
 from pmrf.models.components.lines.formulations import (
@@ -94,6 +95,8 @@ from pmrf.models.components.lines.formulations import (
     HammerstadJensenMicrostripFormulation as HammerstadJensenMicrostripFormulation,
     AbstractMicrostripDispersion as AbstractMicrostripDispersion,
     KirschningJansen as KirschningJansen,
+    AbstractStriplineFormulation as AbstractStriplineFormulation,
+    CohnStriplineFormulation as CohnStriplineFormulation,
     QuasiStaticResult as QuasiStaticResult,
     DielectricProperties as DielectricProperties,
     ConductorProperties as ConductorProperties,

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -1,5 +1,5 @@
 """
-Closed-form physics for transmission lines (coaxial, microstrip).
+Closed-form physics for transmission lines (coaxial, microstrip, stripline).
 
 A formulation is pure numerics. Materials are evaluated by the line, so a
 formulation never sees a :class:`~pmrf.Param` or a :class:`~pmrf.Module`
@@ -591,3 +591,128 @@ class KirschningJansen(AbstractMicrostripDispersion):
         ep_eff = ep_eff_0 + modal_weight * (ep_eff - ep_eff_0)
         zc = zc_0 + modal_weight * (zc - zc_0)
         return ep_eff, zc
+
+
+class AbstractStriplineFormulation(eqx.Module):
+    """
+    Abstract base class for a closed-form stripline formulation.
+
+    Stripline is homogeneously filled, so there is no modal dispersion to
+    correct afterwards: the quasi-static solution is the solution, and its
+    effective permittivity is the substrate permittivity itself.
+
+    A formulation is pure numerics: every argument arrives as an
+    already-evaluated array, so it can be exercised directly against its
+    published equations with no ParamRF objects in sight.
+    """
+
+    @abstractmethod
+    def quasi_static(self, freq: Frequency, *, w, b, t, ep_r, zs) -> QuasiStaticResult:
+        r"""
+        Calculates the quasi-static solution of the line.
+
+        Parameters
+        ----------
+        freq : Frequency
+            The frequency axis.
+        w : ArrayLike
+            Width of the centre strip in meters.
+        b : ArrayLike
+            Ground-plane separation in meters.
+        t : ArrayLike | None
+            Thickness of the strip in meters, or None for a zero-thickness strip.
+        ep_r : jnp.ndarray
+            Complex relative permittivity of the filling, shape ``(npoints,)``.
+        zs : jnp.ndarray
+            Complex surface impedance of the conductor in ohm per square,
+            shape ``(npoints,)``.
+
+        Returns
+        -------
+        QuasiStaticResult
+            The effective permittivity, impedance and effective width.
+        """
+        raise NotImplementedError
+
+
+class CohnStriplineFormulation(AbstractStriplineFormulation):
+    r"""
+    Cohn's stripline formulation, in the form tabulated by Pozar.
+
+    **Mathematical Formulation**
+
+    The filling is homogeneous, so
+    $$\varepsilon_e = \varepsilon_r$$
+    exactly, with no filling factor and no modal dispersion. With the fringing
+    correction to the strip width,
+    $$\frac{W_e}{b} = \frac{W}{b} -
+    \begin{cases}0, & W/b > 0.35,\\ (0.35 - W/b)^2, & W/b \leq 0.35,\end{cases}$$
+    the characteristic impedance of the zero-thickness strip is
+    $$Z_c = \frac{30\pi}{\sqrt{\varepsilon_r}}\frac{b}{W_e + 0.441b}.$$
+
+    Conductor loss follows Cohn's incremental-inductance result, which unlike
+    the impedance does depend on the strip thickness $T$:
+    $$\frac{\alpha_c}{R_s} = \begin{cases}
+    \dfrac{2.7\times10^{-3}\,\varepsilon_r Z_c}{30\pi(b-T)}A,
+        & \sqrt{\varepsilon_r}Z_c < 120,\\[2ex]
+    \dfrac{0.16}{Z_c b}B, & \sqrt{\varepsilon_r}Z_c \geq 120,
+    \end{cases}$$
+    $$A = 1 + \frac{2W}{b-T}
+    + \frac{1}{\pi}\frac{b+T}{b-T}\ln\frac{2b-T}{T}$$
+    $$B = 1 + \frac{b}{0.5W + 0.7T}
+    \left(0.5 + \frac{0.7T}{W} + \frac{1}{2\pi}\ln\frac{4\pi W}{T}\right).$$
+
+    That attenuation is returned as the effective width the line applies it
+    through. A per-unit-length series resistance $R = 2\alpha_c Z_c$ and the
+    line's own $R = 2R_s/W_{eff}$ are the same statement, so
+    $$W_{eff} = \frac{R_s}{\alpha_c Z_c} = \left[\frac{\alpha_c}{R_s}Z_c\right]^{-1},$$
+    which is independent of $R_s$ and therefore stays finite for a perfect
+    conductor. Dielectric loss needs no separate term: $\varepsilon_e$ is
+    complex, and carries it.
+
+    The formulas are the standard piecewise fits, discontinuous by a fraction of
+    a percent at $\sqrt{\varepsilon_r}Z_c = 120$; the branch is selected on the
+    real parts.
+
+    References
+    ----------
+    Cohn, S. B. (1955). Problems in Strip Transmission Lines. IRE Transactions
+    on Microwave Theory and Techniques, 3(2), 119-126.
+
+    Pozar, D. M. (2011). Microwave Engineering (4th ed.), Section 3.7. Wiley.
+    """
+
+    def quasi_static(self, freq: Frequency, *, w, b, t, ep_r, zs) -> QuasiStaticResult:
+        ones = jnp.ones(freq.npoints)
+        ep_eff = ep_r * ones
+
+        u = w / b
+        w_e = b * (u - jnp.where(u > 0.35, 0.0, (0.35 - u) ** 2))
+        zc = 30 * jnp.pi / jnp.sqrt(ep_eff) * b / (w_e + 0.441 * b)
+
+        w_eff = self._loss_width(w, b, t, ep_eff, zc) * ones
+        return QuasiStaticResult(ep_eff=ep_eff, zc=zc, w_eff=w_eff)
+
+    @staticmethod
+    def _loss_width(w, b, t, ep_eff, zc):
+        """Return the effective width carrying Cohn's conductor attenuation."""
+        if t is None:
+            # Cohn's attenuation diverges logarithmically as the strip thins:
+            # a zero-thickness strip has no finite conductor loss to apply.
+            return jnp.inf
+
+        ep_r = jnp.real(ep_eff)
+        zc_real = jnp.real(zc)
+
+        a = 1 + 2 * w / (b - t) + (b + t) / (jnp.pi * (b - t)) * jnp.log((2 * b - t) / t)
+        alpha_low = 2.7e-3 * ep_r * zc_real / (30 * jnp.pi * (b - t)) * a
+
+        beta = 1 + b / (0.5 * w + 0.7 * t) * (
+            0.5 + 0.7 * t / w + jnp.log(4 * jnp.pi * w / t) / (2 * jnp.pi)
+        )
+        alpha_high = 0.16 / (zc_real * b) * beta
+
+        alpha_over_rs = jnp.where(
+            jnp.sqrt(ep_r) * zc_real < 120, alpha_low, alpha_high
+        )
+        return 1 / (alpha_over_rs * zc_real)

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -1,5 +1,5 @@
 """
-Physical transmission lines (general, coaxial, microstrip)
+Physical transmission lines (general, coaxial, microstrip, stripline)
 """
 from typing import Literal
 
@@ -27,6 +27,8 @@ from pmrf.models.components.lines.formulations import (
     AbstractMicrostripFormulation,
     ConductorProperties,
     DielectricProperties,
+    AbstractStriplineFormulation,
+    CohnStriplineFormulation,
     KirschningJansen,
     TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
@@ -537,3 +539,111 @@ class MicrostripLine(AbstractImmittanceLine):
         )
         beta = freq.w * jnp.sqrt(ep_eff_real) / c
         return alpha_dielectric + 1j * beta
+
+
+class StriplineLine(AbstractImmittanceLine):
+    r"""
+    Stripline defined by its geometry and material modules.
+
+    Uses :class:`CohnStriplineFormulation` as the default mathematical
+    formulation.
+
+    Stripline is homogeneously filled, so it has no modal dispersion and
+    therefore no ``dispersion`` field: the effective permittivity is the
+    permittivity of the filling itself, at every frequency. Material dispersion
+    still applies, and needs nothing stripline-specific — it arrives through the
+    dielectric module exactly as it does for any other line.
+
+    **Mathematical Formulation**
+
+    The quasi-static formulation returns $(\varepsilon_e, Z_c, W_{eff})$, and
+    :meth:`QuasiStaticResult.to_immittance` converts them directly:
+    $$Z = \frac{j\omega Z_c\sqrt{\varepsilon_e}}{c} + \frac{2Z_s}{W_{eff}}
+    \qquad
+    Y = \frac{j\omega\sqrt{\varepsilon_e}}{Z_c c}.$$
+    See :class:`CohnStriplineFormulation` for the geometry.
+
+    Example
+    --------
+    .. code-block:: python
+
+        import pmrf as prf
+        from pmrf.models import StriplineLine
+        from pmrf.materials import BulkConductor, ConstantDielectric
+
+        line = StriplineLine(
+            w=2.655e-3,
+            b=3.2e-3,
+            t=35e-6,
+            dielectric=ConstantDielectric(ep_r=2.2, tand=0.001),
+            conductor=BulkConductor(rho=1.72e-8),
+            length=0.1,
+        )
+
+        freq = prf.Frequency(start=1, stop=20, npoints=101, unit='ghz')
+        s = line.s(freq)
+
+    Parameters
+    ----------
+    w : Param, default=2.655e-3
+        Width of the centre strip in meters.
+    b : Param, default=3.2e-3
+        Separation of the ground planes in meters.
+    t : Param | None, default=35e-6
+        Thickness of the centre strip in meters. ``None`` idealises it as
+        zero-thickness, which has no finite conductor loss.
+    dielectric : AbstractDielectric, default=ConstantDielectric(ep_r=4.3)
+        The filling between the ground planes. A scalar permittivity or an
+        ``(ep_r, tand)`` tuple is coerced into a
+        :class:`~pmrf.materials.ConstantDielectric`.
+    conductor : AbstractConductor, default=BulkConductor()
+        The material of the strip and the ground planes. A scalar resistivity in
+        ohm-meters is coerced into a :class:`~pmrf.materials.BulkConductor`.
+    formulation : AbstractStriplineFormulation, default=CohnStriplineFormulation()
+        The closed-form physics used to compute the quasi-static solution.
+
+    References
+    ----------
+    Cohn, S. B. (1955). Problems in Strip Transmission Lines. IRE Transactions
+    on Microwave Theory and Techniques, 3(2), 119-126.
+
+    Pozar, D. M. (2011). Microwave Engineering (4th ed.), Section 3.7. Wiley.
+    """
+    #: Width of the centre strip
+    w: Param = param(default=2.655e-3, constraint=Positive())
+
+    #: Separation of the ground planes
+    b: Param = param(default=3.2e-3, constraint=Positive())
+
+    #: Thickness of the centre strip
+    t: Param | None = field(
+        default=35e-6,
+        converter=lambda x: as_param(x, constraint=Positive()) if x is not None else None,
+    )
+
+    #: The filling between the ground planes
+    dielectric: AbstractDielectric = field(
+        default_factory=lambda: ConstantDielectric(ep_r=4.3), converter=as_dielectric
+    )
+
+    #: The material of the strip and the ground planes
+    conductor: AbstractConductor = field(
+        default_factory=BulkConductor, converter=as_conductor
+    )
+
+    #: The underlying physics formulation
+    formulation: AbstractStriplineFormulation = field(
+        default_factory=CohnStriplineFormulation
+    )
+
+    def immittance(self, freq: Frequency) -> ImmittanceResult:
+        zs = self.conductor.surface_impedance(freq)
+        quasi_static = self.formulation.quasi_static(
+            freq,
+            w=self.w,
+            b=self.b,
+            t=self.t,
+            ep_r=self.dielectric.epsilon_r(freq),
+            zs=zs,
+        )
+        return quasi_static.to_immittance(freq, zs)

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -13,8 +13,10 @@ from pmrf.materials import (
     AbstractDielectric,
     BulkConductor,
     ConstantDielectric,
+    Substrate,
     as_conductor,
     as_dielectric,
+    as_substrate,
 )
 from pmrf.utils import field
 from pmrf.parameters import Param, param, as_param
@@ -32,6 +34,9 @@ from pmrf.models.components.lines.formulations import (
 
 
 EpsilonConvention = Literal["complex", "real"]
+
+# `None` disables modal dispersion, so it cannot double as "not given".
+_DEFAULT_DISPERSION = object()
 
 
 def _as_epsilon_convention(value: str) -> EpsilonConvention:
@@ -353,12 +358,21 @@ class MicrostripLine(AbstractImmittanceLine):
         freq = prf.Frequency(start=1, stop=20, npoints=101, unit='ghz')
         s_phys = phys_microstrip.s(freq)    
 
+    The substrate can be given as one :class:`~pmrf.materials.Substrate`, or as
+    its loose fields. Both build the same canonical substrate, so the two
+    idioms produce identical PyTrees; they may not be mixed in one call.
+
     Parameters
     ----------
     w : Param, default=3e-3
         Width of the microstrip trace in meters.
+    substrate : Substrate, optional
+        The substrate carrying the trace, as a single grouped module. Sharing
+        one substrate between several traces is what dedupes their permittivity
+        into a single parameter; see :class:`~pmrf.materials.Substrate`.
     h : Param, default=1.6e-3
-        Height of the dielectric substrate in meters.
+        Height of the dielectric substrate in meters. Loose form of
+        ``substrate.h``.
     dielectric : AbstractDielectric, default=ConstantDielectric(ep_r=4.3)
         The substrate material. A scalar permittivity or an ``(ep_r, tand)`` tuple
         is coerced into a :class:`~pmrf.materials.ConstantDielectric`.
@@ -393,23 +407,10 @@ class MicrostripLine(AbstractImmittanceLine):
     """
     #: Width of the microstrip trace
     w: Param = param(default=3e-3, constraint=Positive())
-    
-    #: Height of the dielectric substrate
-    h: Param = param(default=1.6e-3, constraint=Positive())
-    
-    #: The substrate material
-    dielectric: AbstractDielectric = field(
-        default_factory=lambda: ConstantDielectric(ep_r=4.3), converter=as_dielectric
-    )
-    
-    #: The material of the trace and ground plane
-    conductor: AbstractConductor = field(
-        default_factory=BulkConductor, converter=as_conductor
-    )
-    
-    #: Thickness of the conductor
-    t: Param | None = field(default=None, converter=lambda x: as_param(x, constraint=Positive()) if x is not None else None)
-    
+
+    #: The substrate carrying the trace
+    substrate: Substrate = field(default_factory=Substrate, converter=as_substrate)
+
     #: The underlying physics formulation
     formulation: AbstractMicrostripFormulation = field(default_factory=WheelerMicrostripFormulation)
 
@@ -421,9 +422,47 @@ class MicrostripLine(AbstractImmittanceLine):
         default="complex", static=True, converter=_as_epsilon_convention
     )
 
+    def __init__(
+        self,
+        w: Param = 3e-3,
+        *,
+        length: Param,
+        substrate: Substrate | None = None,
+        h: Param | None = None,
+        dielectric=None,
+        conductor=None,
+        t: Param | None = None,
+        formulation: AbstractMicrostripFormulation | None = None,
+        dispersion: AbstractMicrostripDispersion | None = _DEFAULT_DISPERSION,
+        epsilon_convention: EpsilonConvention = "complex",
+        name: str | None = None,
+        metadata=None,
+    ):
+        loose = {"h": h, "dielectric": dielectric, "conductor": conductor, "t": t}
+        given = {key: value for key, value in loose.items() if value is not None}
+        if substrate is not None and given:
+            raise ValueError(
+                "pass either substrate= or the loose substrate fields "
+                f"({', '.join(sorted(given))}), not both"
+            )
+
+        self.w = w
+        self.substrate = Substrate(**given) if substrate is None else substrate
+        self.formulation = (
+            WheelerMicrostripFormulation() if formulation is None else formulation
+        )
+        self.dispersion = (
+            KirschningJansen() if dispersion is _DEFAULT_DISPERSION else dispersion
+        )
+        self.epsilon_convention = epsilon_convention
+        self.length = length
+        self.name = name
+        self.metadata = metadata
+
     def immittance(self, freq: Frequency) -> ImmittanceResult:
-        zs = self.conductor.surface_impedance(freq)
-        material_ep_r = self.dielectric.epsilon_r(freq)
+        substrate = self.substrate
+        zs = substrate.conductor.surface_impedance(freq)
+        material_ep_r = substrate.dielectric.epsilon_r(freq)
         formula_ep_r = (
             material_ep_r if self.epsilon_convention == "complex" else jnp.real(material_ep_r)
         )
@@ -431,8 +470,8 @@ class MicrostripLine(AbstractImmittanceLine):
         quasi_static = self.formulation.quasi_static(
             freq,
             w=self.w,
-            h=self.h,
-            t=self.t,
+            h=substrate.h,
+            t=substrate.t,
             ep_r=formula_ep_r,
             zs=zs,
         )
@@ -450,8 +489,8 @@ class MicrostripLine(AbstractImmittanceLine):
                 ep_r=formula_ep_r,
                 w=self.w,
                 w_eff=quasi_static.w_eff,
-                h=self.h,
-                t=self.t,
+                h=substrate.h,
+                t=substrate.t,
             )
 
         if self.epsilon_convention == "complex":
@@ -463,7 +502,7 @@ class MicrostripLine(AbstractImmittanceLine):
 
         # Wheeler's incremental-inductance rule. With no finite conductor
         # thickness scikit-rf defines this empirical correction as zero.
-        if self.t is not None:
+        if substrate.t is not None:
             z0 = jnp.sqrt(mu_0 / epsilon_0)
             loss_zc = zc if self.epsilon_convention == "complex" else quasi_static.zc
             current_distribution = jnp.exp(-1.2 * (jnp.real(loss_zc) / z0) ** 0.7)

--- a/tests/test_dc_limits.py
+++ b/tests/test_dc_limits.py
@@ -37,6 +37,7 @@ from pmrf.models import (
     PhaseLine,
     PhysicalLine,
     RLGCLine,
+    StriplineLine,
 )
 from pmrf.models.components.lines.formulations import (
     HammerstadJensenMicrostripFormulation,
@@ -92,6 +93,17 @@ LINES = {
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
         t=35e-6,
         length=0.1,
+    ),
+    "StriplineLine": StriplineLine(
+        w=2.655e-3,
+        b=3.2e-3,
+        t=35e-6,
+        dielectric=ConstantDielectric(ep_r=2.2, tand=0.001),
+        conductor=BulkConductor(rho=1.72e-8),
+        length=0.1,
+    ),
+    "StriplineLine (zero thickness)": StriplineLine(
+        dielectric=ConstantDielectric(ep_r=2.2, tand=0.001), t=None, length=0.1
     ),
     "FloatingLine": FloatingLine(floating=PhaseLine(z0=50.0, theta=90.0, f0=5e9)),
 }

--- a/tests/test_materials/test_substrate.py
+++ b/tests/test_materials/test_substrate.py
@@ -1,0 +1,103 @@
+import doctest
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import pmrf.materials.substrate as substrate_module
+from pmrf.frequency import Frequency
+from pmrf.materials import BulkConductor, ConstantDielectric, Substrate
+from pmrf.models import AbstractBuilder, MicrostripLine
+from pmrf.parameters import Param
+
+
+@pytest.fixture
+def freq():
+    return Frequency(start=1.0, stop=10.0, npoints=11, unit="GHz")
+
+
+def test_substrate_coerces_loose_materials():
+    """Scalars are coerced by the same converters the lines use."""
+    substrate = Substrate(h=1.6e-3, dielectric=4.3, conductor=1.72e-8)
+
+    assert isinstance(substrate.dielectric, ConstantDielectric)
+    assert isinstance(substrate.conductor, BulkConductor)
+    assert substrate.t is None
+
+
+def test_substrate_docstring_doctests():
+    """The shared-substrate example in the docstring is executable."""
+    results = doctest.testmod(substrate_module, verbose=False)
+    assert results.failed == 0
+    assert results.attempted > 0
+
+
+def test_shared_substrate_exposes_one_permittivity():
+    """A builder injecting one substrate into two traces dedupes its parameters."""
+    class Board(AbstractBuilder):
+        substrate: Substrate
+        w1: Param
+        w2: Param
+
+        def build(self):
+            return (
+                MicrostripLine(w=self.w1, substrate=self.substrate, length=0.1)
+                ** MicrostripLine(w=self.w2, substrate=self.substrate, length=0.2)
+            )
+
+    board = Board(substrate=Substrate(h=1.6e-3, dielectric=4.3), w1=1e-3, w2=2e-3)
+    names = board.named_params()
+
+    permittivities = [name for name in names if name.endswith("ep_r")]
+    assert len(permittivities) == 1
+
+
+def test_same_param_object_in_two_lines_does_not_dedupe():
+    """The contrast: PyTree flattening gives one leaf per line, not one shared leaf."""
+    ep_r = Param(value=4.3)
+    lines = (
+        MicrostripLine(w=1e-3, h=1.6e-3, dielectric=ConstantDielectric(ep_r=ep_r), length=0.1)
+        ** MicrostripLine(w=2e-3, h=1.6e-3, dielectric=ConstantDielectric(ep_r=ep_r), length=0.2)
+    )
+
+    names = lines.named_params()
+    permittivities = [name for name in names if name.endswith("ep_r")]
+    assert len(permittivities) == 2
+
+
+def test_microstrip_substrate_and_loose_forms_are_identical(freq):
+    """Both idioms build the same canonical substrate, so both PyTrees match."""
+    loose = MicrostripLine(
+        w=3e-3,
+        h=1.6e-3,
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
+        conductor=BulkConductor(rho=1.72e-8),
+        length=0.1,
+    )
+    grouped = MicrostripLine(
+        w=3e-3,
+        substrate=Substrate(
+            h=1.6e-3,
+            dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
+            conductor=BulkConductor(rho=1.72e-8),
+        ),
+        length=0.1,
+    )
+
+    assert jax.tree_util.tree_structure(loose) == jax.tree_util.tree_structure(grouped)
+    assert jnp.array_equal(
+        jnp.asarray(jax.tree_util.tree_leaves(loose)),
+        jnp.asarray(jax.tree_util.tree_leaves(grouped)),
+    )
+    assert jnp.allclose(loose.s(freq), grouped.s(freq))
+
+
+def test_microstrip_rejects_substrate_with_loose_fields():
+    """The two idioms are alternatives, not a mixture."""
+    with pytest.raises(ValueError, match="substrate"):
+        MicrostripLine(
+            w=3e-3,
+            h=1.6e-3,
+            substrate=Substrate(h=1.6e-3, dielectric=4.3),
+            length=0.1,
+        )

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -410,10 +410,10 @@ def test_lossy_microstrip_preserves_dispersed_zc_and_phase():
         length=0.1,
     )
 
-    ep_r = line.dielectric.epsilon_r(freq)
-    zs = line.conductor.surface_impedance(freq)
+    ep_r = line.substrate.dielectric.epsilon_r(freq)
+    zs = line.substrate.conductor.surface_impedance(freq)
     quasi_static = formulation.quasi_static(
-        freq, w=line.w, h=line.h, t=line.t, ep_r=ep_r, zs=zs
+        freq, w=line.w, h=line.substrate.h, t=line.substrate.t, ep_r=ep_r, zs=zs
     )
     ep_eff, expected_zc = dispersion.disperse(
         freq,
@@ -422,8 +422,8 @@ def test_lossy_microstrip_preserves_dispersed_zc_and_phase():
         ep_r=ep_r,
         w=line.w,
         w_eff=quasi_static.w_eff,
-        h=line.h,
-        t=line.t,
+        h=line.substrate.h,
+        t=line.substrate.t,
     )
 
     zc, gamma_length = line.zc_and_gammaL(freq)
@@ -446,10 +446,10 @@ def test_microstrip_without_dispersion_preserves_quasi_static_immittance():
         length=0.1,
     )
 
-    ep_r = line.dielectric.epsilon_r(freq)
-    zs = line.conductor.surface_impedance(freq)
+    ep_r = line.substrate.dielectric.epsilon_r(freq)
+    zs = line.substrate.conductor.surface_impedance(freq)
     quasi_static = line.formulation.quasi_static(
-        freq, w=line.w, h=line.h, t=line.t, ep_r=ep_r, zs=zs
+        freq, w=line.w, h=line.substrate.h, t=line.substrate.t, ep_r=ep_r, zs=zs
     )
 
     actual = line.immittance(freq)

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -629,3 +629,176 @@ def test_microstrip_near_air_has_finite_conductance_and_gradient():
 def test_coaxial_line_has_no_modal_dispersion_field():
     """Homogeneously filled coax has no modal-dispersion stage."""
     assert not hasattr(CoaxialLine(length=0.1), "dispersion")
+
+
+# -----------------------------------------------------------------------------
+# Stripline
+#
+# scikit-rf has no stripline media, so these compare against the published
+# closed-form results (Pozar, Microwave Engineering 4th ed., Section 3.7)
+# and against the exact identities a homogeneously-filled line must satisfy.
+# -----------------------------------------------------------------------------
+
+def test_stripline_effective_permittivity_equals_relative_permittivity():
+    """Stripline is homogeneously filled, so there is no filling factor at all."""
+    from pmrf.models import CohnStriplineFormulation, StriplineLine
+
+    freq = Frequency(start=1.0, stop=20.0, npoints=11, unit="GHz")
+    dielectric = ConstantDielectric(ep_r=2.2, tand=0.001)
+    line = StriplineLine(w=2.655e-3, b=3.2e-3, dielectric=dielectric, length=0.1)
+
+    quasi_static = CohnStriplineFormulation().quasi_static(
+        freq,
+        w=line.w,
+        b=line.b,
+        t=line.t,
+        ep_r=dielectric.epsilon_r(freq),
+        zs=line.conductor.surface_impedance(freq),
+    )
+
+    assert jnp.array_equal(quasi_static.ep_eff, dielectric.epsilon_r(freq))
+
+
+def test_stripline_impedance_matches_pozar_design_example():
+    """Pozar Example 3.7: er=2.20, b=0.32 cm, W/b=0.830 designs a 50 ohm line."""
+    from pmrf.models import StriplineLine
+
+    freq = Frequency(start=10.0, stop=10.0, npoints=1, unit="GHz")
+    b = 0.32e-2
+    w_over_b = 30 * jnp.pi / (jnp.sqrt(2.2) * 50.0) - 0.441
+    line = StriplineLine(
+        w=w_over_b * b,
+        b=b,
+        dielectric=2.2,
+        conductor=BulkConductor(rho=0.0),
+        length=0.1,
+    )
+
+    zc = jnp.real(line.zc(freq))
+    assert jnp.allclose(zc, 50.0, rtol=2e-3)
+
+
+def test_stripline_dielectric_loss_is_the_homogeneous_limit():
+    """A homogeneous line has alpha_d = k tan(delta) / 2 exactly."""
+    from pmrf.models import StriplineLine
+
+    freq = Frequency(start=10.0, stop=10.0, npoints=1, unit="GHz")
+    tand = 0.001
+    line = StriplineLine(
+        w=2.655e-3,
+        b=3.2e-3,
+        dielectric=ConstantDielectric(ep_r=2.2, tand=tand),
+        conductor=BulkConductor(rho=0.0),
+        length=1.0,
+    )
+
+    alpha = jnp.real(line.gammaL(freq))
+    k = freq.w * jnp.sqrt(2.2) / c
+    assert jnp.allclose(alpha, k * tand / 2, rtol=1e-3)
+
+
+def test_stripline_attenuation_matches_pozar_worked_example():
+    """Pozar Example 3.7 publishes alpha_d = 0.155 Np/m and alpha_c = 0.122 Np/m.
+
+    Geometry: er=2.20, tand=0.001, b=0.32 cm, t=0.01 mm, copper, Z0=50 ohm,
+    at 10 GHz.
+    """
+    from pmrf.models import StriplineLine
+
+    freq = Frequency(start=10.0, stop=10.0, npoints=1, unit="GHz")
+    geometry = dict(w=2.655e-3, b=3.2e-3, t=1e-5, length=1.0)
+    copper = BulkConductor(rho=1.72e-8)
+
+    lossless = StriplineLine(
+        dielectric=2.2, conductor=BulkConductor(rho=0.0), **geometry
+    )
+    conductor_only = StriplineLine(dielectric=2.2, conductor=copper, **geometry)
+    dielectric_only = StriplineLine(
+        dielectric=ConstantDielectric(ep_r=2.2, tand=0.001),
+        conductor=BulkConductor(rho=0.0),
+        **geometry,
+    )
+
+    assert jnp.allclose(jnp.real(lossless.zc(freq)), 50.0, rtol=1e-3)
+    assert jnp.allclose(jnp.real(lossless.gammaL(freq)), 0.0, atol=1e-12)
+    # Pozar rounds to three digits, so match to that.
+    assert jnp.allclose(jnp.real(conductor_only.gammaL(freq)), 0.122, atol=5e-4)
+    assert jnp.allclose(jnp.real(dielectric_only.gammaL(freq)), 0.155, atol=5e-4)
+
+
+def test_stripline_conductor_loss_scales_with_root_frequency():
+    """Conductor loss enters through the surface impedance, so it follows sqrt(f)."""
+    from pmrf.models import StriplineLine
+
+    freq = Frequency(start=1.0, stop=100.0, npoints=3, unit="GHz")
+    line = StriplineLine(
+        w=2.655e-3,
+        b=3.2e-3,
+        t=35e-6,
+        dielectric=2.2,
+        conductor=BulkConductor(rho=1.72e-8),
+        length=1.0,
+    )
+
+    alpha = jnp.real(line.gammaL(freq))
+    assert jnp.all(alpha > 0)
+    # A hundredfold in frequency is a tenfold in skin-effect attenuation.
+    assert jnp.allclose(alpha[2] / alpha[0], 10.0, rtol=1e-2)
+
+
+def test_stripline_accepts_a_dispersive_dielectric():
+    """A dispersive material needs no stripline-specific code: eps_eff tracks it."""
+    from pmrf.models import CohnStriplineFormulation, StriplineLine
+
+    freq = Frequency(start=1.0, stop=20.0, npoints=11, unit="GHz")
+    dielectric = DjordjevicSarkar(ep_r=3.9, tand=0.02, f_ref=1e9)
+    line = StriplineLine(w=2.655e-3, b=3.2e-3, dielectric=dielectric, length=0.1)
+
+    ep_r = dielectric.epsilon_r(freq)
+    quasi_static = CohnStriplineFormulation().quasi_static(
+        freq,
+        w=line.w,
+        b=line.b,
+        t=line.t,
+        ep_r=ep_r,
+        zs=line.conductor.surface_impedance(freq),
+    )
+
+    assert jnp.array_equal(quasi_static.ep_eff, ep_r)
+    # The dielectric actually disperses over the band, so this is not vacuous.
+    assert jnp.abs(jnp.real(ep_r[0]) - jnp.real(ep_r[-1])) > 1e-3
+
+    s = line.s(freq)
+    assert jnp.all(jnp.isfinite(s))
+
+
+def test_stripline_narrow_strip_uses_the_fringing_correction():
+    """Below W/b = 0.35 Cohn's effective width picks up the fringing term."""
+    from pmrf.models import StriplineLine
+
+    freq = Frequency(start=10.0, stop=10.0, npoints=1, unit="GHz")
+    b = 3.2e-3
+    narrow = StriplineLine(
+        w=0.2 * b, b=b, dielectric=2.2, conductor=BulkConductor(rho=0.0), length=0.1
+    )
+
+    w_e = 0.2 * b - (0.35 - 0.2) ** 2 * b
+    expected = 30 * jnp.pi / jnp.sqrt(2.2) * b / (w_e + 0.441 * b)
+    assert jnp.allclose(jnp.real(narrow.zc(freq)), expected, rtol=1e-6)
+
+
+def test_stripline_high_impedance_branch_is_selected():
+    """A narrow strip crosses sqrt(er)*Zc = 120 onto Cohn's other loss fit."""
+    from pmrf.models import StriplineLine
+
+    freq = Frequency(start=10.0, stop=10.0, npoints=1, unit="GHz")
+    geometry = dict(b=3.2e-3, t=35e-6, dielectric=2.2, length=1.0)
+    copper = BulkConductor(rho=1.72e-8)
+
+    narrow = StriplineLine(w=0.2e-3, conductor=copper, **geometry)
+    wide = StriplineLine(w=2.655e-3, conductor=copper, **geometry)
+
+    assert jnp.sqrt(2.2) * jnp.real(narrow.zc(freq)) > 120
+    assert jnp.sqrt(2.2) * jnp.real(wide.zc(freq)) < 120
+    # A narrower strip concentrates the current, so it loses more.
+    assert jnp.real(narrow.gammaL(freq)) > jnp.real(wide.gammaL(freq)) > 0


### PR DESCRIPTION
Closes #64

## Summary

- add a shared Substrate module and canonicalize both MicrostripLine construction idioms onto it
- document builder-based substrate sharing while retaining direct dielectric/conductor fields on coax
- add StriplineLine with the Cohn stripline formulation and generic dispersive-dielectric support
- cover shared PyTree structure, homogeneous effective permittivity, DC behavior, and Pozar worked values

## Testing

- .venv/bin/python -m pytest — 428 passed, 28 skipped