### PR TITLE
Refactor material properties and planar line state

### DIFF
--- a/pmrf/materials/__init__.py
+++ b/pmrf/materials/__init__.py
@@ -16,6 +16,10 @@ from pmrf.materials.dielectric import (
     TabulatedDielectric as TabulatedDielectric,
     as_dielectric as as_dielectric,
 )
+from pmrf.materials.properties import (
+    ConductorProperties as ConductorProperties,
+    DielectricProperties as DielectricProperties,
+)
 from pmrf.materials.substrate import (
     Substrate as Substrate,
     as_substrate as as_substrate,
@@ -24,7 +28,7 @@ from pmrf.materials.conductor import (
     AbstractConductor as AbstractConductor,
     AbstractRoughness as AbstractRoughness,
     BulkConductor as BulkConductor,
-    Hammerstad as Hammerstad,
+    HammerstadRoughness as HammerstadRoughness,
     RoughConductor as RoughConductor,
     as_conductor as as_conductor,
 )
@@ -38,10 +42,12 @@ __all__ = [
     "ColeCole",
     "TabulatedDielectric",
     "as_dielectric",
+    "DielectricProperties",
+    "ConductorProperties",
     "AbstractConductor",
     "AbstractRoughness",
     "BulkConductor",
-    "Hammerstad",
+    "HammerstadRoughness",
     "RoughConductor",
     "as_conductor",
     "Substrate",

--- a/pmrf/materials/conductor.py
+++ b/pmrf/materials/conductor.py
@@ -16,6 +16,7 @@ from pmrf.constraints import Positive
 from pmrf.frequency import Frequency
 from pmrf.modules.base import Module
 from pmrf.parameters import Param, param
+from pmrf.materials.properties import ConductorProperties
 from pmrf.utils import field
 
 
@@ -27,41 +28,19 @@ class AbstractConductor(Module):
     """
 
     @abstractmethod
-    def surface_impedance(self, freq: Frequency) -> jnp.ndarray:
-        """Complex surface impedance in ohm per square, shape ``(freq.npoints,)``."""
-
-    @abstractmethod
-    def sigma(self, freq: Frequency) -> jnp.ndarray:
-        """Bulk conductivity in S/m, for formulations that need it directly."""
-
-    @abstractmethod
-    def mu_r(self, freq: Frequency) -> jnp.ndarray:
-        r"""Relative permeability, shape ``(freq.npoints,)``.
-
-        Relative rather than absolute, so that it composes with
-        :meth:`AbstractDielectric.mu_r` and with the relative permittivity
-        without a caller having to track which convention a material used.
-
-        The return may be complex, following the same passive convention as the
-        permittivity, $\mu_r = \mu' - j\mu''$ with $\mu'' \geq 0$. A material
-        with magnetic loss is expressed that way rather than through a separate
-        loss field.
-        """
-
-    @abstractmethod
-    def skin_depth(self, freq: Frequency) -> jnp.ndarray:
-        """Skin depth in meters."""
+    def properties(self, freq: Frequency) -> ConductorProperties:
+        """Evaluate surface impedance, conductivity, and permeability."""
 
 
 class AbstractRoughness(Module):
     """Abstract base class for a surface-roughness correction."""
 
     @abstractmethod
-    def factor(self, skin_depth: jnp.ndarray) -> jnp.ndarray:
+    def factor(self, freq: Frequency, sigma, mu_r) -> jnp.ndarray:
         """The multiplicative correction applied to a smooth surface impedance."""
 
 
-class Hammerstad(AbstractRoughness):
+class HammerstadRoughness(AbstractRoughness):
     r"""
     Hammerstad-Jensen surface-roughness correction.
 
@@ -71,6 +50,20 @@ class Hammerstad(AbstractRoughness):
 
     where $\Delta$ is the RMS surface roughness and $\delta$ the skin depth. The
     factor saturates at $2$, which is the well-known limitation of the model.
+
+    **Validity**
+
+    A Roughness is a correction to conductor behaviour, not a line formulation:
+    it scales a smooth surface impedance and produces no state of its own. The
+    skin depth is derived here from frequency, conductivity and permeability
+    rather than being part of the conductor interface, so the correction is
+    meaningful only for a conductor whose loss is genuinely skin-effect
+    limited -- :class:`RoughConductor` therefore extends :class:`BulkConductor`
+    rather than the abstract conductor, and a non-bulk conductor cannot silently
+    acquire one. The arctangent fit is empirical and saturates at $2$: it
+    understates loss once $\Delta/\delta$ exceeds roughly unity, which is the
+    documented limitation of the Hammerstad-Jensen form rather than a rejected
+    input.
 
     References
     ----------
@@ -86,7 +79,12 @@ class Hammerstad(AbstractRoughness):
     #: RMS surface roughness in meters
     roughness: Param = param(default=0.0, constraint=Positive())
 
-    def factor(self, skin_depth: jnp.ndarray) -> jnp.ndarray:
+    def factor(self, freq: Frequency, sigma, mu_r) -> jnp.ndarray:
+        w = jnp.asarray(freq.w)
+        safe_w = jnp.where(w > 0, w, 1.0)
+        skin_depth = jnp.where(
+            w > 0, jnp.sqrt(2 / (safe_w * mu_0 * mu_r * sigma)), jnp.inf
+        )
         ratio = self.roughness / skin_depth
         return 1 + (2 / jnp.pi) * jnp.arctan(1.4 * ratio**2)
 
@@ -115,7 +113,7 @@ class BulkConductor(AbstractConductor):
 
         copper = BulkConductor(rho=1.68e-8)
         freq = prf.Frequency(start=1, stop=10, npoints=101, unit='ghz')
-        zs = copper.surface_impedance(freq)
+        zs = copper.properties(freq).zs
 
     References
     ----------
@@ -125,43 +123,28 @@ class BulkConductor(AbstractConductor):
     ----------
     rho : Param, default=1.68e-8
         Resistivity in ohm-meters. Defaults to copper.
-    mu_rel : Param, default=1.0
-        Relative permeability of the conductor. Stored under `mu_rel` because
-        :meth:`mu_r` is the evaluated accessor; a dataclass field of that name
-        would shadow it.
+    mu_r : Param, default=1.0
+        Relative permeability of the conductor.
     """
     #: Resistivity in ohm-meters
     rho: Param = param(default=1.68e-8, constraint=Positive())
 
     #: Relative permeability of the conductor
-    mu_rel: Param = param(default=1.0, constraint=Positive())
+    mu_r: Param = param(default=1.0, constraint=Positive())
 
     @classmethod
     def from_sigma(cls, sigma, **kwargs):
         """Build a conductor from a conductivity in S/m instead of a resistivity."""
         return cls(rho=1.0 / sigma, **kwargs)
 
-    def sigma(self, freq: Frequency) -> jnp.ndarray:
-        return (1.0 / self.rho) * jnp.ones(freq.npoints)
-
-    def mu_r(self, freq: Frequency) -> jnp.ndarray:
-        return self.mu_rel * jnp.ones(freq.npoints)
-
-    def skin_depth(self, freq: Frequency) -> jnp.ndarray:
-        # Guard DC, where the skin depth is infinite, using the double-`where`
-        # pattern so the gradient stays finite as well as the value.
-        w = jnp.asarray(freq.w)
-        safe_w = jnp.where(w > 0, w, 1.0)
-        depth = jnp.sqrt(2 * self.rho / (safe_w * mu_0 * self.mu_rel))
-        return jnp.where(w > 0, depth, jnp.inf)
-
-    def surface_impedance(self, freq: Frequency) -> jnp.ndarray:
+    def properties(self, freq: Frequency) -> ConductorProperties:
         # sqrt is a branch point at w = 0, so guard it the same way: the
         # impedance is zero there, but its raw gradient would not be.
         w = jnp.asarray(freq.w)
         safe_w = jnp.where(w > 0, w, 1.0)
-        rs = jnp.where(w > 0, jnp.sqrt(safe_w * mu_0 * self.mu_rel * self.rho / 2), 0.0)
-        return rs * (1 + 1j)
+        rs = jnp.where(w > 0, jnp.sqrt(safe_w * mu_0 * self.mu_r * self.rho / 2), 0.0)
+        ones = jnp.ones(freq.npoints)
+        return ConductorProperties(rs * (1 + 1j), ones / self.rho, self.mu_r * ones)
 
 
 class RoughConductor(BulkConductor):
@@ -173,7 +156,7 @@ class RoughConductor(BulkConductor):
     $$Z_s(\omega) = K(\omega) \sqrt{\frac{j\omega\mu}{\sigma}}$$
 
     where $K$ is supplied by the `roughness` formulation, and equals $1$ for a
-    perfectly smooth surface. See :class:`Hammerstad` for the default.
+    perfectly smooth surface. See :class:`HammerstadRoughness` for the default.
 
     References
     ----------
@@ -185,21 +168,22 @@ class RoughConductor(BulkConductor):
     ----------
     rho : Param, default=1.68e-8
         Resistivity in ohm-meters.
-    mu_rel : Param, default=1.0
+    mu_r : Param, default=1.0
         Relative permeability of the conductor.
-    roughness : AbstractRoughness, default=Hammerstad()
+    roughness : AbstractRoughness, default=HammerstadRoughness()
         The roughness correction formulation. A scalar RMS roughness in meters
-        is coerced into a :class:`Hammerstad` correction.
+        is coerced into a :class:`HammerstadRoughness` correction.
     """
     #: The roughness correction formulation
     roughness: AbstractRoughness = field(
-        default_factory=Hammerstad,
-        converter=lambda x: x if isinstance(x, AbstractRoughness) else Hammerstad(x),
+        default_factory=HammerstadRoughness,
+        converter=lambda x: x if isinstance(x, AbstractRoughness) else HammerstadRoughness(x),
     )
 
-    def surface_impedance(self, freq: Frequency) -> jnp.ndarray:
-        factor = self.roughness.factor(self.skin_depth(freq))
-        return super().surface_impedance(freq) * factor
+    def properties(self, freq: Frequency) -> ConductorProperties:
+        properties = super().properties(freq)
+        factor = self.roughness.factor(freq, properties.sigma, properties.mu_r)
+        return properties._replace(zs=properties.zs * factor)
 
 
 def as_conductor(value) -> AbstractConductor:

--- a/pmrf/materials/dielectric.py
+++ b/pmrf/materials/dielectric.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 from abc import abstractmethod
 
 import jax.numpy as jnp
-from scipy.constants import epsilon_0
-
 from pmrf.constraints import Positive, GreaterThan, Interval
 from pmrf.frequency import Frequency
 from pmrf.modules.base import Module
 from pmrf.parameters import Param, param
+from pmrf.materials.properties import DielectricProperties
 from pmrf.utils import field
 
 
@@ -38,8 +37,8 @@ class AbstractDielectric(Module):
     """
 
     @abstractmethod
-    def epsilon_r(self, freq: Frequency) -> jnp.ndarray:
-        """Total complex relative permittivity.
+    def properties(self, freq: Frequency) -> DielectricProperties:
+        """Evaluate the dielectric properties over a frequency axis.
 
         Parameters
         ----------
@@ -49,42 +48,8 @@ class AbstractDielectric(Module):
         Returns
         -------
         jnp.ndarray
-            Complex relative permittivity of shape ``(freq.npoints,)``, including
-            any static conductivity contribution.
+            Complex permittivity, permeability, and static conductivity.
         """
-
-    def mu_r(self, freq: Frequency) -> jnp.ndarray:
-        r"""Total complex relative permeability, shape ``(freq.npoints,)``.
-
-        Permeability belongs to the medium exactly as permittivity does, so it
-        lives here rather than on the geometry that happens to be filled with
-        it. That is what lets a magnetic filling be defined once and used by
-        any line, and it mirrors :meth:`AbstractConductor.mu_r`.
-
-        The convention matches :meth:`epsilon_r`: $\mu_r = \mu' - j\mu''$ with
-        $\mu'' \geq 0$ for a passive medium, so magnetic loss is carried by the
-        imaginary part rather than by a separate field.
-
-        Most dielectrics are non-magnetic, so the default is $1$. A magnetic
-        medium overrides this.
-        """
-        return jnp.ones(freq.npoints, dtype=complex)
-
-    def with_conduction(self, eps: jnp.ndarray, freq: Frequency) -> jnp.ndarray:
-        r"""Add the static conduction term $-j\sigma/(\omega\varepsilon_0)$ to `eps`.
-
-        A constant loss tangent gives a conductance proportional to $\omega$,
-        whereas a constant conductivity gives a frequency-independent one;
-        neither can express the other, so `sigma` is carried separately by every
-        concrete dielectric and folded in here.
-
-        The term is guarded at DC with the double-``where`` pattern, so both the
-        value and its gradient stay finite when the axis includes $\omega = 0$.
-        """
-        w = jnp.asarray(freq.w)
-        safe_w = jnp.where(w > 0, w, 1.0)
-        term = jnp.where(w > 0, self.sigma / (safe_w * epsilon_0), 0.0)
-        return eps - 1j * term
 
 
 class ConstantDielectric(AbstractDielectric):
@@ -111,7 +76,7 @@ class ConstantDielectric(AbstractDielectric):
 
         fr4 = ConstantDielectric(ep_r=4.3, tand=0.02)
         freq = prf.Frequency(start=1, stop=10, npoints=101, unit='ghz')
-        eps = fr4.epsilon_r(freq)
+        eps = fr4.properties(freq).ep_r
 
     References
     ----------
@@ -125,10 +90,8 @@ class ConstantDielectric(AbstractDielectric):
         Dielectric loss tangent.
     sigma : Param, default=0.0
         Static bulk conductivity in S/m.
-    mu_rel : Param, default=1.0
-        Relative permeability of the medium. Stored under `mu_rel` because
-        :meth:`mu_r` is the evaluated accessor; a dataclass field of that name
-        would shadow it.
+    mu_r : Param, default=1.0
+        Relative permeability of the medium.
     """
     #: Real relative permittivity
     ep_r: Param = param(default=1.0, constraint=GreaterThan(1.0))
@@ -140,15 +103,12 @@ class ConstantDielectric(AbstractDielectric):
     sigma: Param = param(default=0.0, constraint=Positive())
 
     #: Relative permeability of the medium
-    mu_rel: Param = param(default=1.0, constraint=Positive())
+    mu_r: Param = param(default=1.0, constraint=Positive())
 
-    def epsilon_r(self, freq: Frequency) -> jnp.ndarray:
+    def properties(self, freq: Frequency) -> DielectricProperties:
         ones = jnp.ones(freq.npoints)
         eps = self.ep_r * ones - 1j * self.ep_r * self.tand * ones
-        return self.with_conduction(eps, freq)
-
-    def mu_r(self, freq: Frequency) -> jnp.ndarray:
-        return self.mu_rel * jnp.ones(freq.npoints, dtype=complex)
+        return DielectricProperties(eps, self.mu_r * ones, self.sigma * ones)
 
 
 class DjordjevicSarkar(AbstractDielectric):
@@ -217,7 +177,7 @@ class DjordjevicSarkar(AbstractDielectric):
     #: Static bulk conductivity in S/m
     sigma: Param = param(default=0.0, constraint=Positive())
 
-    def epsilon_r(self, freq: Frequency) -> jnp.ndarray:
+    def properties(self, freq: Frequency) -> DielectricProperties:
         f = freq.f
         k = jnp.log((self.f_high + 1j * self.f_ref) / (self.f_low + 1j * self.f_ref))
         fd = jnp.log((self.f_high + 1j * f) / (self.f_low + 1j * f))
@@ -225,7 +185,8 @@ class DjordjevicSarkar(AbstractDielectric):
         eps_d = -self.tand * self.ep_r / jnp.imag(k)
         eps_inf = self.ep_r * (1.0 + self.tand * jnp.real(k) / jnp.imag(k))
 
-        return self.with_conduction(eps_inf + eps_d * fd, freq)
+        ones = jnp.ones(freq.npoints)
+        return DielectricProperties(eps_inf + eps_d * fd, ones, self.sigma * ones)
 
 
 class DebyePole(Module):
@@ -305,11 +266,12 @@ class MultipoleDebye(AbstractDielectric):
     #: Static bulk conductivity in S/m
     sigma: Param = param(default=0.0, constraint=Positive())
 
-    def epsilon_r(self, freq: Frequency) -> jnp.ndarray:
+    def properties(self, freq: Frequency) -> DielectricProperties:
         eps = self.ep_inf * jnp.ones(freq.npoints, dtype=complex)
         for pole in self.poles:
             eps = eps + pole.contribution(freq)
-        return self.with_conduction(eps, freq)
+        ones = jnp.ones(freq.npoints)
+        return DielectricProperties(eps, ones, self.sigma * ones)
 
 
 class ColeCole(AbstractDielectric):
@@ -357,14 +319,15 @@ class ColeCole(AbstractDielectric):
     #: Static bulk conductivity in S/m
     sigma: Param = param(default=0.0, constraint=Positive())
 
-    def epsilon_r(self, freq: Frequency) -> jnp.ndarray:
+    def properties(self, freq: Frequency) -> DielectricProperties:
         # Guard f = 0, where (jf/f_r)**(1-alpha) is a branch point.
         f = jnp.asarray(freq.f)
         safe_f = jnp.where(f > 0, f, 1.0)
         ratio = jnp.where(f > 0, (1j * safe_f / self.f_relax) ** (1.0 - self.alpha), 0.0)
 
         eps = self.ep_inf + self.dep_r / (1.0 + ratio)
-        return self.with_conduction(eps, freq)
+        ones = jnp.ones(freq.npoints)
+        return DielectricProperties(eps, ones, self.sigma * ones)
 
 
 class TabulatedDielectric(AbstractDielectric):
@@ -402,17 +365,24 @@ class TabulatedDielectric(AbstractDielectric):
     #: Static bulk conductivity in S/m
     sigma: Param = param(default=0.0, constraint=Positive())
 
-    def __post_init__(self):
+    def __check_init__(self):
+        if self.f.ndim != 1 or self.ep_r.ndim != 1:
+            raise ValueError("`f` and `ep_r` must be one-dimensional")
+        if self.f.size == 0:
+            raise ValueError("tabulated dielectric data must be nonempty")
         if self.f.shape != self.ep_r.shape:
             raise ValueError(
                 "`f` and `ep_r` must have the same shape, got "
                 f"{self.f.shape} and {self.ep_r.shape}"
             )
+        if not bool(jnp.all(jnp.diff(self.f) > 0)):
+            raise ValueError("`f` must be strictly increasing")
 
-    def epsilon_r(self, freq: Frequency) -> jnp.ndarray:
+    def properties(self, freq: Frequency) -> DielectricProperties:
         real = jnp.interp(freq.f, self.f, jnp.real(self.ep_r))
         imag = jnp.interp(freq.f, self.f, jnp.imag(self.ep_r))
-        return self.with_conduction(real + 1j * imag, freq)
+        ones = jnp.ones(freq.npoints)
+        return DielectricProperties(real + 1j * imag, ones, self.sigma * ones)
 
 
 def as_dielectric(value) -> AbstractDielectric:

--- a/pmrf/materials/properties.py
+++ b/pmrf/materials/properties.py
@@ -1,0 +1,40 @@
+"""Frequency-evaluated, geometry-free material properties."""
+from typing import NamedTuple
+
+import jax.numpy as jnp
+
+
+class DielectricProperties(NamedTuple):
+    """Evaluated dielectric properties.
+
+    Parameters
+    ----------
+    ep_r : jnp.ndarray
+        Complex relative permittivity excluding static conduction.
+    mu_r : jnp.ndarray
+        Complex relative permeability.
+    sigma : jnp.ndarray
+        Static bulk conductivity in S/m.
+    """
+
+    ep_r: jnp.ndarray
+    mu_r: jnp.ndarray
+    sigma: jnp.ndarray
+
+
+class ConductorProperties(NamedTuple):
+    """Evaluated conductor properties.
+
+    Parameters
+    ----------
+    zs : jnp.ndarray
+        Surface impedance in ohm per square.
+    sigma : jnp.ndarray
+        Bulk conductivity in S/m.
+    mu_r : jnp.ndarray
+        Complex relative permeability.
+    """
+
+    zs: jnp.ndarray
+    sigma: jnp.ndarray
+    mu_r: jnp.ndarray

--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -94,12 +94,10 @@ from pmrf.models.components.lines.formulations import (
     WheelerMicrostripFormulation as WheelerMicrostripFormulation,
     HammerstadJensenMicrostripFormulation as HammerstadJensenMicrostripFormulation,
     AbstractMicrostripDispersion as AbstractMicrostripDispersion,
-    KirschningJansen as KirschningJansen,
+    KirschningJansenMicrostripDispersion as KirschningJansenMicrostripDispersion,
     AbstractStriplineFormulation as AbstractStriplineFormulation,
     CohnStriplineFormulation as CohnStriplineFormulation,
-    QuasiStaticResult as QuasiStaticResult,
-    DielectricProperties as DielectricProperties,
-    ConductorProperties as ConductorProperties,
+    PlanarQuasiStaticResult as PlanarQuasiStaticResult,
 )
 
 from pmrf.models.components.lumped import (

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -1,59 +1,34 @@
 """
 Closed-form physics for transmission lines (coaxial, microstrip, stripline).
 
+Three distinct strategy roles appear on a line model, each with its own field:
+
+- A **Formulation** (`formulation`) produces the complete electrical state a
+  model needs to reach S-parameters: either a per-unit-length immittance
+  directly, or a :class:`PlanarQuasiStaticResult` the line converts into one.
+  It is the primary strategy, and a line always has exactly one.
+- A **Dispersion** (`dispersion`) modifies an existing quasi-static state with
+  modal frequency dependence. It never produces a state of its own, so it only
+  exists where the cross-section is inhomogeneous and the mode is therefore not
+  strictly TEM -- microstrip has one, homogeneously filled coaxial and stripline
+  do not.
+- A **Roughness** (`roughness`, in :mod:`pmrf.materials.conductor`) modifies
+  conductor behaviour rather than line state: it scales a surface impedance,
+  and so belongs to the conductor material, not to the geometry.
+
 A formulation is pure numerics. Materials are evaluated by the line, so a
 formulation never sees a :class:`~pmrf.Param` or a :class:`~pmrf.Module`
 parameter: it can be checked directly against the equations of the paper it
 comes from, and contributed without learning the material taxonomy.
 """
 from abc import abstractmethod
-from typing import NamedTuple
-
 from scipy.constants import c, mu_0, epsilon_0
 import jax.numpy as jnp
 import equinox as eqx
 
 from pmrf.frequency import Frequency
+from pmrf.materials import ConductorProperties, DielectricProperties
 from pmrf.models.components.lines.base import ImmittanceResult
-
-
-class DielectricProperties(NamedTuple):
-    """Evaluated, geometry-free dielectric properties.
-
-    Parameters
-    ----------
-    ep_r : array-like
-        Complex relative permittivity.
-    mu_r : array-like
-        Complex relative permeability. Magnetic loss is carried by the
-        imaginary part, so a lossy magnetic filling needs no extra field.
-    """
-
-    #: Complex relative permittivity
-    ep_r: jnp.ndarray
-    #: Complex relative permeability
-    mu_r: jnp.ndarray
-
-
-class ConductorProperties(NamedTuple):
-    """Evaluated, geometry-free conductor properties.
-
-    Parameters
-    ----------
-    zs : array-like
-        Surface impedance in ohm per square.
-    sigma : array-like
-        Bulk conductivity in S/m.
-    mu_r : array-like
-        Complex relative permeability.
-    """
-
-    #: Surface impedance in ohm per square
-    zs: jnp.ndarray
-    #: Bulk conductivity in S/m
-    sigma: jnp.ndarray
-    #: Complex relative permeability
-    mu_r: jnp.ndarray
 
 
 def _tesche_internal_impedance(zs_over_radius, rdc, lint, w):
@@ -112,7 +87,7 @@ def tube_internal_impedance(zs, sigma, mu_r, radius, thickness, w):
     return _tesche_internal_impedance(zs / radius, rdc, lint, w)
 
 
-class QuasiStaticResult(eqx.Module):
+class PlanarQuasiStaticResult(eqx.Module):
     r"""
     Quasi-static solution of a single-conductor planar line over a ground plane.
 
@@ -131,7 +106,11 @@ class QuasiStaticResult(eqx.Module):
     zc : jnp.ndarray
         Quasi-static characteristic impedance in ohms, $Z_a/\sqrt{\varepsilon_e}$.
     w_eff : jnp.ndarray
-        Effective conductor width in meters, carrying the series loss.
+        Electromagnetic effective conductor width in meters.
+    conductor_loss_factor : jnp.ndarray
+        Geometry factor multiplying surface impedance, in inverse meters.
+    shunt_conductance_factor : jnp.ndarray
+        Geometry factor multiplying static conductivity, in meters.
     """
     #: Complex effective relative permittivity
     ep_eff: jnp.ndarray
@@ -142,7 +121,16 @@ class QuasiStaticResult(eqx.Module):
     #: Effective conductor width in meters
     w_eff: jnp.ndarray
 
-    def to_immittance(self, freq: Frequency, zs: jnp.ndarray) -> ImmittanceResult:
+    #: Geometry factor multiplying surface impedance
+    conductor_loss_factor: jnp.ndarray
+
+    #: Geometry factor multiplying static conductivity
+    shunt_conductance_factor: jnp.ndarray
+
+    def to_immittance(
+        self, freq: Frequency, dielectric: DielectricProperties,
+        conductor: ConductorProperties,
+    ) -> ImmittanceResult:
         r"""
         Converts the quasi-static solution into a per-unit-length immittance.
 
@@ -174,10 +162,13 @@ class QuasiStaticResult(eqx.Module):
         Pozar, D. M. (2011). Microwave Engineering (4th ed.), Section 3.8. Wiley.
         """
         w = freq.w
-        sqrt_ep_eff = jnp.sqrt(self.ep_eff)
+        sqrt_ep_eff_mu = jnp.sqrt(self.ep_eff * dielectric.mu_r)
+        sqrt_ep_eff_over_mu = jnp.sqrt(self.ep_eff / dielectric.mu_r)
 
-        Z = 1j * w * self.zc * sqrt_ep_eff / c + 2 * zs / self.w_eff
-        Y = 1j * w * sqrt_ep_eff / (self.zc * c)
+        Z = 1j * w * self.zc * sqrt_ep_eff_mu / c
+        Z = Z + conductor.zs * self.conductor_loss_factor
+        Y = 1j * w * sqrt_ep_eff_over_mu / (self.zc * c)
+        Y = Y + dielectric.sigma * self.shunt_conductance_factor
 
         return ImmittanceResult(Z=Z, Y=Y, w=w)
 
@@ -244,6 +235,17 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     term $j\omega L'$ acquires the real part $\omega\mu''\ln(b/a)/2\pi$, so
     magnetic loss enters the series resistance on its own.
 
+    **Validity**
+
+    The equivalent circuit is not an empirical fit to a width ratio, so it
+    carries no geometric fit range: it interpolates between the exact DC
+    resistance and the exact high-frequency skin-effect impedance of a round
+    conductor. The transmission-line description itself is the limit: it assumes
+    the TEM mode, so it holds below the TE11 cutoff
+    $f_c \approx c / \left[\pi (a + b) \sqrt{\varepsilon_r \mu_r}\right]$.
+    Above that, higher-order modes propagate and a single per-unit-length
+    immittance no longer describes the line.
+
     References
     ----------
     Tesche, F. M. (2007). A Simple Model for the Line Parameters of a Lossy Coaxial
@@ -258,6 +260,7 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
         mu = mu_0 * dielectric.mu_r
         w = freq.w
 
+        d_out = eqx.error_if(d_out, d_out - d_in <= 0, "d_out must exceed d_in")
         a, b = d_in / 2, d_out / 2
         ln_b_over_a = jnp.log(b / a)
 
@@ -272,6 +275,7 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
 
         Z = 1j * w * L_ext + Z_int
         Y = 1j * w * 2 * jnp.pi * eps / ln_b_over_a
+        Y = Y + 2 * jnp.pi * dielectric.sigma / ln_b_over_a
 
         return ImmittanceResult(Z=Z, Y=Y, w=w)
 
@@ -285,7 +289,7 @@ class AbstractMicrostripFormulation(eqx.Module):
     published equations with no ParamRF objects in sight.
     """
     @abstractmethod
-    def quasi_static(self, freq: Frequency, *, w, h, t, ep_r, zs) -> QuasiStaticResult:
+    def quasi_static(self, *, w, h, t, ep_r) -> PlanarQuasiStaticResult:
         r"""
         Calculates the quasi-static solution of the line.
 
@@ -307,7 +311,7 @@ class AbstractMicrostripFormulation(eqx.Module):
 
         Returns
         -------
-        QuasiStaticResult
+        PlanarQuasiStaticResult
             The effective permittivity, impedance and effective width.
         """
         raise NotImplementedError
@@ -334,12 +338,23 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
     here — a thickness-aware formulation uses it to widen $W_{eff}$ for the
     current distribution, and the line applies the series loss either way.
 
+    **Validity**
+
+    Derived for a zero-thickness strip on an isotropic, non-magnetic substrate,
+    which is why finite thickness is rejected rather than ignored. It is a
+    quasi-static result and carries no modal dispersion, so it describes the
+    line only well below the frequency at which $\varepsilon_e$ begins to rise
+    towards $\varepsilon_r$; pair it with an
+    :class:`AbstractMicrostripDispersion` above that. Outside its fitted width
+    range the closed form remains smooth and finite, so ParamRF extrapolates
+    rather than rejecting.
+
     References
     ----------
     Wheeler, H. A. (1977). Transmission-Line Properties of a Strip on a Dielectric Sheet on a Plane.
     IEEE Transactions on Microwave Theory and Techniques.
     """
-    def quasi_static(self, freq: Frequency, *, w, h, t, ep_r, zs) -> QuasiStaticResult:
+    def quasi_static(self, *, w, h, t, ep_r) -> PlanarQuasiStaticResult:
         if t is not None:
             raise ValueError("Wheeler microstrip approximation does not support finite thickness")
 
@@ -354,7 +369,7 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
         # Piecewise effective permittivity (ep_eff)
         ep_eff_le1 = t1 + t2 * (t3 + 0.04 * (1 - u)**2)
         ep_eff_gt1 = t1 + t2 * t3
-        ep_eff = jnp.where(u <= 1.0, ep_eff_le1, ep_eff_gt1) * jnp.ones(freq.npoints)
+        ep_eff = jnp.where(u <= 1.0, ep_eff_le1, ep_eff_gt1) * jnp.ones_like(ep_r)
 
         # Piecewise characteristic impedance in air (Za)
         Za_le1 = 60 * jnp.log(8 / u + 0.25 * u)
@@ -362,9 +377,10 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
         Za = jnp.where(u <= 1.0, Za_le1, Za_gt1)
 
         zc = Za / jnp.sqrt(ep_eff)
-        w_eff = W * jnp.ones(freq.npoints)
+        w_eff = W * jnp.ones_like(ep_r)
+        conductance_factor = _microstrip_conductance_factor(ep_r, ep_eff, zc)
 
-        return QuasiStaticResult(ep_eff=ep_eff, zc=zc, w_eff=w_eff)
+        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, 2 / w_eff, conductance_factor)
 
 
 class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
@@ -404,6 +420,19 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
     The dielectric constraint $\Re(\varepsilon_r)>1$ keeps its argument away
     from the negative-real branch cut for passive materials.
 
+    **Validity**
+
+    Hammerstad and Jensen quote the fit accuracy of $\varepsilon_e$ as better
+    than 0.2% for $\varepsilon_r < 128$ and $0.01 \leq u \leq 100$, and the
+    accuracy of $Z_L$ as better than 0.01% for $u \leq 1$ and 0.03% for
+    $u \leq 1000$. The result is quasi-static: it carries no modal dispersion,
+    so a :class:`AbstractMicrostripDispersion` supplies the frequency
+    dependence. The substrate must be non-magnetic; :class:`MicrostripLine`
+    rejects $\mu_r \neq 1$ rather than extrapolating. Leaving the fitted ranges
+    is a documented extrapolation: the expressions stay finite and smooth, and
+    only $\Re(\varepsilon_r) > 1$ is enforced, because the fractional power in
+    $b$ has a branch cut below it.
+
     References
     ----------
     Hammerstad, E., & Jensen, O. (1980). Accurate Models for Microstrip
@@ -411,7 +440,7 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
     407-409.
     """
 
-    def quasi_static(self, freq: Frequency, *, w, h, t, ep_r, zs) -> QuasiStaticResult:
+    def quasi_static(self, *, w, h, t, ep_r) -> PlanarQuasiStaticResult:
         u = w / h
         thickness = None if t is None else t / h
 
@@ -440,7 +469,8 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
         zc = zr / jnp.sqrt(e)
         ep_eff = e * (z1 / zr) ** 2
         w_eff = ur * h
-        return QuasiStaticResult(ep_eff=ep_eff, zc=zc, w_eff=w_eff)
+        conductance_factor = _microstrip_conductance_factor(ep_r, ep_eff, zc)
+        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, 2 / w_eff, conductance_factor)
 
     @staticmethod
     def _homogeneous_impedance(u):
@@ -454,13 +484,35 @@ class AbstractMicrostripDispersion(eqx.Module):
 
     @abstractmethod
     def disperse(
-        self, freq: Frequency, *, ep_eff_0, zc_0, ep_r, w, w_eff, h, t
+        self, freq: Frequency, *, ep_eff_0, zc_0, ep_r, w_eff, h
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
-        r"""Return frequency-dependent $(\varepsilon_e, Z_c)$."""
+        r"""
+        Return frequency-dependent $(\varepsilon_e, Z_c)$.
+
+        Parameters
+        ----------
+        freq : Frequency
+            The frequency axis.
+        ep_eff_0 : jnp.ndarray
+            Quasi-static complex effective relative permittivity.
+        zc_0 : jnp.ndarray
+            Quasi-static characteristic impedance in ohms.
+        ep_r : jnp.ndarray
+            Complex relative permittivity of the substrate.
+        w_eff : jnp.ndarray
+            Electromagnetic effective conductor width in meters.
+        h : ArrayLike
+            Substrate height in meters.
+
+        Returns
+        -------
+        tuple of jnp.ndarray
+            The dispersed effective permittivity and characteristic impedance.
+        """
         raise NotImplementedError
 
 
-class KirschningJansen(AbstractMicrostripDispersion):
+class KirschningJansenMicrostripDispersion(AbstractMicrostripDispersion):
     r"""
     Kirschning--Jansen modal dispersion for microstrip.
 
@@ -478,9 +530,8 @@ class KirschningJansen(AbstractMicrostripDispersion):
     $$P_4=1+2.751[1-e^{-(\varepsilon_r/15.916)^8}].$$
     The normalized frequency is
     $f_n=f[\mathrm{Hz}]H[\mathrm{m}]10^{-6}$ (GHz-mm).
-    Following the ADS and QUCS conventions, the normalized width is
-    $$u=\begin{cases}W_{eff}/H,&\text{complex permittivity},\\
-    W/H,&\text{real permittivity}.\end{cases}$$
+    Following the ADS convention adopted throughout ParamRF, the normalized
+    width is the thickness-corrected $u = W_{eff}/H$.
 
     Characteristic impedance is corrected by
     $$Z_c(f)=Z_c(0)\left(\frac{R_{13}}{R_{14}}\right)^{R_{17}},$$
@@ -514,6 +565,16 @@ class KirschningJansen(AbstractMicrostripDispersion):
     This extension is not part of the cited empirical fit; it supplies a
     continuous, differentiable connection to its required homogeneous limit.
 
+    **Validity**
+
+    The published fits cover $1 \leq \varepsilon_r \leq 20$,
+    $0.1 \leq W/H \leq 100$ and $0 \leq H/\lambda_0 \leq 0.13$, with the
+    numerical fits themselves anchored from $\varepsilon_r = 2.2$ upwards; the
+    smooth homogeneous-limit weight described above covers the interval below
+    that, and is ParamRF's own extension rather than part of the cited fit.
+    Outside these ranges the expressions remain finite, so ParamRF extrapolates
+    and documents it rather than rejecting the input.
+
     References
     ----------
     Kirschning, M., & Jansen, R. H. (1982). Accurate Model for Effective
@@ -526,12 +587,9 @@ class KirschningJansen(AbstractMicrostripDispersion):
     """
 
     def disperse(
-        self, freq: Frequency, *, ep_eff_0, zc_0, ep_r, w, w_eff, h, t
+        self, freq: Frequency, *, ep_eff_0, zc_0, ep_r, w_eff, h
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
-        # ADS applies the effective width in its complex-permittivity path;
-        # QUCS applies the physical width in its real-permittivity path.
-        dispersion_width = w_eff if jnp.iscomplexobj(ep_r) else w
-        u = dispersion_width / h
+        u = w_eff / h
         fn = freq.f * h * 1e-6
 
         p1 = (
@@ -607,7 +665,7 @@ class AbstractStriplineFormulation(eqx.Module):
     """
 
     @abstractmethod
-    def quasi_static(self, freq: Frequency, *, w, b, t, ep_r, zs) -> QuasiStaticResult:
+    def quasi_static(self, *, w, b, t, ep_r) -> PlanarQuasiStaticResult:
         r"""
         Calculates the quasi-static solution of the line.
 
@@ -629,7 +687,7 @@ class AbstractStriplineFormulation(eqx.Module):
 
         Returns
         -------
-        QuasiStaticResult
+        PlanarQuasiStaticResult
             The effective permittivity, impedance and effective width.
         """
         raise NotImplementedError
@@ -662,17 +720,29 @@ class CohnStriplineFormulation(AbstractStriplineFormulation):
     $$B = 1 + \frac{b}{0.5W + 0.7T}
     \left(0.5 + \frac{0.7T}{W} + \frac{1}{2\pi}\ln\frac{4\pi W}{T}\right).$$
 
-    That attenuation is returned as the effective width the line applies it
-    through. A per-unit-length series resistance $R = 2\alpha_c Z_c$ and the
-    line's own $R = 2R_s/W_{eff}$ are the same statement, so
-    $$W_{eff} = \frac{R_s}{\alpha_c Z_c} = \left[\frac{\alpha_c}{R_s}Z_c\right]^{-1},$$
-    which is independent of $R_s$ and therefore stays finite for a perfect
-    conductor. Dielectric loss needs no separate term: $\varepsilon_e$ is
-    complex, and carries it.
+    That attenuation is returned directly as the conductor-loss factor, not
+    disguised as a width. A per-unit-length series resistance is
+    $R = 2\alpha_c Z_c$, so the factor multiplying the surface impedance is
+    $$K_c = 2\frac{\alpha_c}{R_s}Z_c,$$
+    which is independent of $R_s$. The returned $W_e$ stays the genuine
+    electromagnetic fringing width and is not reused for loss. Dielectric loss
+    needs no separate term: $\varepsilon_e$ is complex, and carries it.
 
     The formulas are the standard piecewise fits, discontinuous by a fraction of
     a percent at $\sqrt{\varepsilon_r}Z_c = 120$; the branch is selected on the
     real parts.
+
+    **Validity**
+
+    The filling is homogeneous, so $\varepsilon_e = \varepsilon_r$ is exact and
+    there is no fit range on the permittivity and no modal dispersion below the
+    first higher-order mode. The impedance expression is Cohn's zero-thickness
+    result with a fringing correction whose two branches meet at $W/b = 0.35$;
+    the attenuation fit is piecewise in $\sqrt{\varepsilon_r} Z_c$ and is
+    discontinuous there by a fraction of a percent. Finite thickness must
+    satisfy $0 < T < b$, which is enforced, and the attenuation diverges
+    logarithmically as $T \to 0$, so a zero-thickness strip is given no
+    conductor loss rather than an infinite one.
 
     References
     ----------
@@ -682,24 +752,30 @@ class CohnStriplineFormulation(AbstractStriplineFormulation):
     Pozar, D. M. (2011). Microwave Engineering (4th ed.), Section 3.7. Wiley.
     """
 
-    def quasi_static(self, freq: Frequency, *, w, b, t, ep_r, zs) -> QuasiStaticResult:
-        ones = jnp.ones(freq.npoints)
+    def quasi_static(self, *, w, b, t, ep_r) -> PlanarQuasiStaticResult:
+        ones = jnp.ones_like(ep_r)
+        if t is not None:
+            t = eqx.error_if(t, t - b >= 0, "stripline thickness must satisfy 0 < t < b")
         ep_eff = ep_r * ones
 
         u = w / b
         w_e = b * (u - jnp.where(u > 0.35, 0.0, (0.35 - u) ** 2))
         zc = 30 * jnp.pi / jnp.sqrt(ep_eff) * b / (w_e + 0.441 * b)
 
-        w_eff = self._loss_width(w, b, t, ep_eff, zc) * ones
-        return QuasiStaticResult(ep_eff=ep_eff, zc=zc, w_eff=w_eff)
+        conductor_loss_factor = self._conductor_loss_factor(w, b, t, ep_eff, zc) * ones
+        shunt_conductance_factor = jnp.sqrt(ep_eff) / (zc * c * epsilon_0 * ep_eff)
+        return PlanarQuasiStaticResult(
+            ep_eff, zc, w_e * ones, conductor_loss_factor,
+            shunt_conductance_factor,
+        )
 
     @staticmethod
-    def _loss_width(w, b, t, ep_eff, zc):
-        """Return the effective width carrying Cohn's conductor attenuation."""
+    def _conductor_loss_factor(w, b, t, ep_eff, zc):
+        """Return the geometry factor multiplying surface impedance."""
         if t is None:
             # Cohn's attenuation diverges logarithmically as the strip thins:
             # a zero-thickness strip has no finite conductor loss to apply.
-            return jnp.inf
+            return 0.0
 
         ep_r = jnp.real(ep_eff)
         zc_real = jnp.real(zc)
@@ -715,4 +791,17 @@ class CohnStriplineFormulation(AbstractStriplineFormulation):
         alpha_over_rs = jnp.where(
             jnp.sqrt(ep_r) * zc_real < 120, alpha_low, alpha_high
         )
-        return 1 / (alpha_over_rs * zc_real)
+        return 2 * alpha_over_rs * zc_real
+
+
+def _microstrip_conductance_factor(ep_r, ep_eff, zc):
+    """Convert static substrate conductivity through the quasi-static fill."""
+    capacitance = jnp.sqrt(ep_eff) / (zc * c)
+    delta = ep_r - 1
+    safe_delta = jnp.where(jnp.abs(delta) > 1e-14, delta, 1.0)
+    filling = jnp.where(
+        jnp.abs(delta) > 1e-14,
+        (capacitance - 1 / (zc * c * jnp.sqrt(ep_eff))) / safe_delta,
+        0.0,
+    )
+    return jnp.real(filling) / epsilon_0

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -1,10 +1,9 @@
 """
 Physical transmission lines (general, coaxial, microstrip, stripline)
 """
-from typing import Literal
-
 from scipy.constants import c, epsilon_0, mu_0
 import jax.numpy as jnp
+import equinox as eqx
 
 from pmrf.frequency import Frequency
 from pmrf.constraints import Positive, GreaterThan
@@ -13,6 +12,7 @@ from pmrf.materials import (
     AbstractDielectric,
     BulkConductor,
     ConstantDielectric,
+    DielectricProperties,
     Substrate,
     as_conductor,
     as_dielectric,
@@ -25,26 +25,16 @@ from pmrf.models.components.lines.formulations import (
     AbstractCoaxialFormulation,
     AbstractMicrostripDispersion,
     AbstractMicrostripFormulation,
-    ConductorProperties,
-    DielectricProperties,
     AbstractStriplineFormulation,
     CohnStriplineFormulation,
-    KirschningJansen,
+    KirschningJansenMicrostripDispersion,
     TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
 )
 
 
-EpsilonConvention = Literal["complex", "real"]
-
 # `None` disables modal dispersion, so it cannot double as "not given".
 _DEFAULT_DISPERSION = object()
-
-
-def _as_epsilon_convention(value: str) -> EpsilonConvention:
-    if value not in ("complex", "real"):
-        raise ValueError("epsilon_convention must be 'complex' or 'real'")
-    return value
 
 # -----------------------------------------------------------------------------
 # Lines
@@ -269,7 +259,7 @@ class CoaxialLine(AbstractImmittanceLine):
         The dielectric filling, which supplies both its permittivity and its
         permeability. A scalar permittivity or an ``(ep_r, tand)`` tuple is
         coerced into a :class:`~pmrf.materials.ConstantDielectric`; a magnetic
-        filling sets that material's ``mu_rel``.
+        filling sets that material's ``mu_r``.
     conductor : AbstractConductor, default=BulkConductor()
         The conductor material of both conductors. A scalar resistivity in
         ohm-meters is coerced into a :class:`~pmrf.materials.BulkConductor`.
@@ -300,14 +290,8 @@ class CoaxialLine(AbstractImmittanceLine):
             freq,
             d_in=self.d_in,
             d_out=self.d_out,
-            dielectric=DielectricProperties(
-                self.dielectric.epsilon_r(freq), self.dielectric.mu_r(freq)
-            ),
-            conductor=ConductorProperties(
-                self.conductor.surface_impedance(freq),
-                self.conductor.sigma(freq),
-                self.conductor.mu_r(freq),
-            ),
+            dielectric=self.dielectric.properties(freq),
+            conductor=self.conductor.properties(freq),
         )
     
     
@@ -317,21 +301,27 @@ class MicrostripLine(AbstractImmittanceLine):
     
     Uses :class:`WheelerMicrostripFormulation` for the default mathematical formulation.
 
-    The quasi-static formulation returns a :class:`QuasiStaticResult`. With
-    modal dispersion disabled, :meth:`QuasiStaticResult.to_immittance` converts
+    The quasi-static formulation returns a :class:`PlanarQuasiStaticResult`. With
+    modal dispersion disabled, :meth:`PlanarQuasiStaticResult.to_immittance` converts
     it directly; otherwise the dispersed modal quantities are inverted exactly.
 
     **Mathematical Formulation**
 
     The line evaluates material permittivity, a quasi-static formulation, and
-    then the optional modal-dispersion formulation. Under the complex
-    convention the material loss is carried directly by effective permittivity:
+    then the optional modal-dispersion formulation. ParamRF carries permittivity
+    complex throughout, following the ADS/AWR convention, so the dielectric loss
+    is carried directly by the effective permittivity and needs no separate
+    attenuation term:
     $$\gamma_m=\frac{j\omega}{c}\sqrt{\varepsilon_e(f)}.$$
-    Under the real convention, QUCS-like dielectric attenuation is added to a
-    real phase constant:
-    $$\alpha_d=\frac{\pi f}{c}\frac{\varepsilon_r}{\varepsilon_r-1}
-    \frac{\varepsilon_e(0)-1}{\sqrt{\varepsilon_e(0)}}\tan\delta,
-    \qquad \beta=\frac{\omega}{c}\sqrt{\varepsilon_e(f)}.$$
+
+    Static bulk conductivity is not folded into that permittivity, which would
+    make it singular at DC. It is applied separately as a shunt conductance
+    $G = \sigma K_g$, where $K_g$ is the geometric
+    ``shunt_conductance_factor`` of the quasi-static result, so the line keeps a
+    finite, nonzero conductance down to DC.
+
+    The substrate must be nonmagnetic. No cited microstrip formulation covers
+    magnetic media, so $\mu_r \neq 1$ is rejected rather than silently ignored.
 
     For a finite-thickness conductor, Wheeler's incremental-inductance
     correction adds
@@ -386,13 +376,9 @@ class MicrostripLine(AbstractImmittanceLine):
         formulations such as Hammerstad--Jensen use a positive value.
     formulation : AbstractMicrostripFormulation, default=WheelerMicrostripFormulation()
         The closed-form physics used to compute the quasi-static solution.
-    dispersion : AbstractMicrostripDispersion | None, default=KirschningJansen()
+    dispersion : AbstractMicrostripDispersion | None, default=KirschningJansenMicrostripDispersion()
         The modal-dispersion correction. ``None`` disables modal dispersion and
         preserves the quasi-static immittance path.
-    epsilon_convention : {'complex', 'real'}, default='complex'
-        Whether the quasi-static and modal formulas consume the full complex
-        material permittivity or only its real part. The real convention adds
-        dielectric attenuation separately.
 
     References
     ----------
@@ -417,11 +403,8 @@ class MicrostripLine(AbstractImmittanceLine):
     formulation: AbstractMicrostripFormulation = field(default_factory=WheelerMicrostripFormulation)
 
     #: The modal-dispersion formulation, or None to disable it
-    dispersion: AbstractMicrostripDispersion | None = field(default_factory=KirschningJansen)
-
-    #: Permittivity convention used by the empirical formulas
-    epsilon_convention: EpsilonConvention = field(
-        default="complex", static=True, converter=_as_epsilon_convention
+    dispersion: AbstractMicrostripDispersion | None = field(
+        default_factory=KirschningJansenMicrostripDispersion
     )
 
     def __init__(
@@ -436,7 +419,6 @@ class MicrostripLine(AbstractImmittanceLine):
         t: Param | None = None,
         formulation: AbstractMicrostripFormulation | None = None,
         dispersion: AbstractMicrostripDispersion | None = _DEFAULT_DISPERSION,
-        epsilon_convention: EpsilonConvention = "complex",
         name: str | None = None,
         metadata=None,
     ):
@@ -454,91 +436,59 @@ class MicrostripLine(AbstractImmittanceLine):
             WheelerMicrostripFormulation() if formulation is None else formulation
         )
         self.dispersion = (
-            KirschningJansen() if dispersion is _DEFAULT_DISPERSION else dispersion
+            KirschningJansenMicrostripDispersion()
+            if dispersion is _DEFAULT_DISPERSION else dispersion
         )
-        self.epsilon_convention = epsilon_convention
         self.length = length
         self.name = name
         self.metadata = metadata
 
     def immittance(self, freq: Frequency) -> ImmittanceResult:
         substrate = self.substrate
-        zs = substrate.conductor.surface_impedance(freq)
-        material_ep_r = substrate.dielectric.epsilon_r(freq)
-        formula_ep_r = (
-            material_ep_r if self.epsilon_convention == "complex" else jnp.real(material_ep_r)
+        conductor = substrate.conductor.properties(freq)
+        dielectric = substrate.dielectric.properties(freq)
+        ep_r = eqx.error_if(
+            dielectric.ep_r,
+            jnp.any(jnp.abs(dielectric.mu_r - 1) > 1e-12),
+            "microstrip formulations require a nonmagnetic substrate (mu_r = 1)",
         )
 
         quasi_static = self.formulation.quasi_static(
-            freq,
             w=self.w,
             h=substrate.h,
             t=substrate.t,
-            ep_r=formula_ep_r,
-            zs=zs,
+            ep_r=ep_r,
         )
 
-        if self.dispersion is None and self.epsilon_convention == "complex":
-            return quasi_static.to_immittance(freq, zs)
-
         if self.dispersion is None:
-            ep_eff, zc = quasi_static.ep_eff, quasi_static.zc
+            return quasi_static.to_immittance(freq, dielectric, conductor)
         else:
             ep_eff, zc = self.dispersion.disperse(
                 freq,
                 ep_eff_0=quasi_static.ep_eff,
                 zc_0=quasi_static.zc,
-                ep_r=formula_ep_r,
-                w=self.w,
+                ep_r=ep_r,
                 w_eff=quasi_static.w_eff,
                 h=substrate.h,
-                t=substrate.t,
             )
 
-        if self.epsilon_convention == "complex":
-            gamma = 1j * freq.w * jnp.sqrt(ep_eff) / c
-        else:
-            gamma = self._real_convention_gamma(
-                freq, material_ep_r, ep_eff, quasi_static.ep_eff
-            )
+        gamma = 1j * freq.w * jnp.sqrt(ep_eff) / c
 
         # Wheeler's incremental-inductance rule. With no finite conductor
         # thickness scikit-rf defines this empirical correction as zero.
         if substrate.t is not None:
             z0 = jnp.sqrt(mu_0 / epsilon_0)
-            loss_zc = zc if self.epsilon_convention == "complex" else quasi_static.zc
-            current_distribution = jnp.exp(-1.2 * (jnp.real(loss_zc) / z0) ** 0.7)
+            current_distribution = jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
             gamma = gamma + (
-                jnp.real(zs) / (jnp.real(loss_zc) * self.w) * current_distribution
+                jnp.real(conductor.zs) / (jnp.real(zc) * self.w) * current_distribution
             )
 
-        return ImmittanceResult.from_zc_gamma(zc, gamma, freq.w)
-
-    @staticmethod
-    def _real_convention_gamma(freq, material_ep_r, ep_eff, loss_ep_eff):
-        ep_r_real = jnp.real(material_ep_r)
-        ep_eff_real = jnp.real(ep_eff)
-        loss_ep_eff_real = jnp.real(loss_ep_eff)
-        tan_delta = -jnp.imag(material_ep_r) / ep_r_real
-
-        delta_ep_r = ep_r_real - 1
-        safe_delta = jnp.where(jnp.abs(delta_ep_r) > 1e-14, delta_ep_r, 1.0)
-        filling = jnp.where(
-            jnp.abs(delta_ep_r) > 1e-14,
-            (loss_ep_eff_real - 1) / safe_delta,
-            0.0,
+        result = ImmittanceResult.from_zc_gamma(zc, gamma, freq.w)
+        return ImmittanceResult(
+            Z=result.Z,
+            Y=result.Y + dielectric.sigma * quasi_static.shunt_conductance_factor,
+            w=freq.w,
         )
-        alpha_dielectric = (
-            jnp.pi
-            * ep_r_real
-            * filling
-            / jnp.sqrt(loss_ep_eff_real)
-            * tan_delta
-            * freq.f
-            / c
-        )
-        beta = freq.w * jnp.sqrt(ep_eff_real) / c
-        return alpha_dielectric + 1j * beta
 
 
 class StriplineLine(AbstractImmittanceLine):
@@ -557,7 +507,7 @@ class StriplineLine(AbstractImmittanceLine):
     **Mathematical Formulation**
 
     The quasi-static formulation returns $(\varepsilon_e, Z_c, W_{eff})$, and
-    :meth:`QuasiStaticResult.to_immittance` converts them directly:
+    :meth:`PlanarQuasiStaticResult.to_immittance` converts them directly:
     $$Z = \frac{j\omega Z_c\sqrt{\varepsilon_e}}{c} + \frac{2Z_s}{W_{eff}}
     \qquad
     Y = \frac{j\omega\sqrt{\varepsilon_e}}{Z_c c}.$$
@@ -637,13 +587,12 @@ class StriplineLine(AbstractImmittanceLine):
     )
 
     def immittance(self, freq: Frequency) -> ImmittanceResult:
-        zs = self.conductor.surface_impedance(freq)
+        dielectric = self.dielectric.properties(freq)
+        conductor = self.conductor.properties(freq)
         quasi_static = self.formulation.quasi_static(
-            freq,
             w=self.w,
             b=self.b,
             t=self.t,
-            ep_r=self.dielectric.epsilon_r(freq),
-            zs=zs,
+            ep_r=dielectric.ep_r,
         )
-        return quasi_static.to_immittance(freq, zs)
+        return quasi_static.to_immittance(freq, dielectric, conductor)

--- a/tests/test_dc_limits.py
+++ b/tests/test_dc_limits.py
@@ -19,7 +19,7 @@ from pmrf.materials import (
     ColeCole,
     ConstantDielectric,
     DjordjevicSarkar,
-    Hammerstad,
+    HammerstadRoughness,
     MultipoleDebye,
     BulkConductor,
     DebyePole,
@@ -41,7 +41,7 @@ from pmrf.models import (
 )
 from pmrf.models.components.lines.formulations import (
     HammerstadJensenMicrostripFormulation,
-    KirschningJansen,
+    KirschningJansenMicrostripDispersion,
     WheelerMicrostripFormulation,
 )
 
@@ -77,14 +77,9 @@ LINES = {
     "MicrostripLine (no dispersion)": MicrostripLine(
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.02), dispersion=None, length=0.1
     ),
-    "MicrostripLine (real convention)": MicrostripLine(
-        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
-        epsilon_convention="real",
-        length=0.1,
-    ),
-    "MicrostripLine (explicit KirschningJansen)": MicrostripLine(
+    "MicrostripLine (explicit KirschningJansenMicrostripDispersion)": MicrostripLine(
         formulation=WheelerMicrostripFormulation(),
-        dispersion=KirschningJansen(),
+        dispersion=KirschningJansenMicrostripDispersion(),
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
         length=0.1,
     ),
@@ -121,7 +116,7 @@ MATERIALS = {
         sigma=1e-3,
     ),
     "BulkConductor": BulkConductor(rho=1.72e-8),
-    "RoughConductor": RoughConductor(rho=1.72e-8, roughness=Hammerstad(1e-6)),
+    "RoughConductor": RoughConductor(rho=1.72e-8, roughness=HammerstadRoughness(1e-6)),
 }
 
 
@@ -158,23 +153,11 @@ def test_line_is_finite_at_dc(line, dc_freq):
 
 @pytest.mark.parametrize("material", MATERIALS.values(), ids=MATERIALS.keys())
 def test_material_is_finite_at_dc(material, dc_freq):
-    if hasattr(material, "epsilon_r"):
-        _assert_finite_value_and_grad(material, lambda m: m.epsilon_r(dc_freq))
+    if isinstance(material, AbstractDielectric):
+        _assert_finite_value_and_grad(material, lambda m: m.properties(dc_freq).ep_r)
     else:
-        _assert_finite_value_and_grad(material, lambda m: m.surface_impedance(dc_freq))
-        _assert_finite_value_and_grad(material, lambda m: m.sigma(dc_freq))
-
-
-def test_skin_depth_is_infinite_at_dc(dc_freq):
-    """The existing guard: the DC value is infinite, but the gradient is not."""
-    conductor = BulkConductor(rho=1.72e-8)
-    depth = conductor.skin_depth(dc_freq)
-    assert jnp.isinf(depth[0])
-    assert jnp.all(jnp.isfinite(depth[1:]))
-
-    grads = eqx.filter_grad(lambda m: jnp.sum(m.skin_depth(dc_freq)[1:]))(conductor)
-    for leaf in jax.tree.leaves(eqx.filter(grads, eqx.is_inexact_array)):
-        assert jnp.all(jnp.isfinite(leaf))
+        _assert_finite_value_and_grad(material, lambda m: m.properties(dc_freq).zs)
+        _assert_finite_value_and_grad(material, lambda m: m.properties(dc_freq).sigma)
 
 
 def test_immittance_l_and_c_carry_the_lowest_frequency(dc_freq):
@@ -197,7 +180,11 @@ def _concrete_subclasses(base):
     while pending:
         cls = pending.pop()
         pending.extend(cls.__subclasses__())
-        if cls is not base and not getattr(cls, "__abstractmethods__", None):
+        if (
+            cls is not base
+            and cls.__module__.startswith("pmrf.")
+            and not getattr(cls, "__abstractmethods__", None)
+        ):
             found.add(cls)
     return found
 

--- a/tests/test_materials/test_conductor.py
+++ b/tests/test_materials/test_conductor.py
@@ -5,7 +5,25 @@ from scipy.constants import mu_0
 
 import pmrf as prf
 from pmrf.frequency import Frequency
-from pmrf.materials import BulkConductor, Hammerstad, RoughConductor, as_conductor
+from pmrf.materials import (
+    BulkConductor,
+    ConductorProperties,
+    HammerstadRoughness,
+    RoughConductor,
+    as_conductor,
+)
+
+
+def test_conductor_exposes_one_property_record(freq):
+    conductor = BulkConductor(rho=1.68e-8, mu_r=2.0)
+
+    properties = conductor.properties(freq)
+
+    assert isinstance(properties, ConductorProperties)
+    assert jnp.allclose(properties.sigma, 1 / 1.68e-8)
+    assert jnp.allclose(properties.mu_r, 2.0)
+    assert not hasattr(conductor, "surface_impedance")
+    assert not hasattr(conductor, "skin_depth")
 
 
 @pytest.fixture
@@ -15,7 +33,7 @@ def freq():
 
 def test_bulk_surface_impedance(freq):
     rho = 1.68e-8
-    zs = BulkConductor(rho).surface_impedance(freq)
+    zs = BulkConductor(rho).properties(freq).zs
 
     expected = jnp.sqrt(1j * freq.w * mu_0 / (1 / rho))
     assert zs.shape == (freq.npoints,)
@@ -24,17 +42,14 @@ def test_bulk_surface_impedance(freq):
     assert jnp.allclose(jnp.real(zs), jnp.imag(zs))
 
 
-def test_bulk_sigma_and_skin_depth(freq):
+def test_bulk_sigma(freq):
     rho = 1.68e-8
     conductor = BulkConductor(rho)
-    assert jnp.allclose(conductor.sigma(freq), 1 / rho)
-    assert jnp.allclose(
-        conductor.skin_depth(freq), jnp.sqrt(2 * rho / (freq.w * mu_0))
-    )
+    assert jnp.allclose(conductor.properties(freq).sigma, 1 / rho)
 
 
 def test_bulk_permeability(freq):
-    assert jnp.allclose(BulkConductor(1.68e-8, mu_rel=4.0).mu_r(freq), 4.0)
+    assert jnp.allclose(BulkConductor(1.68e-8, mu_r=4.0).properties(freq).mu_r, 4.0)
 
 
 def test_bulk_from_sigma(freq):
@@ -46,7 +61,7 @@ def test_bulk_reproduces_tesche_skin_terms(freq):
     rho, a = 1.68e-8, 0.56e-3
     sigma = 1 / rho
 
-    zs = BulkConductor(rho).surface_impedance(freq)
+    zs = BulkConductor(rho).properties(freq).zs
     R_skin = (1 / (2 * jnp.pi * a)) * jnp.sqrt(freq.w * mu_0 / (2 * sigma))
     L_skin = (1 / (2 * jnp.pi * a)) * jnp.sqrt(mu_0 / (2 * freq.w * sigma))
 
@@ -57,34 +72,35 @@ def test_bulk_reproduces_tesche_skin_terms(freq):
 def test_bulk_reproduces_wheeler_resistance(freq):
     """Wheeler's R = (1/W)*sqrt(2*mu_0*rho*w) is two squares of Re(Zs)."""
     rho, W = 1.68e-8, 3e-3
-    zs = BulkConductor(rho).surface_impedance(freq)
+    zs = BulkConductor(rho).properties(freq).zs
     R_wheeler = (1 / W) * jnp.sqrt(2 * mu_0 * rho * freq.w)
     assert jnp.allclose(2 * jnp.real(zs) / W, R_wheeler)
 
 
 def test_bulk_permeability_scaling(freq):
-    plain = BulkConductor(1.68e-8).surface_impedance(freq)
-    magnetic = BulkConductor(1.68e-8, mu_rel=4.0).surface_impedance(freq)
+    plain = BulkConductor(1.68e-8).properties(freq).zs
+    magnetic = BulkConductor(1.68e-8, mu_r=4.0).properties(freq).zs
     assert jnp.allclose(magnetic, 2.0 * plain)
 
 
 def test_smooth_rough_conductor_is_bulk(freq):
     rough = RoughConductor(1.68e-8, roughness=0.0)
     assert jnp.allclose(
-        rough.surface_impedance(freq), BulkConductor(1.68e-8).surface_impedance(freq)
+        rough.properties(freq).zs, BulkConductor(1.68e-8).properties(freq).zs
     )
 
 
 def test_roughness_increases_loss_and_saturates(freq):
     rho = 1.68e-8
     rough = RoughConductor(rho, roughness=1e-6)
-    factor = rough.roughness.factor(rough.skin_depth(freq))
+    properties = rough.properties(freq)
+    factor = rough.roughness.factor(freq, properties.sigma, properties.mu_r)
 
     assert jnp.all(factor > 1.0)
     assert jnp.all(factor < 2.0)
     # Rougher surfaces lose more, and the factor grows with frequency.
     assert jnp.all(jnp.diff(factor) > 0)
-    assert jnp.allclose(rough.surface_impedance(freq), factor * BulkConductor(rho).surface_impedance(freq))
+    assert jnp.allclose(rough.properties(freq).zs, factor * BulkConductor(rho).properties(freq).zs)
 
 
 def test_conductor_gradients_are_finite(freq):
@@ -93,7 +109,7 @@ def test_conductor_gradients_are_finite(freq):
     for material in (BulkConductor(1.68e-8), RoughConductor(1.68e-8, roughness=1e-6)):
         for axis in (freq, dc):
             grads = jax.grad(
-                lambda m: jnp.sum(jnp.abs(m.surface_impedance(axis)))
+                lambda m: jnp.sum(jnp.abs(m.properties(axis).zs))
             )(material)
             leaves = jax.tree_util.tree_leaves(prf.unwrap(grads))
             assert all(jnp.all(jnp.isfinite(leaf)) for leaf in leaves)
@@ -105,7 +121,7 @@ def test_unconstrained_gradients_are_finite_at_dc():
 
     def loss(rho):
         conductor = BulkConductor(rho=prf.Unconstrained(rho))
-        return jnp.sum(jnp.real(conductor.surface_impedance(dc)))
+        return jnp.sum(jnp.real(conductor.properties(dc).zs))
 
     assert jnp.isfinite(jax.grad(loss)(1.68e-8))
 
@@ -117,8 +133,8 @@ def test_abstract_conductor_is_an_abc():
 
 
 def test_roughness_formulation_is_swappable():
-    conductor = RoughConductor(1.68e-8, roughness=Hammerstad(2e-6))
-    assert isinstance(conductor.roughness, Hammerstad)
+    conductor = RoughConductor(1.68e-8, roughness=HammerstadRoughness(2e-6))
+    assert isinstance(conductor.roughness, HammerstadRoughness)
     assert jnp.allclose(conductor.roughness.roughness, 2e-6)
 
 

--- a/tests/test_materials/test_dielectric.py
+++ b/tests/test_materials/test_dielectric.py
@@ -7,6 +7,7 @@ from scipy.constants import epsilon_0
 import pmrf as prf
 from pmrf.frequency import Frequency
 from pmrf.materials import (
+    DielectricProperties,
     ColeCole,
     ConstantDielectric,
     DebyePole,
@@ -15,6 +16,18 @@ from pmrf.materials import (
     TabulatedDielectric,
     as_dielectric,
 )
+
+
+def test_dielectric_properties_separate_static_conductivity(freq):
+    material = ConstantDielectric(ep_r=4.3, tand=0.02, sigma=0.01, mu_r=2.0)
+
+    properties = material.properties(freq)
+
+    assert isinstance(properties, DielectricProperties)
+    assert jnp.allclose(properties.ep_r, 4.3 * (1 - 0.02j))
+    assert jnp.allclose(properties.mu_r, 2.0)
+    assert jnp.allclose(properties.sigma, 0.01)
+    assert not hasattr(material, "epsilon_r")
 
 
 @pytest.fixture
@@ -28,38 +41,38 @@ def wideband_freq():
 
 
 def test_constant_dielectric(freq):
-    eps = ConstantDielectric(4.3, 0.02).epsilon_r(freq)
+    eps = ConstantDielectric(4.3, 0.02).properties(freq).ep_r
     assert eps.shape == (freq.npoints,)
     assert jnp.allclose(eps, 4.3 * (1 - 0.02j))
 
 
 def test_constant_dielectric_loss_tangent(freq):
-    eps = ConstantDielectric(4.3, 0.02).epsilon_r(freq)
+    eps = ConstantDielectric(4.3, 0.02).properties(freq).ep_r
     assert jnp.allclose(-jnp.imag(eps) / jnp.real(eps), 0.02)
 
 
 def test_conductivity_gives_frequency_independent_conductance(freq):
-    """A sigma-only dielectric gives w*eps'' constant, hence a constant G."""
+    """Static conductivity is retained separately from permittivity."""
     sigma = 0.01
-    eps = ConstantDielectric(4.3, sigma=sigma).epsilon_r(freq)
-    G_like = freq.w * -jnp.imag(eps) * epsilon_0
-    assert jnp.allclose(G_like, sigma)
+    properties = ConstantDielectric(4.3, sigma=sigma).properties(freq)
+    assert jnp.allclose(jnp.imag(properties.ep_r), 0.0)
+    assert jnp.allclose(properties.sigma, sigma)
 
 
 def test_loss_terms_are_additive(freq):
-    both = ConstantDielectric(4.3, 0.02, 0.01).epsilon_r(freq)
-    tand_only = ConstantDielectric(4.3, 0.02).epsilon_r(freq)
-    sigma_only = ConstantDielectric(4.3, sigma=0.01).epsilon_r(freq)
+    both = ConstantDielectric(4.3, 0.02, 0.01).properties(freq).ep_r
+    tand_only = ConstantDielectric(4.3, 0.02).properties(freq).ep_r
+    sigma_only = ConstantDielectric(4.3, sigma=0.01).properties(freq).ep_r
     assert jnp.allclose(both, tand_only + sigma_only - 4.3)
 
 
 def test_conductivity_guarded_at_dc():
     dc = Frequency.from_f(jnp.array([0.0, 1e9]))
-    eps = ConstantDielectric(4.3, sigma=0.01).epsilon_r(dc)
+    eps = ConstantDielectric(4.3, sigma=0.01).properties(dc).ep_r
     assert jnp.all(jnp.isfinite(eps))
 
     grad = jax.grad(
-        lambda s: jnp.sum(jnp.imag(ConstantDielectric(4.3, sigma=s).epsilon_r(dc)))
+        lambda s: jnp.sum(jnp.imag(ConstantDielectric(4.3, sigma=s).properties(dc).ep_r))
     )(0.01)
     assert jnp.isfinite(grad)
 
@@ -76,20 +89,20 @@ def test_djordjevic_sarkar_matches_skrf(wideband_freq):
         None, ep_r=ep_r, tand=tand, f_low=f_low, f_high=f_high,
         f_epr_tand=f_ref, f=f, diel='djordjevicsvensson',
     )
-    got = DjordjevicSarkar(ep_r, tand, f_low, f_high, f_ref).epsilon_r(wideband_freq)
+    got = DjordjevicSarkar(ep_r, tand, f_low, f_high, f_ref).properties(wideband_freq).ep_r
 
     assert jnp.allclose(got, jnp.asarray(expected), rtol=1e-10, atol=0.0)
 
 
 def test_djordjevic_sarkar_matches_target_at_reference():
     freq = Frequency.from_f(jnp.array([1e9]))
-    eps = DjordjevicSarkar(4.3, 0.02, f_ref=1e9).epsilon_r(freq)
+    eps = DjordjevicSarkar(4.3, 0.02, f_ref=1e9).properties(freq).ep_r
     assert jnp.allclose(jnp.real(eps), 4.3, rtol=1e-6)
     assert jnp.allclose(-jnp.imag(eps) / jnp.real(eps), 0.02, rtol=1e-6)
 
 
 def test_djordjevic_sarkar_is_dispersive(wideband_freq):
-    eps = DjordjevicSarkar(4.3, 0.02).epsilon_r(wideband_freq)
+    eps = DjordjevicSarkar(4.3, 0.02).properties(wideband_freq).ep_r
     # Permittivity falls monotonically with frequency inside the relaxation band.
     assert jnp.all(jnp.diff(jnp.real(eps)) < 0)
 
@@ -99,8 +112,8 @@ def test_multipole_debye_limits():
     hi = Frequency.from_f(jnp.array([1e15]))
     material = MultipoleDebye(ep_inf=2.0, poles=[(1.0, 1e9), (0.5, 1e10)])
 
-    assert jnp.allclose(jnp.real(material.epsilon_r(lo)), 3.5, rtol=1e-5)
-    assert jnp.allclose(jnp.real(material.epsilon_r(hi)), 2.0, rtol=1e-5)
+    assert jnp.allclose(jnp.real(material.properties(lo).ep_r), 3.5, rtol=1e-5)
+    assert jnp.allclose(jnp.real(material.properties(hi).ep_r), 2.0, rtol=1e-5)
 
 
 def test_multipole_debye_coerces_pairs():
@@ -112,12 +125,12 @@ def test_multipole_debye_coerces_pairs():
 def test_cole_cole_reduces_to_debye(freq):
     cole = ColeCole(ep_inf=2.0, dep_r=1.0, f_relax=1e9, alpha=0.0)
     debye = MultipoleDebye(ep_inf=2.0, poles=[(1.0, 1e9)])
-    assert jnp.allclose(cole.epsilon_r(freq), debye.epsilon_r(freq))
+    assert jnp.allclose(cole.properties(freq).ep_r, debye.properties(freq).ep_r)
 
 
 def test_cole_cole_finite_at_dc():
     dc = Frequency.from_f(jnp.array([0.0, 1e9]))
-    eps = ColeCole(2.0, 1.0, 1e9, 0.3).epsilon_r(dc)
+    eps = ColeCole(2.0, 1.0, 1e9, 0.3).properties(dc).ep_r
     assert jnp.all(jnp.isfinite(eps))
     assert jnp.allclose(eps[0], 3.0)
 
@@ -128,8 +141,23 @@ def test_tabulated_dielectric_interpolates():
         ep_r=jnp.array([4.0 - 0.1j, 3.8 - 0.2j, 3.6 - 0.3j]),
     )
     freq = Frequency.from_f(jnp.array([1e9, 1.5e9, 3e9]))
-    eps = material.epsilon_r(freq)
+    eps = material.properties(freq).ep_r
     assert jnp.allclose(eps, jnp.array([4.0 - 0.1j, 3.9 - 0.15j, 3.6 - 0.3j]))
+
+
+@pytest.mark.parametrize(
+    ("f", "ep_r", "message"),
+    [
+        ([], [], "nonempty"),
+        ([[1e9, 2e9]], [[4.0, 3.9]], "one-dimensional"),
+        ([1e9, 1e9], [4.0, 3.9], "strictly increasing"),
+        ([2e9, 1e9], [4.0, 3.9], "strictly increasing"),
+        ([1e9], [4.0, 3.9], "same shape"),
+    ],
+)
+def test_tabulated_dielectric_rejects_invalid_tables(f, ep_r, message):
+    with pytest.raises(ValueError, match=message):
+        TabulatedDielectric(f=f, ep_r=ep_r)
 
 
 def test_tabulated_dielectric_validates_shapes():
@@ -159,7 +187,7 @@ def test_as_dielectric_converters():
 ])
 def test_gradients_are_finite(material, wideband_freq):
     def loss(m):
-        return jnp.sum(jnp.abs(m.epsilon_r(wideband_freq)))
+        return jnp.sum(jnp.abs(m.properties(wideband_freq).ep_r))
 
     grads = jax.grad(loss)(material)
     leaves = jax.tree_util.tree_leaves(prf.unwrap(grads))
@@ -174,10 +202,10 @@ def test_dielectrics_are_non_magnetic_by_default(freq):
         MultipoleDebye(ep_inf=2.0, poles=[(1.0, 1e9)]),
         ColeCole(2.0, 1.0, 1e9, 0.3),
     ):
-        mu_r = material.mu_r(freq)
+        mu_r = material.properties(freq).mu_r
         assert mu_r.shape == (freq.npoints,)
         assert jnp.allclose(mu_r, 1.0)
 
 
 def test_constant_dielectric_carries_permeability(freq):
-    assert jnp.allclose(ConstantDielectric(4.3, mu_rel=4.0).mu_r(freq), 4.0)
+    assert jnp.allclose(ConstantDielectric(4.3, mu_r=4.0).properties(freq).mu_r, 4.0)

--- a/tests/test_materials/test_serialization.py
+++ b/tests/test_materials/test_serialization.py
@@ -34,7 +34,10 @@ def test_material_round_trips(material, tmp_path):
     assert type(loaded) is type(material)
 
     freq = Frequency(start=1.0, stop=10.0, npoints=11, unit='GHz')
-    if hasattr(material, "epsilon_r"):
-        assert jnp.allclose(loaded.epsilon_r(freq), material.epsilon_r(freq))
+    if isinstance(
+        material,
+        (ConstantDielectric, DjordjevicSarkar, MultipoleDebye, ColeCole, TabulatedDielectric),
+    ):
+        assert jnp.allclose(loaded.properties(freq).ep_r, material.properties(freq).ep_r)
     else:
-        assert jnp.allclose(loaded.surface_impedance(freq), material.surface_impedance(freq))
+        assert jnp.allclose(loaded.properties(freq).zs, material.properties(freq).zs)

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -14,12 +14,18 @@ from pmrf.models import (
     DatasheetLine, 
     CoaxialLine, 
     MicrostripLine, 
+    StriplineLine,
     FloatingLine
 )
-from pmrf.materials import BulkConductor, ConstantDielectric, DjordjevicSarkar, RoughConductor
-from pmrf.models.components.lines.formulations import (
+from pmrf.materials import (
+    BulkConductor,
     ConductorProperties,
+    ConstantDielectric,
     DielectricProperties,
+    DjordjevicSarkar,
+    RoughConductor,
+)
+from pmrf.models.components.lines.formulations import (
     TescheCoaxialFormulation,
     tube_internal_impedance,
 )
@@ -134,6 +140,28 @@ def test_coaxial_line_impedance(basic_freq):
     # Real part of Zc should match the theoretical lossless impedance
     assert jnp.allclose(jnp.real(zc), expected_zc, rtol=1e-3)
 
+
+def test_coaxial_static_conductivity_has_analytic_dc_conductance():
+    freq = Frequency.from_f(jnp.array([0.0, 1.0, 1e3]))
+    sigma = 0.01
+    d_in, d_out = 0.9e-3, 2.95e-3
+    line = CoaxialLine(
+        d_in=d_in,
+        d_out=d_out,
+        dielectric=ConstantDielectric(ep_r=2.25, sigma=sigma),
+        conductor=BulkConductor(rho=0.0),
+        length=1.0,
+    )
+
+    expected = 2 * jnp.pi * sigma / jnp.log(d_out / d_in)
+    assert jnp.allclose(line.immittance(freq).G, expected)
+
+
+def test_coaxial_rejects_reversed_diameters():
+    line = CoaxialLine(d_in=2e-3, d_out=1e-3, length=0.1)
+    with pytest.raises(Exception, match="d_out must exceed d_in"):
+        line.immittance(Frequency.from_f(jnp.array([1e9])))
+
 def test_coaxial_permeability_comes_from_the_dielectric(basic_freq):
     """A magnetic filling is a property of the material, not of the geometry.
 
@@ -149,7 +177,7 @@ def test_coaxial_permeability_comes_from_the_dielectric(basic_freq):
         )
 
     plain = coax(ConstantDielectric(ep_r=2.25, tand=0.0))
-    magnetic = coax(ConstantDielectric(ep_r=2.25, tand=0.0, mu_rel=4.0))
+    magnetic = coax(ConstantDielectric(ep_r=2.25, tand=0.0, mu_r=4.0))
 
     zc_plain, _ = plain.zc_and_gammaL(basic_freq)
     zc_magnetic, _ = magnetic.zc_and_gammaL(basic_freq)
@@ -164,8 +192,11 @@ def test_coaxial_magnetic_loss_enters_the_series_resistance(basic_freq):
     channel is magnetic: Im(mu_r) < 0 adds w*mu''*ln(b/a)/2pi to Re(Z).
     """
     class LossyMagnetic(ConstantDielectric):
-        def mu_r(self, freq):
-            return (4.0 - 0.5j) * jnp.ones(freq.npoints, dtype=complex)
+        def properties(self, freq):
+            properties = super().properties(freq)
+            return properties._replace(
+                mu_r=(4.0 - 0.5j) * jnp.ones(freq.npoints, dtype=complex)
+            )
 
     line = CoaxialLine(
         d_in=0.9e-3,
@@ -219,7 +250,9 @@ def test_coaxial_formulation_takes_plain_arrays(basic_freq):
         basic_freq,
         d_in=0.9e-3,
         d_out=2.95e-3,
-        dielectric=DielectricProperties(np.full(npoints, 2.25 - 0.00225j), np.ones(npoints)),
+        dielectric=DielectricProperties(
+            np.full(npoints, 2.25 - 0.00225j), np.ones(npoints), np.zeros(npoints)
+        ),
         conductor=ConductorProperties(
             np.full(npoints, 0.01 + 0.01j),
             np.full(npoints, 1 / 1.72e-8),
@@ -312,7 +345,7 @@ def test_microstrip_line_matches_skrf(basic_freq):
     zc, gammaL = line.zc_and_gammaL(basic_freq)
 
     # scikit-rf implements Wheeler's own closed form, where ParamRF uses the
-    # Hammerstad simplification of it. The two agree on the impedance to half a
+    # HammerstadRoughness simplification of it. The two agree on the impedance to half a
     # percent and on the effective permittivity, hence the phase constant, to
     # under two percent.
     assert jnp.allclose(zc, media.z0_characteristic, rtol=1e-2)
@@ -384,7 +417,7 @@ def test_microstrip_formulation_takes_plain_arrays(basic_freq):
     zs = np.full(npoints, 0.01 + 0.01j)
 
     result = WheelerMicrostripFormulation().quasi_static(
-        basic_freq, w=3.0e-3, h=1.6e-3, t=None, ep_r=ep_r, zs=zs
+        w=3.0e-3, h=1.6e-3, t=None, ep_r=ep_r
     )
 
     assert result.ep_eff.shape == (npoints,)
@@ -394,11 +427,11 @@ def test_microstrip_formulation_takes_plain_arrays(basic_freq):
 
 def test_lossy_microstrip_preserves_dispersed_zc_and_phase():
     """The dispersed modal solution survives exact immittance inversion."""
-    from pmrf.models import HammerstadJensenMicrostripFormulation, KirschningJansen
+    from pmrf.models import HammerstadJensenMicrostripFormulation, KirschningJansenMicrostripDispersion
 
     freq = Frequency(start=1.0, stop=50.0, npoints=51, unit="GHz")
     formulation = HammerstadJensenMicrostripFormulation()
-    dispersion = KirschningJansen()
+    dispersion = KirschningJansenMicrostripDispersion()
     line = MicrostripLine(
         w=0.2e-3,
         h=0.5e-3,
@@ -410,20 +443,18 @@ def test_lossy_microstrip_preserves_dispersed_zc_and_phase():
         length=0.1,
     )
 
-    ep_r = line.substrate.dielectric.epsilon_r(freq)
-    zs = line.substrate.conductor.surface_impedance(freq)
+    ep_r = line.substrate.dielectric.properties(freq).ep_r
+    zs = line.substrate.conductor.properties(freq).zs
     quasi_static = formulation.quasi_static(
-        freq, w=line.w, h=line.substrate.h, t=line.substrate.t, ep_r=ep_r, zs=zs
+        w=line.w, h=line.substrate.h, t=line.substrate.t, ep_r=ep_r
     )
     ep_eff, expected_zc = dispersion.disperse(
         freq,
         ep_eff_0=quasi_static.ep_eff,
         zc_0=quasi_static.zc,
         ep_r=ep_r,
-        w=line.w,
         w_eff=quasi_static.w_eff,
         h=line.substrate.h,
-        t=line.substrate.t,
     )
 
     zc, gamma_length = line.zc_and_gammaL(freq)
@@ -446,23 +477,27 @@ def test_microstrip_without_dispersion_preserves_quasi_static_immittance():
         length=0.1,
     )
 
-    ep_r = line.substrate.dielectric.epsilon_r(freq)
-    zs = line.substrate.conductor.surface_impedance(freq)
+    ep_r = line.substrate.dielectric.properties(freq).ep_r
+    zs = line.substrate.conductor.properties(freq).zs
     quasi_static = line.formulation.quasi_static(
-        freq, w=line.w, h=line.substrate.h, t=line.substrate.t, ep_r=ep_r, zs=zs
+        w=line.w, h=line.substrate.h, t=line.substrate.t, ep_r=ep_r
     )
 
     actual = line.immittance(freq)
-    expected = quasi_static.to_immittance(freq, zs)
+    expected = quasi_static.to_immittance(
+        freq,
+        line.substrate.dielectric.properties(freq),
+        line.substrate.conductor.properties(freq),
+    )
     assert jnp.array_equal(actual.Z, expected.Z)
     assert jnp.array_equal(actual.Y, expected.Y)
 
 
 def test_microstrip_defaults_to_kirschning_jansen():
     """Modal dispersion is the accuracy-oriented microstrip default."""
-    from pmrf.models import KirschningJansen
+    from pmrf.models import KirschningJansenMicrostripDispersion
 
-    assert isinstance(MicrostripLine(length=0.1).dispersion, KirschningJansen)
+    assert isinstance(MicrostripLine(length=0.1).dispersion, KirschningJansenMicrostripDispersion)
 
 
 def test_hammerstad_jensen_finite_thickness_matches_skrf():
@@ -473,9 +508,7 @@ def test_hammerstad_jensen_finite_thickness_matches_skrf():
     freq = Frequency(start=1.0, stop=10.0, npoints=10, unit="GHz")
     formulation = HammerstadJensenMicrostripFormulation()
     ep_r = jnp.full(freq.npoints, 4.3)
-    result = formulation.quasi_static(
-        freq, w=1e-3, h=1e-3, t=35e-6, ep_r=ep_r, zs=jnp.zeros(freq.npoints)
-    )
+    result = formulation.quasi_static(w=1e-3, h=1e-3, t=35e-6, ep_r=ep_r)
     media = MLine(
         freq.to_skrf(),
         w=1e-3,
@@ -531,12 +564,8 @@ def test_kirschning_jansen_matches_skrf(ep_r, width_height):
     assert jnp.allclose(gamma_length / line.length, media.gamma, rtol=1e-3)
 
 
-@pytest.mark.parametrize(
-    ("convention", "compatibility_mode"),
-    [("complex", None), ("real", "qucs")],
-)
-def test_microstrip_epsilon_convention_matches_skrf(convention, compatibility_mode):
-    """Both documented permittivity conventions match their scikit-rf modes."""
+def test_microstrip_complex_permittivity_matches_skrf():
+    """Microstrip uses the ADS/AWR complex-permittivity convention."""
     from skrf.media import MLine
     from pmrf.models import HammerstadJensenMicrostripFormulation
 
@@ -548,7 +577,6 @@ def test_microstrip_epsilon_convention_matches_skrf(convention, compatibility_mo
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
         conductor=BulkConductor(rho=1.68e-8),
         formulation=HammerstadJensenMicrostripFormulation(),
-        epsilon_convention=convention,
         length=0.1,
     )
     media = MLine(
@@ -563,31 +591,12 @@ def test_microstrip_epsilon_convention_matches_skrf(convention, compatibility_mo
         model="hammerstadjensen",
         disp="kirschningjansen",
         diel="frequencyinvariant",
-        compatibility_mode=compatibility_mode,
+        compatibility_mode=None,
     )
 
     zc, gamma_length = line.zc_and_gammaL(freq)
     assert jnp.allclose(zc, media.z0_characteristic, rtol=1e-3)
     assert jnp.allclose(gamma_length / line.length, media.gamma, rtol=1e-3)
-
-
-def test_real_epsilon_convention_retains_loss_without_modal_dispersion():
-    """The convention switch is independent of enabling modal dispersion."""
-    freq = Frequency(start=1.0, stop=10.0, npoints=10, unit="GHz")
-    line = MicrostripLine(
-        dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
-        conductor=BulkConductor(rho=0.0),
-        dispersion=None,
-        epsilon_convention="real",
-        length=0.1,
-    )
-
-    assert jnp.all(line.immittance(freq).G > 0)
-
-
-def test_microstrip_rejects_unknown_epsilon_convention():
-    with pytest.raises(ValueError, match="epsilon_convention"):
-        MicrostripLine(epsilon_convention="hybrid", length=0.1)
 
 
 def test_microstrip_near_air_has_finite_conductance_and_gradient():
@@ -639,6 +648,36 @@ def test_coaxial_line_has_no_modal_dispersion_field():
 # and against the exact identities a homogeneously-filled line must satisfy.
 # -----------------------------------------------------------------------------
 
+
+@pytest.mark.parametrize("line", [
+    MicrostripLine(
+        dielectric=ConstantDielectric(ep_r=4.3, sigma=0.01), length=0.1
+    ),
+    StriplineLine(
+        dielectric=ConstantDielectric(ep_r=2.2, sigma=0.01), length=0.1
+    ),
+])
+def test_planar_static_conductivity_is_finite_and_continuous_at_dc(line):
+    freq = Frequency.from_f(jnp.array([0.0, 1e-3, 1.0]))
+    conductance = line.immittance(freq).G
+    assert jnp.all(jnp.isfinite(conductance))
+    assert jnp.all(conductance > 0)
+    assert jnp.allclose(conductance[0], conductance[1], rtol=1e-12)
+
+
+def test_microstrip_rejects_magnetic_substrate():
+    line = MicrostripLine(
+        dielectric=ConstantDielectric(ep_r=4.3, mu_r=2.0), length=0.1
+    )
+    with pytest.raises(Exception, match="nonmagnetic substrate"):
+        line.immittance(Frequency.from_f(jnp.array([1e9])))
+
+
+def test_stripline_rejects_thickness_not_below_ground_spacing():
+    line = StriplineLine(b=1e-3, t=1e-3, length=0.1)
+    with pytest.raises(Exception, match="0 < t < b"):
+        line.immittance(Frequency.from_f(jnp.array([1e9])))
+
 def test_stripline_effective_permittivity_equals_relative_permittivity():
     """Stripline is homogeneously filled, so there is no filling factor at all."""
     from pmrf.models import CohnStriplineFormulation, StriplineLine
@@ -648,15 +687,13 @@ def test_stripline_effective_permittivity_equals_relative_permittivity():
     line = StriplineLine(w=2.655e-3, b=3.2e-3, dielectric=dielectric, length=0.1)
 
     quasi_static = CohnStriplineFormulation().quasi_static(
-        freq,
         w=line.w,
         b=line.b,
         t=line.t,
-        ep_r=dielectric.epsilon_r(freq),
-        zs=line.conductor.surface_impedance(freq),
+        ep_r=dielectric.properties(freq).ep_r,
     )
 
-    assert jnp.array_equal(quasi_static.ep_eff, dielectric.epsilon_r(freq))
+    assert jnp.array_equal(quasi_static.ep_eff, dielectric.properties(freq).ep_r)
 
 
 def test_stripline_impedance_matches_pozar_design_example():
@@ -754,14 +791,12 @@ def test_stripline_accepts_a_dispersive_dielectric():
     dielectric = DjordjevicSarkar(ep_r=3.9, tand=0.02, f_ref=1e9)
     line = StriplineLine(w=2.655e-3, b=3.2e-3, dielectric=dielectric, length=0.1)
 
-    ep_r = dielectric.epsilon_r(freq)
+    ep_r = dielectric.properties(freq).ep_r
     quasi_static = CohnStriplineFormulation().quasi_static(
-        freq,
         w=line.w,
         b=line.b,
         t=line.t,
         ep_r=ep_r,
-        zs=line.conductor.surface_impedance(freq),
     )
 
     assert jnp.array_equal(quasi_static.ep_eff, ep_r)


### PR DESCRIPTION
Closes #75.

Refactors the material-to-line seam so every material exposes one cohesive frequency-evaluated property record, static conductivity stays physically correct at DC, and single-mode planar formulations share an honest quasi-static state. Intentionally breaking: the displaced interfaces are removed without aliases.

## Material interface

`AbstractDielectric` and `AbstractConductor` each expose `properties(freq)` as their sole required evaluated-material operation. `DielectricProperties` carries `ep_r`, `mu_r`, `sigma`; `ConductorProperties` carries `zs`, `sigma`, `mu_r`. Both live in the materials package. The former individual accessors are gone rather than retained as wrappers, so stored parameters can use their documented RF symbols without colliding with an accessor name.

## Static conductivity at DC

Conductivity is no longer encoded as a singular `sigma/(omega*eps_0)` term in the permittivity. It is applied as an explicit shunt conductance, so coaxial, microstrip and stripline immittance all retain a finite, nonzero conductance at DC. A coaxial regression asserts the analytic `2*pi*sigma/log(b/a)`; the planar regressions assert finite, nonzero and continuous with the low-frequency limit.

## Planar state

`QuasiStaticResult` becomes `PlanarQuasiStaticResult`. Conductor loss and static shunt conduction are separate geometry factors, so `w_eff` keeps one topology-independent meaning and Cohn attenuation is no longer smuggled through a synthetic effective width.

## Conventions and permeability

The real/QUCS permittivity convention, its field, branches, tests and documentation are removed; permittivity is complex throughout per ADS/AWR. Homogeneous coaxial and stripline consume both `ep_r` and `mu_r`. Microstrip rejects a magnetic substrate with a formulation-validity error rather than ignoring it or extrapolating uncited behaviour.

## Vocabulary

A Formulation produces the complete electrical state; a Dispersion corrects a quasi-static state with modal frequency dependence; a Roughness corrects conductor behaviour. Hence `KirschningJansenMicrostripDispersion` and `HammerstadRoughness`, with the fields `formulation`, `dispersion`, `roughness`. The three roles are defined in the `formulations` module header. Microstrip dispersion now takes only the arrays it actually uses.

## Validation

Invalid geometry is rejected at the formulation seam with JAX-compatible checks: coaxial `d_out > d_in`, stripline `0 < t < b`. Hammerstad roughness derives skin depth internally from frequency, conductivity and permeability, so skin depth is not part of the conductor interface. The tabulated dielectric enforces its shape, dimensionality, nonempty and strictly-increasing invariants. Each empirical formulation documents its cited validity range, with departures from a published fit range marked as documented extrapolation rather than rejected.

## Testing

Full suite: 436 passed, 28 skipped. `import pmrf` clean.

## Reviewer note

The validity figures quoted for Hammerstad-Jensen and Kirschning-Jansen are the commonly cited numbers from those papers but were not re-read against the sources while preparing this branch. Worth a check against the originals before merge, per the repo's rule on unattributed formulae.