### PR TITLE
Apply Wheeler conductor loss unconditionally in MicrostripLine

### DIFF
--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -323,12 +323,18 @@ class MicrostripLine(AbstractImmittanceLine):
     The substrate must be nonmagnetic. No cited microstrip formulation covers
     magnetic media, so $\mu_r \neq 1$ is rejected rather than silently ignored.
 
-    For a finite-thickness conductor, Wheeler's incremental-inductance
-    correction adds
+    Wheeler's incremental-inductance correction adds
     $$\alpha_c=\frac{\Re(Z_s)}{\Re(Z_{c,loss})W}
-    \exp\left[-1.2\left(\frac{\Re(Z_{c,loss})}{Z_0}\right)^{0.7}\right].$$
-    The resulting modal quantities are inverted exactly into the line's
-    internal currency:
+    \exp\left[-1.2\left(\frac{\Re(Z_{c,loss})}{Z_0}\right)^{0.7}\right],$$
+    applied unconditionally on the dispersion path. The rule contains no $t$:
+    it sums over every receded conductor surface, and the broad-face terms do
+    not vanish as $t\to0$. So $t=\text{None}$ ("thickness unspecified") is not
+    the same input as $t=0$; it is read as skin effect being in operation
+    regardless, which is the good-faith default since Wheeler's $R_s$ is
+    itself a thick-conductor result. $t$ only refines the geometry (through
+    the quasi-static formulation, where supported), it does not gate whether
+    conductor loss is applied. The resulting modal quantities are inverted
+    exactly into the line's internal currency:
     $$Z=\gamma Z_c,\qquad Y=\frac{\gamma}{Z_c}.$$
     
     Example
@@ -372,8 +378,13 @@ class MicrostripLine(AbstractImmittanceLine):
         The material of the trace and ground plane. A scalar resistivity in
         ohm-meters is coerced into a :class:`~pmrf.materials.BulkConductor`.
     t : Param | None, default=None
-        Thickness of the conductor. Wheeler requires ``None``; thickness-aware
-        formulations such as Hammerstad--Jensen use a positive value.
+        Thickness of the conductor. ``None`` means the thickness is
+        unspecified, not that it is zero: skin effect is assumed to be in
+        operation regardless, and Wheeler's conductor-loss correction (which
+        does not depend on `t`) is applied unconditionally. Wheeler's
+        quasi-static formulation requires ``None``; thickness-aware
+        formulations such as Hammerstad--Jensen use a positive value to
+        refine the geometry.
     formulation : AbstractMicrostripFormulation, default=WheelerMicrostripFormulation()
         The closed-form physics used to compute the quasi-static solution.
     dispersion : AbstractMicrostripDispersion | None, default=KirschningJansenMicrostripDispersion()
@@ -474,14 +485,15 @@ class MicrostripLine(AbstractImmittanceLine):
 
         gamma = 1j * freq.w * jnp.sqrt(ep_eff) / c
 
-        # Wheeler's incremental-inductance rule. With no finite conductor
-        # thickness scikit-rf defines this empirical correction as zero.
-        if substrate.t is not None:
-            z0 = jnp.sqrt(mu_0 / epsilon_0)
-            current_distribution = jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
-            gamma = gamma + (
-                jnp.real(conductor.zs) / (jnp.real(zc) * self.w) * current_distribution
-            )
+        # Wheeler's incremental-inductance rule applies at every thickness.
+        # It contains no `t`: the broad-face terms it sums over do not vanish
+        # as t -> 0, so t=None ("thickness unspecified") is not the same as
+        # t=0. Skin effect is assumed to be in operation regardless.
+        z0 = jnp.sqrt(mu_0 / epsilon_0)
+        current_distribution = jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
+        gamma = gamma + (
+            jnp.real(conductor.zs) / (jnp.real(zc) * self.w) * current_distribution
+        )
 
         result = ImmittanceResult.from_zc_gamma(zc, gamma, freq.w)
         return ImmittanceResult(

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -215,6 +215,30 @@ def test_coaxial_magnetic_loss_enters_the_series_resistance(basic_freq):
     assert jnp.all(immittance.R > 0)
 
 
+def test_microstrip_line_default_construction_has_conductor_loss(basic_freq):
+    """A default-constructed line has nonzero, rho-sensitive attenuation.
+
+    Regression for the bug where Wheeler's conductor-loss correction was
+    guarded on `substrate.t is not None`, and `t` defaults to `None`: a
+    default-constructed line (dispersion=KirschningJansenMicrostripDispersion,
+    t=None) had `rho` completely inert.
+    """
+    def alpha(rho):
+        line = MicrostripLine(
+            dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
+            conductor=BulkConductor(rho=rho),
+            length=0.1,
+        )
+        _, gamma_length = line.zc_and_gammaL(basic_freq)
+        return jnp.real(gamma_length / line.length)
+
+    alpha_lossless = alpha(0.0)
+    alpha_lossy = alpha(1.68e-8)
+
+    assert jnp.all(alpha_lossless == 0.0)
+    assert jnp.all(alpha_lossy > alpha_lossless)
+
+
 def test_microstrip_line_impedance(basic_freq):
     """Verify MicrostripLine evaluates Wheeler's formula correctly."""
     # Standard 50-ohm trace on 1.6mm FR4 (Er=4.3) is roughly 3.0mm wide

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -454,11 +454,17 @@ MICROSTRIP_CASES = [
     ),
     Case(
         id="wide_high_er_zero_thickness_dispersive",
-        purpose="u = 10 on a high-permittivity substrate with zero conductor "
-                "thickness, where neither side applies a conductor correction "
-                "and the dielectric loss stands alone.",
+        purpose="u = 10 on a high-permittivity substrate with unspecified "
+                "conductor thickness and a lossless conductor, so the "
+                "dielectric loss stands alone. (A nonzero rho here would pit "
+                "ParamRF's unconditional Wheeler correction against "
+                "scikit-rf's policy of zeroing conductor loss whenever t is "
+                "unspecified -- a difference in missing-input policy, not "
+                "physics, already covered by "
+                "test_microstrip_line_default_construction_has_conductor_loss "
+                "in test_lines.py.)",
         **_microstrip_pair(w=10e-3, h=1e-3, t=None, ep_r=10.0, tand=0.002,
-                           rho=RHO_COPPER,
+                           rho=0.0,
                            dispersion=KirschningJansenMicrostripDispersion,
                            diel="frequencyinvariant",
                            formulation=HammerstadJensenMicrostripFormulation,


### PR DESCRIPTION
## Summary
- `MicrostripLine.immittance` guarded Wheeler's conductor-loss correction behind `substrate.t is not None`. Since `t` defaults to `None`, a default-constructed `MicrostripLine` had zero conductor loss regardless of `rho`. Wheeler's incremental-inductance rule contains no `t`, so this was a missing-input policy, not a physical limit. The guard is removed; the correction now applies unconditionally.
- Docstring updated so `t=None` reads as "thickness unspecified, skin effect assumed in operation," not zero thickness.
- Added a regression test asserting `rho` measurably moves attenuation on a default-constructed line.
- Fixed the one scikit-rf validation-matrix case whose `rho` was silently neutralized by the bug (`wide_high_er_zero_thickness_dispersive`), setting `rho=0.0` with a recorded reason rather than widening any tolerance.

Closes #81 (first of the child tickets split off parent #79; #82-#85 continue the restructure).

## Test plan
- [x] `pytest tests/test_models/test_lines.py tests/test_models/test_lines_skrf_matrix.py tests/test_dc_limits.py` — 94 passed
- [x] Full suite: `pytest` — 452 passed, 28 skipped
- [x] `python -c "import pmrf"` smoke check