### PR TITLE
Microstrip: charge Wheeler's conductor-loss rule on both immittance paths

### DIFF
--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -135,12 +135,19 @@ class PlanarQuasiStaticResult(eqx.Module):
         Converts the quasi-static solution into a per-unit-length immittance.
 
         The external inductance and the shunt admittance follow from the
-        quasi-static impedance and effective permittivity, and the signal
-        conductor and its return path each add their surface impedance over the
-        effective width:
-        $$Z = \frac{j\omega Z_c \sqrt{\varepsilon_e}}{c} + \frac{2 Z_s}{W_{eff}}
+        quasi-static impedance and effective permittivity, and the surface
+        impedance is charged through a geometry factor the formulation itself
+        supplies:
+        $$Z = \frac{j\omega Z_c \sqrt{\varepsilon_e}}{c} + Z_s K_c
         \qquad
         Y = \frac{j\omega \sqrt{\varepsilon_e}}{Z_c c}$$
+
+        $K_c$ (`conductor_loss_factor`) is formulation-specific: Cohn's
+        stripline result charges the sheet impedance over an effective width,
+        $2/W_{eff}$, while both microstrip formulations charge Wheeler's own
+        incremental-inductance rule instead (see
+        :func:`_wheeler_conductor_loss_factor`), a different geometry factor
+        over the physical width $W$.
 
         $\varepsilon_e$ is complex, so $Y$ already carries the dielectric loss
         as its real part and needs no separate loss-tangent term.
@@ -335,8 +342,10 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
     dielectric loss carries through the same filling factor as the real part and
     needs no separate loss-tangent term. The effective width is $W$: the
     approximation is derived for a zero-thickness strip, so `zs` does not enter
-    here — a thickness-aware formulation uses it to widen $W_{eff}$ for the
-    current distribution, and the line applies the series loss either way.
+    here. Conductor loss is charged separately, through
+    `conductor_loss_factor`, by Wheeler's own incremental-inductance rule
+    (see :func:`_wheeler_conductor_loss_factor`), applied over the physical
+    width $W$ rather than a thickness-widened one.
 
     **Validity**
 
@@ -379,8 +388,9 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
         zc = Za / jnp.sqrt(ep_eff)
         w_eff = W * jnp.ones_like(ep_r)
         conductance_factor = _microstrip_conductance_factor(ep_r, ep_eff, zc)
+        conductor_loss_factor = _wheeler_conductor_loss_factor(W, zc)
 
-        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, 2 / w_eff, conductance_factor)
+        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, conductor_loss_factor, conductance_factor)
 
 
 class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
@@ -414,7 +424,12 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
     \varepsilon_e=e\left[\frac{Z_L(u_1)}{Z_L(u_r)}\right]^2,
     \qquad W_{eff}=u_rH,$$
     where $e$ denotes the bracketed permittivity expression before its
-    thickness correction.
+    thickness correction. $W_{eff}$ is the electromagnetic fringing width and
+    feeds the dispersion formulation; conductor loss is charged separately,
+    through `conductor_loss_factor`, by Wheeler's incremental-inductance rule
+    (see :func:`_wheeler_conductor_loss_factor`) over the physical width $W$,
+    which is the correct one for that rule regardless of which formulation
+    supplied the quasi-static solution.
 
     The fractional power in $b$ is evaluated through the principal logarithm.
     The dielectric constraint $\Re(\varepsilon_r)>1$ keeps its argument away
@@ -470,7 +485,8 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
         ep_eff = e * (z1 / zr) ** 2
         w_eff = ur * h
         conductance_factor = _microstrip_conductance_factor(ep_r, ep_eff, zc)
-        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, 2 / w_eff, conductance_factor)
+        conductor_loss_factor = _wheeler_conductor_loss_factor(w, zc)
+        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, conductor_loss_factor, conductance_factor)
 
     @staticmethod
     def _homogeneous_impedance(u):
@@ -792,6 +808,36 @@ class CohnStriplineFormulation(AbstractStriplineFormulation):
             jnp.sqrt(ep_r) * zc_real < 120, alpha_low, alpha_high
         )
         return 2 * alpha_over_rs * zc_real
+
+
+def _wheeler_conductor_loss_factor(w, zc):
+    r"""Wheeler's incremental-inductance rule, as a `conductor_loss_factor`.
+
+    $$k_c = \frac{2}{W}\exp\left[-1.2\left(\frac{\Re(Z_c)}{Z_0}\right)^{0.7}\right]$$
+
+    charges the sheet impedance over the physical trace width $W$, not the
+    dispersion-widened $W_{eff}$: the rule sums over every receded conductor
+    surface, and those terms do not vanish as $t\to0$, so the effective width
+    used to widen the current-carrying geometry is not the right one here.
+    $Z_c$ is the (possibly dispersed) characteristic impedance at the point in
+    the line's pipeline where the factor is evaluated; only its real part
+    enters, since the exponent is a lossless current-crowding correction.
+
+    This is the low-loss linearisation shared by both callers: charged
+    directly onto $\gamma$ it reproduces the rule's own $\alpha_c$, and
+    charged onto $Z$ through :meth:`PlanarQuasiStaticResult.to_immittance` it
+    reduces to the same $\alpha_c$ once $Z=\gamma Z_c$ is inverted, using
+    $\Re(\gamma) \approx \Re(Z_s k_c)/(2\Re(Z_c))$ for a small series
+    perturbation on an otherwise lossless line.
+
+    References
+    ----------
+    Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
+    IRE, 30(9), 412-424.
+    """
+    z0 = jnp.sqrt(mu_0 / epsilon_0)
+    current_distribution = jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
+    return 2 / w * current_distribution
 
 
 def _microstrip_conductance_factor(ep_r, ep_eff, zc):

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -1,7 +1,7 @@
 """
 Physical transmission lines (general, coaxial, microstrip, stripline)
 """
-from scipy.constants import c, epsilon_0, mu_0
+from scipy.constants import c
 import jax.numpy as jnp
 import equinox as eqx
 
@@ -30,6 +30,7 @@ from pmrf.models.components.lines.formulations import (
     KirschningJansenMicrostripDispersion,
     TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
+    _wheeler_conductor_loss_factor,
 )
 
 
@@ -323,12 +324,17 @@ class MicrostripLine(AbstractImmittanceLine):
     The substrate must be nonmagnetic. No cited microstrip formulation covers
     magnetic media, so $\mu_r \neq 1$ is rejected rather than silently ignored.
 
-    Wheeler's incremental-inductance correction adds
+    Wheeler's incremental-inductance rule (:func:`_wheeler_conductor_loss_factor`)
+    is the single conductor-loss term charged on both paths:
     $$\alpha_c=\frac{\Re(Z_s)}{\Re(Z_{c,loss})W}
     \exp\left[-1.2\left(\frac{\Re(Z_{c,loss})}{Z_0}\right)^{0.7}\right],$$
-    applied unconditionally on the dispersion path. The rule contains no $t$:
-    it sums over every receded conductor surface, and the broad-face terms do
-    not vanish as $t\to0$. So $t=\text{None}$ ("thickness unspecified") is not
+    applied unconditionally, over the physical width $W$ rather than any
+    thickness-widened one. So ``dispersion=None`` is a pure dispersion toggle:
+    the quasi-static formulation's own `conductor_loss_factor` charges the
+    same rule at $Z_{c,loss}=Z_{c,0}$, and the dispersion path charges it
+    again at the dispersed $Z_{c,loss}$. The rule contains no $t$: it sums
+    over every receded conductor surface, and the broad-face terms do not
+    vanish as $t\to0$. So $t=\text{None}$ ("thickness unspecified") is not
     the same input as $t=0$; it is read as skin effect being in operation
     regardless, which is the good-faith default since Wheeler's $R_s$ is
     itself a thick-conductor result. $t$ only refines the geometry (through
@@ -488,11 +494,13 @@ class MicrostripLine(AbstractImmittanceLine):
         # Wheeler's incremental-inductance rule applies at every thickness.
         # It contains no `t`: the broad-face terms it sums over do not vanish
         # as t -> 0, so t=None ("thickness unspecified") is not the same as
-        # t=0. Skin effect is assumed to be in operation regardless.
-        z0 = jnp.sqrt(mu_0 / epsilon_0)
-        current_distribution = jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
-        gamma = gamma + (
-            jnp.real(conductor.zs) / (jnp.real(zc) * self.w) * current_distribution
+        # t=0. Skin effect is assumed to be in operation regardless. This is
+        # the same conductor_loss_factor the quasi-static path charges
+        # through PlanarQuasiStaticResult.to_immittance, evaluated here at the
+        # dispersed zc and applied directly to gamma rather than to Z.
+        conductor_loss_factor = _wheeler_conductor_loss_factor(self.w, zc)
+        gamma = gamma + jnp.real(conductor.zs) * conductor_loss_factor / (
+            2 * jnp.real(zc)
         )
 
         result = ImmittanceResult.from_zc_gamma(zc, gamma, freq.w)

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -461,6 +461,48 @@ def test_microstrip_without_dispersion_preserves_quasi_static_immittance():
     assert jnp.array_equal(actual.Y, expected.Y)
 
 
+def test_microstrip_dispersion_is_a_pure_dispersion_toggle():
+    """Turning dispersion off must not change *which* conductor loss applies.
+
+    Both the quasi-static path (``PlanarQuasiStaticResult.to_immittance``) and
+    the dispersion path charge Wheeler's incremental-inductance rule, so
+    disabling dispersion with an identity dispersion formulation (one that
+    hands the quasi-static ep_eff/zc straight through, unchanged) reproduces
+    the quasi-static attenuation to the accuracy of the quasi-static path's
+    own low-loss linearisation -- not to the ~9% gap that opened when the two
+    paths charged different conductor-loss forms (issue #82).
+    """
+    from pmrf.models import HammerstadJensenMicrostripFormulation
+    from pmrf.models.components.lines.formulations import AbstractMicrostripDispersion
+
+    class IdentityDispersion(AbstractMicrostripDispersion):
+        """Hands the quasi-static ep_eff/zc through unchanged."""
+
+        def disperse(self, freq, *, ep_eff_0, zc_0, ep_r, w_eff, h):
+            return ep_eff_0, zc_0
+
+    freq = Frequency(start=1.0, stop=20.0, npoints=21, unit="GHz")
+
+    def alpha(dispersion):
+        line = MicrostripLine(
+            w=3e-3,
+            h=1.6e-3,
+            t=35e-6,
+            dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
+            conductor=BulkConductor(rho=1.72e-8),
+            formulation=HammerstadJensenMicrostripFormulation(),
+            dispersion=dispersion,
+            length=0.1,
+        )
+        _, gamma_length = line.zc_and_gammaL(freq)
+        return jnp.real(gamma_length / line.length)
+
+    alpha_quasi_static = alpha(None)
+    alpha_identity_dispersion = alpha(IdentityDispersion())
+
+    assert jnp.allclose(alpha_quasi_static, alpha_identity_dispersion, rtol=1e-2)
+
+
 def test_microstrip_defaults_to_kirschning_jansen():
     """Modal dispersion is the accuracy-oriented microstrip default."""
     from pmrf.models import KirschningJansenMicrostripDispersion

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -399,7 +399,7 @@ MICROSTRIP_CASES = [
                            model="hammerstadjensen"),
         length=5e-3, z0=50.0,
         tol={"ep_eff": (1e-12, 0.0), "zc": (5e-3, 0.0),
-             "alpha": (1e-1, 1e-12), "beta": (5e-3, 0.0), "s": (0.0, 5e-3)},
+             "alpha": (1e-2, 1e-12), "beta": (5e-3, 0.0), "s": (0.0, 5e-3)},
         f_min={"zc": 1e9, "alpha": 1e9, "beta": 1e9, "s": 1e9},
         notes={
             "zc": "Finding, not a tolerance to widen. With modal dispersion "
@@ -414,10 +414,14 @@ MICROSTRIP_CASES = [
                   "comparison starts at 1 GHz; the low-frequency limit is "
                   "checked against theory in "
                   "test_quasi_static_microstrip_zc_follows_the_rlgc_limit.",
-            "alpha": _MICROSTRIP_NOTES["alpha"] + " On this quasi-static path "
-                     "the conductor term differs too: ParamRF charges the sheet "
-                     "impedance over the effective width, 2*Zs/w_eff, where "
-                     "scikit-rf applies Wheeler's incremental-inductance rule.",
+            "alpha": _MICROSTRIP_NOTES["alpha"] + " Both ParamRF and scikit-rf "
+                     "now charge Wheeler's incremental-inductance rule on this "
+                     "path too, evaluated at the (unrenormalized) quasi-static "
+                     "Zc, so the residual here is the same dielectric-loss "
+                     "difference as the dispersive cases, about half a percent "
+                     "at 40 GHz -- tighter than the general Hammerstad-Jensen "
+                     "tolerance because this substrate's low permittivity keeps "
+                     "the linear-in-ep_r approximation closer to exact.",
             "beta": _MICROSTRIP_NOTES["beta"] + " On this path beta also "
                     "carries the conductor resistance through sqrt(Z*Y), which "
                     "is what the 1 GHz floor excludes.",
@@ -562,20 +566,27 @@ def test_quasi_static_microstrip_zc_follows_the_rlgc_limit():
     r"""The low-frequency Zc that scikit-rf's MLine cannot express.
 
     Once the sheet impedance of the conductor outgrows $j\omega L$, the series
-    impedance of this line is $2Z_s/W_{eff}$, which is
+    impedance of this line is $Z_s K_c$ (Wheeler's incremental-inductance
+    rule, $K_c$ constant at a fixed quasi-static $Z_c$), which is
     $(1 + j)R_s \propto \sqrt{f}$. So
-    $$Z_c = \sqrt{Z/Y} \to \sqrt{\frac{(1 + j)R_s}{j\omega C}},$$
+    $$Z_c = \sqrt{Z/Y} \to \sqrt{\frac{(1 + j)R_s K_c}{j\omega C}},$$
     whose magnitude rises as $f^{-1/4}$ and whose phase settles at
     $(45 - 90)/2 = -22.5$ degrees. scikit-rf's MLine reports the quasi-static
     impedance there instead, because its ``z0_characteristic`` never sees the
     conductor at all. That is the difference the ``f_min`` floor on
     ``wide_low_er_lossy_quasi_static`` excludes, checked here against theory
     rather than against the other implementation.
+
+    Wheeler's current-distribution factor makes $K_c$ smaller than the
+    retired $2/W_{eff}$ term was, so $j\omega L$ stays non-negligible to a
+    lower frequency than before; the swept range is kept inside the decade
+    where the asymptote already holds to a fraction of a percent, rather than
+    widening the tolerance to paper over a range that reaches beyond it.
     """
     case = next(c for c in MICROSTRIP_CASES if c.id == "wide_low_er_lossy_quasi_static")
     line = case.line(case.length)
 
-    low = Frequency.from_f(jnp.geomspace(1e-3, 1e1, 9))
+    low = Frequency.from_f(jnp.geomspace(1e-3, 1e0, 9))
     zc = line.zc_and_gammaL(low)[0]
 
     scaled = jnp.abs(zc) * low.f ** 0.25


### PR DESCRIPTION
## Summary
- `PlanarQuasiStaticResult.to_immittance` charged `2*Zs/w_eff`, while the dispersion path charged Wheeler's incremental-inductance rule -- so `dispersion=None` silently changed which conductor-loss model applied, not just whether dispersion was on.
- Both microstrip formulations (`WheelerMicrostripFormulation`, `HammerstadJensenMicrostripFormulation`) now derive `conductor_loss_factor` from Wheeler's rule over the physical trace width, via a shared `_wheeler_conductor_loss_factor` helper also reused by the dispersion path.
- `2*Zs/w_eff` is retired for microstrip; Stripline's own Cohn-derived conductor-loss term is untouched (different physical structure, out of scope).
- Re-derived the `wide_low_er_lossy_quasi_static` alpha tolerance (1e-1 -> 1e-2) now that both paths agree, and updated its note.

## Test plan
- [x] `pytest tests/test_models/test_lines.py -q`
- [x] `pytest tests/test_models/test_lines_skrf_matrix.py -q`
- [x] Full suite: `pytest -q` (453 passed, 28 skipped)
- [x] `/code-review` (Standards + Spec axes) run against `main`, no hard violations found

Fixes #82