### PR TITLE
Microstrip: report exact RLGC characteristic impedance on both paths

### DIFF
--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -28,6 +28,7 @@ from pmrf.models.components.lines.formulations import (
     AbstractStriplineFormulation,
     CohnStriplineFormulation,
     KirschningJansenMicrostripDispersion,
+    PlanarQuasiStaticResult,
     TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
     _wheeler_conductor_loss_factor,
@@ -302,9 +303,13 @@ class MicrostripLine(AbstractImmittanceLine):
     
     Uses :class:`WheelerMicrostripFormulation` for the default mathematical formulation.
 
-    The quasi-static formulation returns a :class:`PlanarQuasiStaticResult`. With
-    modal dispersion disabled, :meth:`PlanarQuasiStaticResult.to_immittance` converts
-    it directly; otherwise the dispersed modal quantities are inverted exactly.
+    The quasi-static formulation returns a :class:`PlanarQuasiStaticResult`.
+    :meth:`PlanarQuasiStaticResult.to_immittance` converts it directly whether
+    modal dispersion is disabled or not: with dispersion enabled, the dispersed
+    $(\varepsilon_e, Z_c)$ replace the quasi-static ones in a fresh
+    :class:`PlanarQuasiStaticResult` first, so both paths report the same
+    genuine RLGC $Z_c=\sqrt{Z/Y}$ rather than the dispersion path tautologically
+    reproducing Kirschning-Jansen's modal $Z_c$.
 
     **Mathematical Formulation**
 
@@ -339,9 +344,12 @@ class MicrostripLine(AbstractImmittanceLine):
     regardless, which is the good-faith default since Wheeler's $R_s$ is
     itself a thick-conductor result. $t$ only refines the geometry (through
     the quasi-static formulation, where supported), it does not gate whether
-    conductor loss is applied. The resulting modal quantities are inverted
-    exactly into the line's internal currency:
-    $$Z=\gamma Z_c,\qquad Y=\frac{\gamma}{Z_c}.$$
+    conductor loss is applied. This is a ParamRF convention, not a correction
+    of Kirschning-Jansen: K-J's $Z_c$ is a power-current quasi-TEM modal
+    quantity, chosen by Jansen & Koster for its weak frequency dependence, and
+    NIST (Williams, Alpert, Arz et al., *Causal Characteristic Impedance of
+    Planar Transmission Lines*) establishes that microstrip has no unique
+    $Z_c$.
     
     Example
     --------
@@ -479,36 +487,44 @@ class MicrostripLine(AbstractImmittanceLine):
 
         if self.dispersion is None:
             return quasi_static.to_immittance(freq, dielectric, conductor)
-        else:
-            ep_eff, zc = self.dispersion.disperse(
-                freq,
-                ep_eff_0=quasi_static.ep_eff,
-                zc_0=quasi_static.zc,
-                ep_r=ep_r,
-                w_eff=quasi_static.w_eff,
-                h=substrate.h,
-            )
 
-        gamma = 1j * freq.w * jnp.sqrt(ep_eff) / c
+        ep_eff, zc = self.dispersion.disperse(
+            freq,
+            ep_eff_0=quasi_static.ep_eff,
+            zc_0=quasi_static.zc,
+            ep_r=ep_r,
+            w_eff=quasi_static.w_eff,
+            h=substrate.h,
+        )
 
+        # Route through the same to_immittance a quasi-static line uses, at
+        # the dispersed (ep_eff, zc) rather than inverting the modal (zc,
+        # gamma) through from_zc_gamma. That inversion made Zc = sqrt(Z/Y)
+        # tautologically equal to the modal zc, so the conductor never
+        # genuinely entered it; to_immittance instead builds Z and Y from
+        # physical per-unit-length quantities, so Zc = sqrt(Z/Y) falls out
+        # exact with the conductor contribution actually in it. This is a
+        # ParamRF convention, not a correction of Kirschning-Jansen: K-J's Zc
+        # is a power-current quasi-TEM modal quantity, chosen by Jansen &
+        # Koster for its weak frequency dependence, and NIST (Williams,
+        # Alpert, Arz et al., "Causal Characteristic Impedance of Planar
+        # Transmission Lines") establishes that microstrip has no unique Zc.
+        #
         # Wheeler's incremental-inductance rule applies at every thickness.
         # It contains no `t`: the broad-face terms it sums over do not vanish
         # as t -> 0, so t=None ("thickness unspecified") is not the same as
         # t=0. Skin effect is assumed to be in operation regardless. This is
-        # the same conductor_loss_factor the quasi-static path charges
-        # through PlanarQuasiStaticResult.to_immittance, evaluated here at the
-        # dispersed zc and applied directly to gamma rather than to Z.
+        # the same conductor_loss_factor the quasi-static path charges,
+        # evaluated here at the dispersed zc.
         conductor_loss_factor = _wheeler_conductor_loss_factor(self.w, zc)
-        gamma = gamma + jnp.real(conductor.zs) * conductor_loss_factor / (
-            2 * jnp.real(zc)
+        dispersed_quasi_static = PlanarQuasiStaticResult(
+            ep_eff=ep_eff,
+            zc=zc,
+            w_eff=quasi_static.w_eff,
+            conductor_loss_factor=conductor_loss_factor,
+            shunt_conductance_factor=quasi_static.shunt_conductance_factor,
         )
-
-        result = ImmittanceResult.from_zc_gamma(zc, gamma, freq.w)
-        return ImmittanceResult(
-            Z=result.Z,
-            Y=result.Y + dielectric.sigma * quasi_static.shunt_conductance_factor,
-            w=freq.w,
-        )
+        return dispersed_quasi_static.to_immittance(freq, dielectric, conductor)
 
 
 class StriplineLine(AbstractImmittanceLine):

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -393,9 +393,24 @@ def test_microstrip_formulation_takes_plain_arrays(basic_freq):
     assert jnp.allclose(result.w_eff, 3.0e-3)
 
 
-def test_lossy_microstrip_preserves_dispersed_zc_and_phase():
-    """The dispersed modal solution survives exact immittance inversion."""
+def test_dispersive_microstrip_routes_through_planar_quasi_static_to_immittance():
+    """#83: the dispersion path reports true RLGC Zc, not modal K-J Zc.
+
+    Inverting the dispersed modal ``(zc, gamma)`` through ``from_zc_gamma``
+    made ``Zc = sqrt(Z/Y)`` tautologically reproduce Kirschning-Jansen's own
+    modal Zc, so the conductor never genuinely entered it. The dispersion
+    path must instead build a fresh
+    :class:`~pmrf.models.components.lines.formulations.PlanarQuasiStaticResult`
+    at the dispersed ``(ep_eff, zc)`` and route it through
+    :meth:`~pmrf.models.components.lines.formulations.PlanarQuasiStaticResult.to_immittance`,
+    exactly like the quasi-static path, so ``line.immittance`` matches that
+    construction bit for bit.
+    """
     from pmrf.models import HammerstadJensenMicrostripFormulation, KirschningJansenMicrostripDispersion
+    from pmrf.models.components.lines.formulations import (
+        PlanarQuasiStaticResult,
+        _wheeler_conductor_loss_factor,
+    )
 
     freq = Frequency(start=1.0, stop=50.0, npoints=51, unit="GHz")
     formulation = HammerstadJensenMicrostripFormulation()
@@ -411,26 +426,35 @@ def test_lossy_microstrip_preserves_dispersed_zc_and_phase():
         length=0.1,
     )
 
-    ep_r = line.substrate.dielectric.properties(freq).ep_r
-    zs = line.substrate.conductor.properties(freq).zs
+    dielectric = line.substrate.dielectric.properties(freq)
+    conductor = line.substrate.conductor.properties(freq)
     quasi_static = formulation.quasi_static(
-        w=line.w, h=line.substrate.h, t=line.substrate.t, ep_r=ep_r
+        w=line.w, h=line.substrate.h, t=line.substrate.t, ep_r=dielectric.ep_r
     )
-    ep_eff, expected_zc = dispersion.disperse(
+    ep_eff, zc = dispersion.disperse(
         freq,
         ep_eff_0=quasi_static.ep_eff,
         zc_0=quasi_static.zc,
-        ep_r=ep_r,
+        ep_r=dielectric.ep_r,
         w_eff=quasi_static.w_eff,
         h=line.substrate.h,
     )
+    expected = PlanarQuasiStaticResult(
+        ep_eff=ep_eff,
+        zc=zc,
+        w_eff=quasi_static.w_eff,
+        conductor_loss_factor=_wheeler_conductor_loss_factor(line.w, zc),
+        shunt_conductance_factor=quasi_static.shunt_conductance_factor,
+    ).to_immittance(freq, dielectric, conductor)
 
-    zc, gamma_length = line.zc_and_gammaL(freq)
-    gamma = gamma_length / line.length
+    actual = line.immittance(freq)
+    assert jnp.array_equal(actual.Z, expected.Z)
+    assert jnp.array_equal(actual.Y, expected.Y)
 
-    assert jnp.allclose(zc, expected_zc, rtol=1e-12, atol=1e-12)
-    expected_beta = jnp.imag(1j * freq.w * jnp.sqrt(ep_eff) / c)
-    assert jnp.allclose(jnp.imag(gamma), expected_beta, rtol=1e-12, atol=1e-12)
+    # The dispersed zc no longer equals sqrt(Z/Y) tautologically: the
+    # conductor genuinely enters the exact RLGC ratio, so the two differ.
+    exact_zc = jnp.sqrt(actual.Z / actual.Y)
+    assert not jnp.allclose(exact_zc, zc, rtol=1e-6, atol=1e-6)
 
 
 def test_microstrip_without_dispersion_preserves_quasi_static_immittance():

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -367,6 +367,41 @@ _MICROSTRIP_HJ = {
     "alpha": (1e-1, 1e-12), "beta": (1e-4, 0.0), "s": (0.0, 5e-3),
 }
 
+#: Same low-frequency finding as ``wide_low_er_lossy_quasi_static``'s "zc"
+#: note, now on the dispersion path as well: below the transition where the
+#: conductor's sheet impedance outgrows j*w*L, ParamRF's Zc = sqrt(Z/Y)
+#: genuinely departs from scikit-rf's MLine, whose z0_characteristic never
+#: sees the conductor. This is Zc's own finding, not a re-derivation of it,
+#: but it now also drags alpha and beta off scikit-rf's perturbative values
+#: (which assume the lossless Zc), and s along with them, so all four
+#: quantities need the same floor.
+_MICROSTRIP_DISPERSIVE_CONDUCTOR_NOTE = (
+    "Below the transition where the conductor's sheet impedance outgrows "
+    "j*w*L, ParamRF's Zc = sqrt(Z/Y) now genuinely includes the conductor "
+    "(see the fix routing the dispersion path through "
+    "PlanarQuasiStaticResult.to_immittance), while scikit-rf's MLine reports "
+    "the quasi-static Zc there and never sees it. The comparison floor "
+    "excludes that transition; the low-frequency limit itself is checked "
+    "against theory in "
+    "test_quasi_static_microstrip_zc_follows_the_rlgc_limit[dispersive]."
+)
+
+
+def _dispersive_conductor_notes(*, s_extra=""):
+    """Attach ``_MICROSTRIP_DISPERSIVE_CONDUCTOR_NOTE`` to zc, beta and s.
+
+    Shared by every dispersive case whose conductor is lossy enough to pull
+    its low-frequency Zc, beta and s off scikit-rf's quasi-static-only values.
+    ``s_extra`` appends a case-specific addendum to the s note.
+    """
+    return {
+        **_MICROSTRIP_NOTES,
+        "zc": _MICROSTRIP_DISPERSIVE_CONDUCTOR_NOTE,
+        "beta": _MICROSTRIP_NOTES["beta"] + " " + _MICROSTRIP_DISPERSIVE_CONDUCTOR_NOTE,
+        "s": _MICROSTRIP_NOTES["s"] + " " + _MICROSTRIP_DISPERSIVE_CONDUCTOR_NOTE + s_extra,
+    }
+
+
 MICROSTRIP_CASES = [
     Case(
         id="narrow_low_er_lossless_quasi_static",
@@ -413,7 +448,7 @@ MICROSTRIP_CASES = [
                   "definitions only converge above the transition, so the "
                   "comparison starts at 1 GHz; the low-frequency limit is "
                   "checked against theory in "
-                  "test_quasi_static_microstrip_zc_follows_the_rlgc_limit.",
+                  "test_quasi_static_microstrip_zc_follows_the_rlgc_limit[quasi_static].",
             "alpha": _MICROSTRIP_NOTES["alpha"] + " Both ParamRF and scikit-rf "
                      "now charge Wheeler's incremental-inductance rule on this "
                      "path too, evaluated at the (unrenormalized) quasi-static "
@@ -438,7 +473,11 @@ MICROSTRIP_CASES = [
                            diel="frequencyinvariant",
                            formulation=HammerstadJensenMicrostripFormulation,
                            model="hammerstadjensen"),
-        length=5e-3, z0=50.0, tol=_MICROSTRIP_HJ, notes=_MICROSTRIP_NOTES,
+        length=5e-3, z0=50.0,
+        tol={**_MICROSTRIP_HJ, "zc": (8e-3, 0.0), "beta": (5e-3, 0.0),
+             "s": (0.0, 9e-3)},
+        f_min={"zc": 1e9, "alpha": 1e9, "beta": 1e9, "s": 1e9},
+        notes=_dispersive_conductor_notes(),
     ),
     Case(
         id="narrow_high_er_lossy_stress",
@@ -451,10 +490,21 @@ MICROSTRIP_CASES = [
                            diel="frequencyinvariant",
                            formulation=HammerstadJensenMicrostripFormulation,
                            model="hammerstadjensen"),
-        length=2e-3, z0=50.0, notes=_MICROSTRIP_NOTES,
+        length=2e-3, z0=50.0,
+        notes=_dispersive_conductor_notes(
+            s_extra=" The deliberately resistive conductor here (rho=1e-6) "
+                    "also pushes that transition far higher up the band "
+                    "than any other case, so the floor is correspondingly "
+                    "higher."
+        ),
         # The most attenuating case in the matrix, so the documented
-        # dielectric-loss difference shows up largest in S21.
-        tol={**_MICROSTRIP_HJ, "s": (0.0, 1e-2)},
+        # dielectric-loss difference shows up largest in S21. The deliberately
+        # resistive conductor also pushes the conductor-dominated Zc
+        # transition (see _MICROSTRIP_DISPERSIVE_CONDUCTOR_NOTE) far higher up
+        # the band than any other case, hence the much higher floor here.
+        tol={**_MICROSTRIP_HJ, "zc": (3e-2, 0.0), "beta": (2e-2, 0.0),
+             "s": (0.0, 5e-2)},
+        f_min={"zc": 2e10, "alpha": 2e10, "beta": 2e10, "s": 2e10},
     ),
     Case(
         id="wide_high_er_zero_thickness_dispersive",
@@ -486,7 +536,11 @@ MICROSTRIP_CASES = [
                            diel="djordjevicsvensson",
                            formulation=HammerstadJensenMicrostripFormulation,
                            model="hammerstadjensen"),
-        length=5e-3, z0=50.0, tol=_MICROSTRIP_HJ, notes=_MICROSTRIP_NOTES,
+        length=5e-3, z0=50.0,
+        tol={**_MICROSTRIP_HJ, "zc": (8e-3, 0.0), "beta": (5e-3, 0.0),
+             "s": (0.0, 9e-3)},
+        f_min={"zc": 1e9, "alpha": 1e9, "beta": 1e9, "s": 1e9},
+        notes=_dispersive_conductor_notes(),
     ),
     Case(
         id="wheeler_formulation_nominal",
@@ -562,7 +616,9 @@ def test_microstrip_matches_skrf_s_parameters(case):
     _assert_close(line.s(WIDEBAND, z0=case.z0), expected, "s", case)
 
 
-def test_quasi_static_microstrip_zc_follows_the_rlgc_limit():
+@pytest.mark.parametrize("dispersion", [None, KirschningJansenMicrostripDispersion()],
+                         ids=["quasi_static", "dispersive"])
+def test_quasi_static_microstrip_zc_follows_the_rlgc_limit(dispersion):
     r"""The low-frequency Zc that scikit-rf's MLine cannot express.
 
     Once the sheet impedance of the conductor outgrows $j\omega L$, the series
@@ -582,9 +638,30 @@ def test_quasi_static_microstrip_zc_follows_the_rlgc_limit():
     lower frequency than before; the swept range is kept inside the decade
     where the asymptote already holds to a fraction of a percent, rather than
     widening the tolerance to paper over a range that reaches beyond it.
+
+    #83 routes the dispersion path through
+    :meth:`~pmrf.models.components.lines.formulations.PlanarQuasiStaticResult.to_immittance`
+    at the dispersed $(\varepsilon_e, Z_c)$, in place of inverting the modal
+    $(Z_c, \gamma)$ through ``from_zc_gamma`` -- an inversion that made
+    $Z_c=\sqrt{Z/Y}$ tautologically reproduce Kirschning-Jansen's own modal
+    $Z_c$ and never let the conductor genuinely enter it. With that fix, the
+    same asymptote holds with Kirschning-Jansen dispersion turned on too: its
+    own correction is negligible over this sub-hertz sweep, so the
+    ``dispersive`` case is expected to agree with the ``quasi_static`` one to
+    tight tolerance.
     """
     case = next(c for c in MICROSTRIP_CASES if c.id == "wide_low_er_lossy_quasi_static")
-    line = case.line(case.length)
+    quasi_static_line = case.line(case.length)
+    line = (
+        quasi_static_line if dispersion is None
+        else MicrostripLine(
+            w=quasi_static_line.w,
+            substrate=quasi_static_line.substrate,
+            formulation=quasi_static_line.formulation,
+            dispersion=dispersion,
+            length=case.length,
+        )
+    )
 
     low = Frequency.from_f(jnp.geomspace(1e-3, 1e0, 9))
     zc = line.zc_and_gammaL(low)[0]


### PR DESCRIPTION
## Summary
- Routes the microstrip dispersion path through `PlanarQuasiStaticResult.to_immittance` (fed the dispersed `ep_eff`/`zc` plus Wheeler's conductor-loss factor evaluated at the dispersed `zc`), replacing the `ImmittanceResult.from_zc_gamma` inversion that made `Zc = sqrt(Z/Y)` tautologically reproduce Kirschning-Jansen's own modal `Zc`.
- Records in a comment that this is a ParamRF convention, not a correction of Kirschning-Jansen, citing Jansen & Koster and the NIST causal-Zc paper.
- Parametrizes `test_quasi_static_microstrip_zc_follows_the_rlgc_limit` over quasi-static/dispersive, and adds a direct unit test verifying the dispersion path matches the `to_immittance` construction bit-for-bit.
- Updates three scikit-rf matrix-comparison cases whose Zc previously matched scikit-rf to round-off only because of the from_zc_gamma tautology: they now need a frequency floor and explained tolerance, since the true RLGC Zc genuinely diverges from scikit-rf's quasi-static-only `z0_characteristic` below the conductor-loss transition, same as the existing quasi-static case.

## Test plan
- [x] `.venv/bin/python -m pytest -q` — 454 passed, 28 skipped
- [x] `/code-review` (Standards + Spec axes) run against the diff, findings addressed

Closes #83

https://claude.ai/code/session_01RHe2bAsmQMx5B3GYXaeBwv