### PR TITLE
Microstrip: expose ep_eff(freq) and w_eff(freq) as public model quantities

### DIFF
--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -468,9 +468,14 @@ class MicrostripLine(AbstractImmittanceLine):
         self.name = name
         self.metadata = metadata
 
-    def immittance(self, freq: Frequency) -> ImmittanceResult:
+    def _resolved_quasi_static(self, freq: Frequency) -> PlanarQuasiStaticResult:
+        """The quasi-static solution actually in force, dispersed when ``dispersion`` is set.
+
+        Both :meth:`immittance` and the public :meth:`ep_eff`/:meth:`w_eff`
+        accessors route through this single pipeline, so the accessors cannot
+        drift from what ``immittance`` actually charges.
+        """
         substrate = self.substrate
-        conductor = substrate.conductor.properties(freq)
         dielectric = substrate.dielectric.properties(freq)
         ep_r = eqx.error_if(
             dielectric.ep_r,
@@ -486,7 +491,7 @@ class MicrostripLine(AbstractImmittanceLine):
         )
 
         if self.dispersion is None:
-            return quasi_static.to_immittance(freq, dielectric, conductor)
+            return quasi_static
 
         ep_eff, zc = self.dispersion.disperse(
             freq,
@@ -517,14 +522,61 @@ class MicrostripLine(AbstractImmittanceLine):
         # the same conductor_loss_factor the quasi-static path charges,
         # evaluated here at the dispersed zc.
         conductor_loss_factor = _wheeler_conductor_loss_factor(self.w, zc)
-        dispersed_quasi_static = PlanarQuasiStaticResult(
+        return PlanarQuasiStaticResult(
             ep_eff=ep_eff,
             zc=zc,
             w_eff=quasi_static.w_eff,
             conductor_loss_factor=conductor_loss_factor,
             shunt_conductance_factor=quasi_static.shunt_conductance_factor,
         )
-        return dispersed_quasi_static.to_immittance(freq, dielectric, conductor)
+
+    def immittance(self, freq: Frequency) -> ImmittanceResult:
+        substrate = self.substrate
+        conductor = substrate.conductor.properties(freq)
+        dielectric = substrate.dielectric.properties(freq)
+        return self._resolved_quasi_static(freq).to_immittance(freq, dielectric, conductor)
+
+    def ep_eff(self, freq: Frequency) -> jnp.ndarray:
+        r"""
+        Complex effective relative permittivity the line actually ends up with.
+
+        Dispersed via ``dispersion`` when it is set, quasi-static otherwise —
+        the same value :meth:`immittance` uses internally, so it is exposed
+        here rather than recomputed by the caller. The imaginary part carries
+        the dielectric loss, following the ADS/AWR convention of carrying
+        permittivity complex throughout (see the class docstring and #79).
+
+        Parameters
+        ----------
+        freq : Frequency
+            Frequencies at which to evaluate the line.
+
+        Returns
+        -------
+        jnp.ndarray
+            Complex effective relative permittivity, shape ``(npoints,)``.
+        """
+        return self._resolved_quasi_static(freq).ep_eff
+
+    def w_eff(self, freq: Frequency) -> jnp.ndarray:
+        r"""
+        Effective conductor width the line actually ends up with.
+
+        Dispersed via ``dispersion`` when it is set, quasi-static otherwise —
+        the same value :meth:`immittance` uses internally, so it is exposed
+        here rather than recomputed by the caller.
+
+        Parameters
+        ----------
+        freq : Frequency
+            Frequencies at which to evaluate the line.
+
+        Returns
+        -------
+        jnp.ndarray
+            Effective conductor width in meters, shape ``(npoints,)``.
+        """
+        return self._resolved_quasi_static(freq).w_eff
 
 
 class StriplineLine(AbstractImmittanceLine):

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -28,6 +28,7 @@ from pmrf.materials import (
 from pmrf.models.components.lines.formulations import (
     TescheCoaxialFormulation,
     tube_internal_impedance,
+    KirschningJansenMicrostripDispersion,
 )
 
 @pytest.fixture
@@ -257,6 +258,44 @@ def test_microstrip_line_impedance(basic_freq):
     zc_real = jnp.real(zc)
     assert jnp.all(zc_real > 48.0)
     assert jnp.all(zc_real < 52.0)
+
+@pytest.mark.parametrize("dispersion", [None, KirschningJansenMicrostripDispersion()])
+def test_microstrip_line_ep_eff_and_w_eff_match_immittance_pipeline(basic_freq, dispersion):
+    """`ep_eff`/`w_eff` must report exactly what `immittance` uses internally.
+
+    Regression for #80: these were previously reconstructed by hand in the
+    scikit-rf validation matrix rather than exposed on the model, so a
+    refactor of `immittance` could silently drift from the recomputed value.
+    Recomputes the quasi-static (+ optional dispersion) pipeline independently
+    here, rather than calling the model's own helper, so the test does not
+    just check the method against itself.
+    """
+    w, h, ep_r = 3.0e-3, 1.6e-3, 4.3
+    line = MicrostripLine(
+        w=w,
+        h=h,
+        dielectric=ConstantDielectric(ep_r=ep_r, tand=0.01),
+        conductor=BulkConductor(rho=1.68e-8),
+        dispersion=dispersion,
+        length=0.1,
+    )
+
+    dielectric = line.substrate.dielectric.properties(basic_freq)
+    quasi_static = line.formulation.quasi_static(w=w, h=h, t=None, ep_r=dielectric.ep_r)
+    if dispersion is None:
+        expected_ep_eff, expected_w_eff = quasi_static.ep_eff, quasi_static.w_eff
+    else:
+        expected_ep_eff, _ = dispersion.disperse(
+            basic_freq, ep_eff_0=quasi_static.ep_eff, zc_0=quasi_static.zc,
+            ep_r=dielectric.ep_r, w_eff=quasi_static.w_eff, h=h,
+        )
+        expected_w_eff = quasi_static.w_eff
+
+    assert jnp.allclose(line.ep_eff(basic_freq), expected_ep_eff)
+    assert jnp.allclose(line.w_eff(basic_freq), expected_w_eff)
+    assert jnp.iscomplexobj(line.ep_eff(basic_freq))
+    assert jnp.any(jnp.imag(line.ep_eff(basic_freq)) != 0.0)
+
 
 def test_material_coercion():
     """Scalars and tuples coerce into the corresponding material modules."""

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -318,21 +318,6 @@ def _microstrip_pair(*, w, h, t, ep_r, tand, rho, dispersion, diel, formulation,
     return {"line": line, "media": media}
 
 
-def _ep_eff(line, freq):
-    """The complex effective permittivity a ParamRF microstrip line ends up with."""
-    ep_r = line.substrate.dielectric.properties(freq).ep_r
-    quasi_static = line.formulation.quasi_static(
-        w=line.w, h=line.substrate.h, t=line.substrate.t, ep_r=ep_r
-    )
-    if line.dispersion is None:
-        return quasi_static.ep_eff
-    ep_eff, _ = line.dispersion.disperse(
-        freq, ep_eff_0=quasi_static.ep_eff, zc_0=quasi_static.zc, ep_r=ep_r,
-        w_eff=quasi_static.w_eff, h=line.substrate.h,
-    )
-    return ep_eff
-
-
 # Every microstrip case sits on the same set of documented differences between
 # the two implementations, so the notes are written once and shared.
 _MICROSTRIP_NOTES = {
@@ -599,7 +584,7 @@ def test_microstrip_matches_skrf_electrical_quantities(case):
     # The effective permittivity is what the phase constant is built from,
     # compared in its own right so a phase failure stays distinguishable from a
     # loss failure.
-    _assert_close(_ep_eff(line, WIDEBAND), media.ep_reff_f, "ep_eff", case)
+    _assert_close(line.ep_eff(WIDEBAND), media.ep_reff_f, "ep_eff", case)
     _assert_close(zc, media.z0_characteristic, "zc", case)
     _assert_close(np.real(gamma), np.real(media.gamma), "alpha", case)
     _assert_close(np.imag(gamma), np.imag(media.gamma), "beta", case)


### PR DESCRIPTION
## Summary
- Adds `MicrostripLine.ep_eff(freq)` and `w_eff(freq)`, both routed through a new shared private `_resolved_quasi_static(freq)` helper that `immittance` also uses, so there is exactly one pipeline and the public accessors cannot drift from it.
- Removes the `_ep_eff` test helper in the scikit-rf validation matrix, which re-derived the same pipeline by hand; its one call site now uses the public method.
- Adds a regression test that independently recomputes the quasi-static/dispersion pipeline and checks it against the new accessors, for both `dispersion=None` and dispersion enabled.

Closes #80

## Test plan
- [x] `.venv/bin/python -m pytest` — 456 passed, 28 skipped
- [x] `.venv/bin/python -m pytest tests/test_models/test_lines.py -k "ep_eff or w_eff or microstrip"` — passed
- [x] `.venv/bin/python -m pytest tests/test_models/test_lines_skrf_matrix.py -k microstrip` — passed
- [x] `/code-review` (Standards + Spec axes) — no hard violations