### PR TITLE
Microstrip: dc resistance floor for finite-thickness conductors

### DIFF
--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -129,7 +129,7 @@ class PlanarQuasiStaticResult(eqx.Module):
 
     def to_immittance(
         self, freq: Frequency, dielectric: DielectricProperties,
-        conductor: ConductorProperties,
+        conductor: ConductorProperties, r_dc: jnp.ndarray | None = None,
     ) -> ImmittanceResult:
         r"""
         Converts the quasi-static solution into a per-unit-length immittance.
@@ -152,12 +152,29 @@ class PlanarQuasiStaticResult(eqx.Module):
         $\varepsilon_e$ is complex, so $Y$ already carries the dielectric loss
         as its real part and needs no separate loss-tangent term.
 
+        When `r_dc` is given, the resistive part of the conductor term is
+        floored at it by a smooth blend, $R=\sqrt{R_{dc}^2+\Re(Z_sK_c)^2}$,
+        leaving the reactive part untouched; the caller passes `r_dc=None`
+        wherever a dc floor does not apply. This blend is a **ParamRF
+        convention, not a rule any cited source prescribes**: ADS applies no
+        floor at all, and mcalc/wcalc hard-switch to a dc solution once the
+        skin depth exceeds the conductor thickness. Both the sheet term and
+        the floor are resistive at every frequency of interest, so a
+        Pythagorean sum is a defensible way to interpolate between the two
+        regimes without a hard switch, but the hard switch remains an
+        equally defensible alternative.
+
         Parameters
         ----------
         freq : Frequency
             The frequency axis.
         zs : jnp.ndarray
             Complex surface impedance of the conductor in ohm per square.
+        r_dc : jnp.ndarray | None, default=None
+            DC resistance per unit length to floor the conductor term at, or
+            `None` where no dc regime applies (e.g. an unspecified-thickness
+            conductor, which asserts skin effect at every frequency including
+            dc).
 
         Returns
         -------
@@ -173,7 +190,11 @@ class PlanarQuasiStaticResult(eqx.Module):
         sqrt_ep_eff_over_mu = jnp.sqrt(self.ep_eff / dielectric.mu_r)
 
         Z = 1j * w * self.zc * sqrt_ep_eff_mu / c
-        Z = Z + conductor.zs * self.conductor_loss_factor
+        Z_cond = conductor.zs * self.conductor_loss_factor
+        if r_dc is not None:
+            r_ac = jnp.real(Z_cond)
+            Z_cond = jnp.sqrt(r_dc**2 + r_ac**2) + 1j * jnp.imag(Z_cond)
+        Z = Z + Z_cond
         Y = 1j * w * sqrt_ep_eff_over_mu / (self.zc * c)
         Y = Y + dielectric.sigma * self.shunt_conductance_factor
 

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -350,7 +350,19 @@ class MicrostripLine(AbstractImmittanceLine):
     NIST (Williams, Alpert, Arz et al., *Causal Characteristic Impedance of
     Planar Transmission Lines*) establishes that microstrip has no unique
     $Z_c$.
-    
+
+    The sheet model above gives $R\to0$ as $f\to0$, which is wrong for a
+    trace of known thickness: a finite $t$ gets a dc floor
+    $R_{dc}=\rho/(Wt)$, blended smoothly with the skin-effect term as
+    $R=\sqrt{R_{dc}^2+R_{ac}^2}$ (see
+    :meth:`~pmrf.models.components.lines.formulations.PlanarQuasiStaticResult.to_immittance`).
+    $t=\text{None}$ gets no floor: it asserts skin effect in operation at
+    every frequency including dc, so there is no dc regime for a floor to
+    describe, matching ADS, which applies no floor at all. The blend itself
+    is a ParamRF convention rather than a rule any cited source prescribes
+    -- mcalc/wcalc hard-switch to a dc solution once skin depth exceeds
+    thickness instead, an equally defensible alternative.
+
     Example
     --------
     .. code-block:: python
@@ -534,7 +546,14 @@ class MicrostripLine(AbstractImmittanceLine):
         substrate = self.substrate
         conductor = substrate.conductor.properties(freq)
         dielectric = substrate.dielectric.properties(freq)
-        return self._resolved_quasi_static(freq).to_immittance(freq, dielectric, conductor)
+        t = substrate.t
+        # t=None asserts skin effect in operation at every frequency,
+        # including dc, so there is no dc regime for a floor to describe; a
+        # finite t gets R_dc = rho/(W*t) = 1/(sigma*W*t).
+        r_dc = None if t is None else 1.0 / (conductor.sigma * self.w * t)
+        return self._resolved_quasi_static(freq).to_immittance(
+            freq, dielectric, conductor, r_dc=r_dc
+        )
 
     def ep_eff(self, freq: Frequency) -> jnp.ndarray:
         r"""

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -297,6 +297,38 @@ def test_microstrip_line_ep_eff_and_w_eff_match_immittance_pipeline(basic_freq, 
     assert jnp.any(jnp.imag(line.ep_eff(basic_freq)) != 0.0)
 
 
+def test_microstrip_finite_thickness_has_dc_resistance_floor():
+    """#84: a finite-t line's R settles at rho/(W*t) at dc instead of 0.
+
+    The sheet model alone gives R -> 0 as f -> 0, wrong for a trace of known
+    thickness. A finite t gets a floor; t=None gets none, since it asserts
+    skin effect in operation at every frequency including dc, leaving no dc
+    regime for a floor to describe (matches ADS, which floors nothing).
+    """
+    from pmrf.models import HammerstadJensenMicrostripFormulation
+
+    w, h, t, rho = 3.0e-3, 1.6e-3, 35e-6, 1.68e-8
+    dc = Frequency.from_f(jnp.array([0.0]))
+
+    floored = MicrostripLine(
+        w=w, h=h, t=t,
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
+        conductor=BulkConductor(rho=rho),
+        formulation=HammerstadJensenMicrostripFormulation(),
+        length=0.1,
+    )
+    r_dc_expected = rho / (w * t)
+    assert jnp.allclose(floored.immittance(dc).R, r_dc_expected)
+
+    unfloored = MicrostripLine(
+        w=w, h=h, t=None,
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
+        conductor=BulkConductor(rho=rho),
+        length=0.1,
+    )
+    assert jnp.allclose(unfloored.immittance(dc).R, 0.0)
+
+
 def test_material_coercion():
     """Scalars and tuples coerce into the corresponding material modules."""
     line = CoaxialLine(dielectric=(2.25, 0.001), conductor=1.68e-8, length=0.1)
@@ -478,13 +510,14 @@ def test_dispersive_microstrip_routes_through_planar_quasi_static_to_immittance(
         w_eff=quasi_static.w_eff,
         h=line.substrate.h,
     )
+    r_dc = 1.0 / (conductor.sigma * line.w * line.substrate.t)
     expected = PlanarQuasiStaticResult(
         ep_eff=ep_eff,
         zc=zc,
         w_eff=quasi_static.w_eff,
         conductor_loss_factor=_wheeler_conductor_loss_factor(line.w, zc),
         shunt_conductance_factor=quasi_static.shunt_conductance_factor,
-    ).to_immittance(freq, dielectric, conductor)
+    ).to_immittance(freq, dielectric, conductor, r_dc=r_dc)
 
     actual = line.immittance(freq)
     assert jnp.array_equal(actual.Z, expected.Z)

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -601,6 +601,26 @@ def test_microstrip_matches_skrf_s_parameters(case):
     _assert_close(line.s(WIDEBAND, z0=case.z0), expected, "s", case)
 
 
+def _wide_low_er_lossy_line(*, t, dispersion):
+    """The ``wide_low_er_lossy_quasi_static`` cross-section, at a given `t`.
+
+    Reads the geometry and loss off the case itself, rather than repeating
+    its literals, so the two low-frequency tests below stay in sync with
+    ``MICROSTRIP_CASES`` automatically if that case ever changes; only the
+    dc-floor policy (`t`) and dispersion vary.
+    """
+    case = next(c for c in MICROSTRIP_CASES if c.id == "wide_low_er_lossy_quasi_static")
+    base = case.line(case.length)
+    return MicrostripLine(
+        w=base.w, h=base.substrate.h, t=t,
+        dielectric=base.substrate.dielectric,
+        conductor=base.substrate.conductor,
+        formulation=base.formulation,
+        dispersion=dispersion,
+        length=case.length,
+    )
+
+
 @pytest.mark.parametrize("dispersion", [None, KirschningJansenMicrostripDispersion()],
                          ids=["quasi_static", "dispersive"])
 def test_quasi_static_microstrip_zc_follows_the_rlgc_limit(dispersion):
@@ -634,19 +654,15 @@ def test_quasi_static_microstrip_zc_follows_the_rlgc_limit(dispersion):
     own correction is negligible over this sub-hertz sweep, so the
     ``dispersive`` case is expected to agree with the ``quasi_static`` one to
     tight tolerance.
+
+    #84 gives a *finite*-t line a dc resistance floor, which caps this
+    $f^{-1/4}$ growth once $R_{dc}$ overtakes the sheet term -- checked
+    separately in ``test_finite_thickness_microstrip_zc_floors_at_dc``. This
+    test uses a t=None line instead, since t=None asserts skin effect in
+    operation at every frequency including dc and so gets no floor: the
+    $f^{-1/4}$ tail is preserved down to arbitrarily low frequency.
     """
-    case = next(c for c in MICROSTRIP_CASES if c.id == "wide_low_er_lossy_quasi_static")
-    quasi_static_line = case.line(case.length)
-    line = (
-        quasi_static_line if dispersion is None
-        else MicrostripLine(
-            w=quasi_static_line.w,
-            substrate=quasi_static_line.substrate,
-            formulation=quasi_static_line.formulation,
-            dispersion=dispersion,
-            length=case.length,
-        )
-    )
+    line = _wide_low_er_lossy_line(t=None, dispersion=dispersion)
 
     low = Frequency.from_f(jnp.geomspace(1e-3, 1e0, 9))
     zc = line.zc_and_gammaL(low)[0]
@@ -654,3 +670,39 @@ def test_quasi_static_microstrip_zc_follows_the_rlgc_limit(dispersion):
     scaled = jnp.abs(zc) * low.f ** 0.25
     assert jnp.allclose(scaled, scaled[0], rtol=1e-2)
     assert jnp.allclose(jnp.angle(zc, deg=True), -22.5, atol=1.0)
+
+
+@pytest.mark.parametrize("dispersion", [None, KirschningJansenMicrostripDispersion()],
+                         ids=["quasi_static", "dispersive"])
+def test_finite_thickness_microstrip_zc_floors_at_dc(dispersion):
+    r"""A finite-t line's R saturates at the dc floor instead of vanishing.
+
+    Same cross-section as
+    ``test_quasi_static_microstrip_zc_follows_the_rlgc_limit``, but with
+    t=35um: below the transition where $R_{dc}=\rho/(Wt)$ overtakes the
+    sheet-resistance term $\Re(Z_sK_c)$, #84's floor holds $R\to R_{dc}$
+    rather than $R\to0$. With $R$ constant and $Y\to j\omega C$,
+    $$Z_c=\sqrt{Z/Y}\to\sqrt{\frac{R_{dc}}{j\omega C}},$$
+    whose magnitude rises as $f^{-1/2}$ (steeper than the unfloored
+    $f^{-1/4}$) and whose phase settles at $-45$ degrees, rather than the
+    unfloored $f^{-1/4}$/$-22.5$ degree tail. The immittance is checked first,
+    directly against $R_{dc}$, since that is the quantity #84 actually
+    introduces; the $Z_c$ asymptote is the derived consequence.
+    """
+    t = 35e-6
+    line = _wide_low_er_lossy_line(t=t, dispersion=dispersion)
+
+    dc = Frequency.from_f(jnp.array([1e-6]))
+    r_dc = 1.0 / (
+        line.substrate.conductor.properties(dc).sigma[0] * line.w * t
+    )
+    assert r_dc > 0.0
+
+    low = Frequency.from_f(jnp.geomspace(1e-4, 1e-2, 9))
+    R = line.immittance(low).R
+    assert jnp.allclose(R, r_dc, rtol=1e-3)
+
+    zc = line.zc_and_gammaL(low)[0]
+    scaled = jnp.abs(zc) * low.f ** 0.5
+    assert jnp.allclose(scaled, scaled[0], rtol=1e-2)
+    assert jnp.allclose(jnp.angle(zc, deg=True), -45.0, atol=1.0)


### PR DESCRIPTION
## Summary
- A finite-`t` microstrip line now gets a dc resistance floor `R_dc = rho/(W*t)`, blended smoothly with the skin-effect term as `sqrt(R_dc^2 + R_ac^2)` in `PlanarQuasiStaticResult.to_immittance`, fixing `R -> 0` as `f -> 0` for a trace of known thickness.
- `t=None` lines get no floor (skin effect is asserted in operation at every frequency including dc), matching ADS; the blend itself is documented as a ParamRF convention, with the ADS no-floor and mcalc/wcalc hard-switch alternatives noted, since no primary source prescribes one.

## Test plan
- [x] New unit test asserting `R -> R_dc` at dc for finite `t` and `R -> 0` for `t=None`.
- [x] New low-frequency `Zc` asymptote test: floored case settles to `f^(-1/2)`/`-45°`, unfloored case preserves `f^(-1/4)`/`-22.5°`.
- [x] Existing dispersion-routing test updated for the new floor on its finite-`t` case.
- [x] Full suite: `.venv/bin/python -m pytest` — 459 passed, 28 skipped.

Closes #84

https://claude.ai/code/session_01RDxmU6shKkXjqLLFLr68hm