### PR TITLE
Correct microstrip loss documentation

### DIFF
--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -567,8 +567,7 @@ class KirschningJansenMicrostripDispersion(AbstractMicrostripDispersion):
     $$P_4=1+2.751[1-e^{-(\varepsilon_r/15.916)^8}].$$
     The normalized frequency is
     $f_n=f[\mathrm{Hz}]H[\mathrm{m}]10^{-6}$ (GHz-mm).
-    Following the ADS convention adopted throughout ParamRF, the normalized
-    width is the thickness-corrected $u = W_{eff}/H$.
+    The normalized width is the thickness-corrected $u = W_{eff}/H$.
 
     Characteristic impedance is corrected by
     $$Z_c(f)=Z_c(0)\left(\frac{R_{13}}{R_{14}}\right)^{R_{17}},$$

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -314,10 +314,11 @@ class MicrostripLine(AbstractImmittanceLine):
     **Mathematical Formulation**
 
     The line evaluates material permittivity, a quasi-static formulation, and
-    then the optional modal-dispersion formulation. ParamRF carries permittivity
-    complex throughout, following the ADS/AWR convention, so the dielectric loss
-    is carried directly by the effective permittivity and needs no separate
-    attenuation term:
+    then the optional modal-dispersion formulation. ParamRF carries the complex
+    permittivity through the quasi-static and modal-dispersion formulations. This
+    keeps dielectric loss self-consistent with the effective-permittivity model:
+    the loss is carried directly by the effective permittivity and needs no
+    separate attenuation term:
     $$\gamma_m=\frac{j\omega}{c}\sqrt{\varepsilon_e(f)}.$$
 
     Static bulk conductivity is not folded into that permittivity, which would
@@ -328,6 +329,13 @@ class MicrostripLine(AbstractImmittanceLine):
 
     The substrate must be nonmagnetic. No cited microstrip formulation covers
     magnetic media, so $\mu_r \neq 1$ is rejected rather than silently ignored.
+
+    This treatment is consistent with ADS's documented treatment of permittivity
+    as a complex material property (ADS 2011.01, *Distributed Components*,
+    ``About Dielectric Loss Models``), but the vendor documentation does not
+    establish the dielectric-loss expression used here. The complex evaluation
+    is the exact loss perturbation of the effective-permittivity model, following
+    Schneider's energy-perturbation derivation.
 
     Wheeler's incremental-inductance rule (:func:`_wheeler_conductor_loss_factor`)
     is the single conductor-loss term charged on both paths:
@@ -421,6 +429,12 @@ class MicrostripLine(AbstractImmittanceLine):
     ----------
     Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
     IRE, 30(9), 412-424.
+
+    Schneider, M. V. (1969). Dielectric Loss in Integrated Microwave Circuits.
+    Bell System Technical Journal, 48(7).
+
+    Schneider, M. V. (1969). Microstrip Lines for Microwave Integrated Circuits.
+    Bell System Technical Journal, 48(5), 1421-1444.
 
     Kirschning, M., & Jansen, R. H. (1982). Accurate Model for Effective
     Dielectric Constant of Microstrip with Validity up to Millimeter-Wave
@@ -562,8 +576,8 @@ class MicrostripLine(AbstractImmittanceLine):
         Dispersed via ``dispersion`` when it is set, quasi-static otherwise —
         the same value :meth:`immittance` uses internally, so it is exposed
         here rather than recomputed by the caller. The imaginary part carries
-        the dielectric loss, following the ADS/AWR convention of carrying
-        permittivity complex throughout (see the class docstring and #79).
+        the dielectric loss because ParamRF carries complex permittivity through
+        the model (see the class docstring and #79).
 
         Parameters
         ----------

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -8,8 +8,10 @@ and the skin effect has not yet taken over — as well as microwave behaviour,
 and compares both the internal electrical quantities and the public
 S-parameters.
 
-**Scope.** ParamRF carries permittivity complex throughout, the ADS/AWR
-convention. Only the scikit-rf modes matching that convention are used:
+**Scope.** ParamRF carries permittivity complex throughout its microstrip
+formulations, which is consistent with ADS's documented treatment of permittivity
+as a complex material property. Only the scikit-rf modes with the same complex
+permittivity treatment are used:
 ``compatibility_mode=None`` for :class:`~skrf.media.MLine`, and the complex
 ``dielectric={'ep_r': ...}`` filling for :class:`~skrf.media.Coaxial`. QUCS
 compatibility is deliberately out of scope — ParamRF does not implement the
@@ -322,16 +324,20 @@ def _microstrip_pair(*, w, h, t, ep_r, tand, rho, dispersion, diel, formulation,
 # the two implementations, so the notes are written once and shared.
 _MICROSTRIP_NOTES = {
     "alpha": (
-        "Dielectric loss is modelled differently on the two sides, and this is "
-        "the expected consequence rather than an error. ParamRF evaluates the "
-        "quasi-static formulation at a complex permittivity, so its "
-        "attenuation is (w/2c)*ep_r*tand*(d ep_eff/d ep_r)/sqrt(ep_eff), the "
-        "exact derivative of the model actually in use. scikit-rf instead adds "
-        "the classical filling-factor term, pi*ep_r*(ep_eff-1)*tand/"
-        "((ep_r-1)*sqrt(ep_eff)*lambda_0), which assumes ep_eff is linear in "
-        "ep_r. Hammerstad-Jensen is not linear in ep_r, so the two differ by "
-        "up to about ten percent. The conductor term is identical on both "
-        "sides: Re(Zs)/(Re(Zc)*w) times Wheeler's current-distribution factor."
+        "The residual dielectric-loss difference has three causes. First, in the "
+        "quasi-static path, ParamRF uses the exact d ep_eff/d ep_r from the "
+        "complex effective-permittivity model, while scikit-rf uses the "
+        "linearised (ep_eff-1)/(ep_r-1) surrogate. Schneider's 1969 energy-"
+        "perturbation derivation supports ParamRF's derivative form; the "
+        "linearity difference accounts for only 0.25-0.88% across this matrix. "
+        "Second, dispersion can contribute up to about 3% and grows with "
+        "frequency: ParamRF evaluates Kirschning-Jansen at complex ep_eff, "
+        "whereas scikit-rf feeds dispersed real ep_reff into its quasi-static "
+        "filling factor and adds a_dielectric separately. With dispersion off "
+        "the gap is a flat 0.25%; with it on, it grows to 3.2%. Third, the "
+        "conductor-loss form formerly contributed up to about 9% in the "
+        "wide_low_er_lossy_quasi_static case; that difference was removed by "
+        "issue #82, so it should no longer contribute here."
     ),
     "beta": (
         "ParamRF takes beta = Im(w*sqrt(ep_eff)/c) from the complex effective "


### PR DESCRIPTION
## Summary

- Correct the unsupported ADS/AWR provenance claim in the microstrip documentation.
- Explain the three measured sources of alpha differences against scikit-rf.
- Add Schneider's 1969 dielectric-loss references.

Closes #85

## Verification

- `.venv/bin/python -m pytest tests/test_models/test_lines_skrf_matrix.py`
- `.venv/bin/python -c "import pmrf"`
- Full suite attempted; blocked by the environment's OpenMPI/PMIx initialization failure before pytest could run.
