### PR TITLE
Fix Sphinx build without linkify dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,7 +174,7 @@ napoleon_use_ivar = True
 napoleon_use_param = True
 
 # --- 6. Math & MyST Configuration --------------------------------------------
-myst_enable_extensions = ['colon_fence', 'deflist', 'linkify', 'dollarmath']
+myst_enable_extensions = ['colon_fence', 'deflist', 'dollarmath']
 
 math_dollar_node_blacklist = NODE_BLACKLIST + (sphinx.addnodes.pending_xref_condition,)
 


### PR DESCRIPTION
## Summary

- Remove the unused MyST `linkify` extension from the Sphinx configuration.
- Fix the documentation build failure when Sphinx reads Markdown research notes without `linkify-it-py` installed.

## Verification

- `git diff --check`
- `.venv/bin/python -m compileall -q pmrf`
- Confirmed the failure from the GitHub Actions log: `ModuleNotFoundError: Linkify enabled but not installed.`
