### PR TITLE
Standardise conductor materials on conductivity instead of resistivity

### DIFF
--- a/pmrf/materials/conductor.py
+++ b/pmrf/materials/conductor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 
+import equinox as eqx
 import jax.numpy as jnp
 from scipy.constants import mu_0
 
@@ -96,13 +97,12 @@ class BulkConductor(AbstractConductor):
     **Mathematical Formulation**
 
     $$Z_s(\omega) = \sqrt{\frac{j\omega\mu}{\sigma}}
-    = \sqrt{\frac{\omega\mu\rho}{2}}\,(1 + j)
     \qquad
-    \delta = \sqrt{\frac{2\rho}{\omega\mu}}$$
+    \delta = \sqrt{\frac{2}{\omega\mu\sigma}}$$
 
-    where $\mu = \mu_0\mu_r$ and $\sigma = 1/\rho$. The real part is the skin
-    resistance per square and the imaginary part is the internal reactance,
-    equal to it in this regime.
+    where $\mu = \mu_0\mu_r$. The real part is the skin resistance per square
+    and the imaginary part is the internal reactance, equal to it in this
+    regime.
 
     Example
     --------
@@ -111,7 +111,7 @@ class BulkConductor(AbstractConductor):
         import pmrf as prf
         from pmrf.materials import BulkConductor
 
-        copper = BulkConductor(rho=1.68e-8)
+        copper = BulkConductor(sigma=5.8e7)
         freq = prf.Frequency(start=1, stop=10, npoints=101, unit='ghz')
         zs = copper.properties(freq).zs
 
@@ -121,30 +121,30 @@ class BulkConductor(AbstractConductor):
 
     Parameters
     ----------
-    rho : Param, default=1.68e-8
-        Resistivity in ohm-meters. Defaults to copper.
+    sigma : Param, default=5.8e7
+        Conductivity in S/m. Defaults to copper.
     mu_r : Param, default=1.0
         Relative permeability of the conductor.
     """
-    #: Resistivity in ohm-meters
-    rho: Param = param(default=1.68e-8, constraint=Positive())
+    #: Conductivity in S/m
+    sigma: Param = param(default=5.8e7, constraint=Positive())
 
     #: Relative permeability of the conductor
     mu_r: Param = param(default=1.0, constraint=Positive())
 
     @classmethod
-    def from_sigma(cls, sigma, **kwargs):
-        """Build a conductor from a conductivity in S/m instead of a resistivity."""
-        return cls(rho=1.0 / sigma, **kwargs)
+    def from_rho(cls, rho, **kwargs):
+        """Build a conductor from a resistivity in ohm-meters instead of a conductivity."""
+        return cls(sigma=1.0 / rho, **kwargs)
 
     def properties(self, freq: Frequency) -> ConductorProperties:
         # sqrt is a branch point at w = 0, so guard it the same way: the
         # impedance is zero there, but its raw gradient would not be.
         w = jnp.asarray(freq.w)
         safe_w = jnp.where(w > 0, w, 1.0)
-        rs = jnp.where(w > 0, jnp.sqrt(safe_w * mu_0 * self.mu_r * self.rho / 2), 0.0)
+        rs = jnp.where(w > 0, jnp.sqrt(safe_w * mu_0 * self.mu_r / (2 * self.sigma)), 0.0)
         ones = jnp.ones(freq.npoints)
-        return ConductorProperties(rs * (1 + 1j), ones / self.rho, self.mu_r * ones)
+        return ConductorProperties(rs * (1 + 1j), self.sigma * ones, self.mu_r * ones)
 
 
 class RoughConductor(BulkConductor):
@@ -166,8 +166,8 @@ class RoughConductor(BulkConductor):
 
     Parameters
     ----------
-    rho : Param, default=1.68e-8
-        Resistivity in ohm-meters.
+    sigma : Param, default=5.8e7
+        Conductivity in S/m.
     mu_r : Param, default=1.0
         Relative permeability of the conductor.
     roughness : AbstractRoughness, default=HammerstadRoughness()
@@ -183,15 +183,15 @@ class RoughConductor(BulkConductor):
     def properties(self, freq: Frequency) -> ConductorProperties:
         properties = super().properties(freq)
         factor = self.roughness.factor(freq, properties.sigma, properties.mu_r)
-        return properties._replace(zs=properties.zs * factor)
+        return eqx.tree_at(lambda p: p.zs, properties, properties.zs * factor)
 
 
 def as_conductor(value) -> AbstractConductor:
     """
     Coerce a value into a conductor material.
 
-    Accepts an existing :class:`AbstractConductor` or a scalar resistivity in
-    ohm-meters, which builds a :class:`BulkConductor`.
+    Accepts an existing :class:`AbstractConductor` or a scalar conductivity in
+    S/m, which builds a :class:`BulkConductor`.
 
     Parameters
     ----------
@@ -202,7 +202,20 @@ def as_conductor(value) -> AbstractConductor:
     -------
     AbstractConductor
         The resulting conductor material.
+
+    Raises
+    ------
+    ValueError
+        If ``value`` falls in the resistivity regime (roughly 1e-8 to 1e-5
+        ohm-meters for metals) rather than the conductivity regime (roughly
+        1e5 to 1e8 S/m): the two are fifteen orders of magnitude apart, so
+        there is no ambiguous middle ground.
     """
     if isinstance(value, AbstractConductor):
         return value
-    return BulkConductor(rho=value)
+    if 0 < value < 1.0:
+        raise ValueError(
+            f"{value!r} looks like a resistivity in ohm-meters, not a "
+            "conductivity in S/m; use BulkConductor.from_rho() instead"
+        )
+    return BulkConductor(sigma=value)

--- a/pmrf/materials/conductor.py
+++ b/pmrf/materials/conductor.py
@@ -209,10 +209,18 @@ def as_conductor(value) -> AbstractConductor:
         If ``value`` falls in the resistivity regime (roughly 1e-8 to 1e-5
         ohm-meters for metals) rather than the conductivity regime (roughly
         1e5 to 1e8 S/m): the two are fifteen orders of magnitude apart, so
-        there is no ambiguous middle ground.
+        there is no ambiguous middle ground. Also raised for ``0``, which
+        was the old resistivity-based idiom for a perfect conductor and
+        would now silently build the opposite: an infinitely resistive one.
     """
     if isinstance(value, AbstractConductor):
         return value
+    if value == 0:
+        raise ValueError(
+            "0 is ambiguous as a conductivity: pass sigma=jnp.inf for a "
+            "perfect conductor, or BulkConductor.from_rho(0) if you meant "
+            "zero resistivity"
+        )
     if 0 < value < 1.0:
         raise ValueError(
             f"{value!r} looks like a resistivity in ohm-meters, not a "

--- a/pmrf/materials/substrate.py
+++ b/pmrf/materials/substrate.py
@@ -41,7 +41,7 @@ class Substrate(Module):
         The sheet material. A scalar permittivity or an ``(ep_r, tand)`` tuple is
         coerced into a :class:`~pmrf.materials.ConstantDielectric`.
     conductor : AbstractConductor, default=BulkConductor()
-        The metallization. A scalar resistivity in ohm-meters is coerced into a
+        The metallization. A scalar conductivity in S/m is coerced into a
         :class:`~pmrf.materials.BulkConductor`.
     t : Param | None, default=None
         Thickness of the metallization in meters, or ``None`` for a

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -244,7 +244,7 @@ class CoaxialLine(AbstractImmittanceLine):
             d_in=0.9e-3,
             d_out=2.95e-3,
             dielectric=ConstantDielectric(ep_r=1.5, tand=0.0004),
-            conductor=BulkConductor(rho=1.72e-8),
+            conductor=BulkConductor(sigma=5.8e7),
             length=0.5
         )
 
@@ -263,8 +263,8 @@ class CoaxialLine(AbstractImmittanceLine):
         coerced into a :class:`~pmrf.materials.ConstantDielectric`; a magnetic
         filling sets that material's ``mu_r``.
     conductor : AbstractConductor, default=BulkConductor()
-        The conductor material of both conductors. A scalar resistivity in
-        ohm-meters is coerced into a :class:`~pmrf.materials.BulkConductor`.
+        The conductor material of both conductors. A scalar conductivity in
+        S/m is coerced into a :class:`~pmrf.materials.BulkConductor`.
     formulation : AbstractCoaxialFormulation, default=TescheCoaxialFormulation()
         The closed-form physics used to compute the immittance.
     """
@@ -361,7 +361,7 @@ class MicrostripLine(AbstractImmittanceLine):
 
     The sheet model above gives $R\to0$ as $f\to0$, which is wrong for a
     trace of known thickness: a finite $t$ gets a dc floor
-    $R_{dc}=\rho/(Wt)$, blended smoothly with the skin-effect term as
+    $R_{dc}=1/(\sigma Wt)$, blended smoothly with the skin-effect term as
     $R=\sqrt{R_{dc}^2+R_{ac}^2}$ (see
     :meth:`~pmrf.models.components.lines.formulations.PlanarQuasiStaticResult.to_immittance`).
     $t=\text{None}$ gets no floor: it asserts skin effect in operation at
@@ -383,7 +383,7 @@ class MicrostripLine(AbstractImmittanceLine):
             w=4e-3,
             h=2.0e-3,
             dielectric=ConstantDielectric(ep_r=4.6, tand=0.025),
-            conductor=BulkConductor(rho=1.72e-8),
+            conductor=BulkConductor(sigma=5.8e7),
             length=0.5
         )
 
@@ -409,8 +409,8 @@ class MicrostripLine(AbstractImmittanceLine):
         The substrate material. A scalar permittivity or an ``(ep_r, tand)`` tuple
         is coerced into a :class:`~pmrf.materials.ConstantDielectric`.
     conductor : AbstractConductor, default=BulkConductor()
-        The material of the trace and ground plane. A scalar resistivity in
-        ohm-meters is coerced into a :class:`~pmrf.materials.BulkConductor`.
+        The material of the trace and ground plane. A scalar conductivity in
+        S/m is coerced into a :class:`~pmrf.materials.BulkConductor`.
     t : Param | None, default=None
         Thickness of the conductor. ``None`` means the thickness is
         unspecified, not that it is zero: skin effect is assumed to be in
@@ -563,7 +563,7 @@ class MicrostripLine(AbstractImmittanceLine):
         t = substrate.t
         # t=None asserts skin effect in operation at every frequency,
         # including dc, so there is no dc regime for a floor to describe; a
-        # finite t gets R_dc = rho/(W*t) = 1/(sigma*W*t).
+        # finite t gets R_dc = 1/(sigma*W*t).
         r_dc = None if t is None else 1.0 / (conductor.sigma * self.w * t)
         return self._resolved_quasi_static(freq).to_immittance(
             freq, dielectric, conductor, r_dc=r_dc
@@ -647,7 +647,7 @@ class StriplineLine(AbstractImmittanceLine):
             b=3.2e-3,
             t=35e-6,
             dielectric=ConstantDielectric(ep_r=2.2, tand=0.001),
-            conductor=BulkConductor(rho=1.72e-8),
+            conductor=BulkConductor(sigma=5.8e7),
             length=0.1,
         )
 
@@ -668,8 +668,8 @@ class StriplineLine(AbstractImmittanceLine):
         ``(ep_r, tand)`` tuple is coerced into a
         :class:`~pmrf.materials.ConstantDielectric`.
     conductor : AbstractConductor, default=BulkConductor()
-        The material of the strip and the ground planes. A scalar resistivity in
-        ohm-meters is coerced into a :class:`~pmrf.materials.BulkConductor`.
+        The material of the strip and the ground planes. A scalar conductivity in
+        S/m is coerced into a :class:`~pmrf.materials.BulkConductor`.
     formulation : AbstractStriplineFormulation, default=CohnStriplineFormulation()
         The closed-form physics used to compute the quasi-static solution.
 

--- a/tests/test_dc_limits.py
+++ b/tests/test_dc_limits.py
@@ -64,14 +64,14 @@ LINES = {
         d_in=0.9e-3,
         d_out=2.95e-3,
         dielectric=ConstantDielectric(ep_r=1.5, tand=4e-4),
-        conductor=BulkConductor(rho=1.72e-8),
+        conductor=BulkConductor(sigma=1 / 1.72e-8),
         length=0.5,
     ),
     "MicrostripLine": MicrostripLine(
         w=3e-3,
         h=1.6e-3,
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
-        conductor=BulkConductor(rho=1.72e-8),
+        conductor=BulkConductor(sigma=1 / 1.72e-8),
         length=0.1,
     ),
     "MicrostripLine (no dispersion)": MicrostripLine(
@@ -94,7 +94,7 @@ LINES = {
         b=3.2e-3,
         t=35e-6,
         dielectric=ConstantDielectric(ep_r=2.2, tand=0.001),
-        conductor=BulkConductor(rho=1.72e-8),
+        conductor=BulkConductor(sigma=1 / 1.72e-8),
         length=0.1,
     ),
     "StriplineLine (zero thickness)": StriplineLine(
@@ -115,8 +115,8 @@ MATERIALS = {
         ep_r=jnp.array([4.3 - 0.1j, 4.2 - 0.1j, 4.1 - 0.1j]),
         sigma=1e-3,
     ),
-    "BulkConductor": BulkConductor(rho=1.72e-8),
-    "RoughConductor": RoughConductor(rho=1.72e-8, roughness=HammerstadRoughness(1e-6)),
+    "BulkConductor": BulkConductor(sigma=1 / 1.72e-8),
+    "RoughConductor": RoughConductor(sigma=1 / 1.72e-8, roughness=HammerstadRoughness(1e-6)),
 }
 
 

--- a/tests/test_fitting_minimize.py
+++ b/tests/test_fitting_minimize.py
@@ -19,7 +19,7 @@ def truth_model():
         d_in=1.12e-3, 
         d_out=3.2e-3, 
         dielectric=ConstantDielectric(ep_r=1.384, tand=0.001),
-        conductor=BulkConductor(rho=1.6e-8),
+        conductor=BulkConductor(sigma=1 / 1.6e-8),
         length=0.1,  # This is the target length we want to find (10 cm)
     )
 
@@ -40,7 +40,7 @@ def starting_model():
         d_in=Fixed(1.12e-3),
         d_out=Fixed(3.2e-3),
         dielectric=ConstantDielectric(ep_r=Fixed(1.384), tand=Fixed(0.001)),
-        conductor=BulkConductor(rho=Fixed(1.6e-8)),
+        conductor=BulkConductor(sigma=Fixed(1 / 1.6e-8)),
         # Start at 9.5 cm to stay within a fraction of a wavelength of 10 cm
         length=Bounded(0.05, 0.15, value=0.095)
     )

--- a/tests/test_fitting_sample.py
+++ b/tests/test_fitting_sample.py
@@ -27,7 +27,7 @@ def truth_model():
         d_in=1.12e-3, 
         d_out=3.2e-3, 
         dielectric=ConstantDielectric(ep_r=1.384, tand=0.001),
-        conductor=BulkConductor(rho=1.6e-8),
+        conductor=BulkConductor(sigma=1 / 1.6e-8),
         length=0.1,  # Target length
     )
 
@@ -44,7 +44,7 @@ def starting_model():
         d_in=Fixed(1.12e-3),
         d_out=Fixed(3.2e-3),
         dielectric=ConstantDielectric(ep_r=Fixed(1.384), tand=Fixed(0.001)),
-        conductor=BulkConductor(rho=Fixed(1.6e-8)),
+        conductor=BulkConductor(sigma=Fixed(1 / 1.6e-8)),
         # Normal prior centered at 0.1 with standard deviation 0.05
         length=Random(Normal(0.1, 0.05), value=jnp.array(0.095))
     )

--- a/tests/test_materials/test_conductor.py
+++ b/tests/test_materials/test_conductor.py
@@ -147,3 +147,9 @@ def test_as_conductor_converters():
 def test_as_conductor_rejects_resistivity_regime_scalar():
     with pytest.raises(ValueError, match="from_rho"):
         as_conductor(1.68e-8)
+
+
+def test_as_conductor_rejects_zero():
+    """0 was the old rho idiom for a perfect conductor; as a sigma it means the opposite."""
+    with pytest.raises(ValueError, match="ambiguous"):
+        as_conductor(0.0)

--- a/tests/test_materials/test_conductor.py
+++ b/tests/test_materials/test_conductor.py
@@ -15,7 +15,7 @@ from pmrf.materials import (
 
 
 def test_conductor_exposes_one_property_record(freq):
-    conductor = BulkConductor(rho=1.68e-8, mu_r=2.0)
+    conductor = BulkConductor(sigma=1 / 1.68e-8, mu_r=2.0)
 
     properties = conductor.properties(freq)
 
@@ -32,10 +32,10 @@ def freq():
 
 
 def test_bulk_surface_impedance(freq):
-    rho = 1.68e-8
-    zs = BulkConductor(rho).properties(freq).zs
+    sigma = 1 / 1.68e-8
+    zs = BulkConductor(sigma).properties(freq).zs
 
-    expected = jnp.sqrt(1j * freq.w * mu_0 / (1 / rho))
+    expected = jnp.sqrt(1j * freq.w * mu_0 / sigma)
     assert zs.shape == (freq.npoints,)
     assert jnp.allclose(zs, expected)
     # Real and imaginary parts are equal in the strong skin-effect regime.
@@ -43,25 +43,24 @@ def test_bulk_surface_impedance(freq):
 
 
 def test_bulk_sigma(freq):
-    rho = 1.68e-8
-    conductor = BulkConductor(rho)
-    assert jnp.allclose(conductor.properties(freq).sigma, 1 / rho)
+    sigma = 1 / 1.68e-8
+    conductor = BulkConductor(sigma)
+    assert jnp.allclose(conductor.properties(freq).sigma, sigma)
 
 
 def test_bulk_permeability(freq):
-    assert jnp.allclose(BulkConductor(1.68e-8, mu_r=4.0).properties(freq).mu_r, 4.0)
+    assert jnp.allclose(BulkConductor(1 / 1.68e-8, mu_r=4.0).properties(freq).mu_r, 4.0)
 
 
-def test_bulk_from_sigma(freq):
-    assert jnp.allclose(BulkConductor.from_sigma(5.8e7).rho, 1 / 5.8e7)
+def test_bulk_from_rho(freq):
+    assert jnp.allclose(BulkConductor.from_rho(1 / 5.8e7).sigma, 5.8e7)
 
 
 def test_bulk_reproduces_tesche_skin_terms(freq):
     """Re(Zs)/(2*pi*a) is the Tesche per-conductor skin resistance."""
-    rho, a = 1.68e-8, 0.56e-3
-    sigma = 1 / rho
+    sigma, a = 1 / 1.68e-8, 0.56e-3
 
-    zs = BulkConductor(rho).properties(freq).zs
+    zs = BulkConductor(sigma).properties(freq).zs
     R_skin = (1 / (2 * jnp.pi * a)) * jnp.sqrt(freq.w * mu_0 / (2 * sigma))
     L_skin = (1 / (2 * jnp.pi * a)) * jnp.sqrt(mu_0 / (2 * freq.w * sigma))
 
@@ -72,27 +71,28 @@ def test_bulk_reproduces_tesche_skin_terms(freq):
 def test_bulk_reproduces_wheeler_resistance(freq):
     """Wheeler's R = (1/W)*sqrt(2*mu_0*rho*w) is two squares of Re(Zs)."""
     rho, W = 1.68e-8, 3e-3
-    zs = BulkConductor(rho).properties(freq).zs
+    zs = BulkConductor(1 / rho).properties(freq).zs
     R_wheeler = (1 / W) * jnp.sqrt(2 * mu_0 * rho * freq.w)
     assert jnp.allclose(2 * jnp.real(zs) / W, R_wheeler)
 
 
 def test_bulk_permeability_scaling(freq):
-    plain = BulkConductor(1.68e-8).properties(freq).zs
-    magnetic = BulkConductor(1.68e-8, mu_r=4.0).properties(freq).zs
+    plain = BulkConductor(1 / 1.68e-8).properties(freq).zs
+    magnetic = BulkConductor(1 / 1.68e-8, mu_r=4.0).properties(freq).zs
     assert jnp.allclose(magnetic, 2.0 * plain)
 
 
 def test_smooth_rough_conductor_is_bulk(freq):
-    rough = RoughConductor(1.68e-8, roughness=0.0)
+    sigma = 1 / 1.68e-8
+    rough = RoughConductor(sigma, roughness=0.0)
     assert jnp.allclose(
-        rough.properties(freq).zs, BulkConductor(1.68e-8).properties(freq).zs
+        rough.properties(freq).zs, BulkConductor(sigma).properties(freq).zs
     )
 
 
 def test_roughness_increases_loss_and_saturates(freq):
-    rho = 1.68e-8
-    rough = RoughConductor(rho, roughness=1e-6)
+    sigma = 1 / 1.68e-8
+    rough = RoughConductor(sigma, roughness=1e-6)
     properties = rough.properties(freq)
     factor = rough.roughness.factor(freq, properties.sigma, properties.mu_r)
 
@@ -100,13 +100,13 @@ def test_roughness_increases_loss_and_saturates(freq):
     assert jnp.all(factor < 2.0)
     # Rougher surfaces lose more, and the factor grows with frequency.
     assert jnp.all(jnp.diff(factor) > 0)
-    assert jnp.allclose(rough.properties(freq).zs, factor * BulkConductor(rho).properties(freq).zs)
+    assert jnp.allclose(rough.properties(freq).zs, factor * BulkConductor(sigma).properties(freq).zs)
 
 
 def test_conductor_gradients_are_finite(freq):
     dc = Frequency.from_f(jnp.array([0.0, 1e9]))
 
-    for material in (BulkConductor(1.68e-8), RoughConductor(1.68e-8, roughness=1e-6)):
+    for material in (BulkConductor(1 / 1.68e-8), RoughConductor(1 / 1.68e-8, roughness=1e-6)):
         for axis in (freq, dc):
             grads = jax.grad(
                 lambda m: jnp.sum(jnp.abs(m.properties(axis).zs))
@@ -119,11 +119,11 @@ def test_unconstrained_gradients_are_finite_at_dc():
     """The bare sqrt at w = 0 must be guarded, not just masked by a constraint."""
     dc = Frequency.from_f(jnp.array([0.0, 1e9]))
 
-    def loss(rho):
-        conductor = BulkConductor(rho=prf.Unconstrained(rho))
+    def loss(sigma):
+        conductor = BulkConductor(sigma=prf.Unconstrained(sigma))
         return jnp.sum(jnp.real(conductor.properties(dc).zs))
 
-    assert jnp.isfinite(jax.grad(loss)(1.68e-8))
+    assert jnp.isfinite(jax.grad(loss)(1 / 1.68e-8))
 
 
 def test_abstract_conductor_is_an_abc():
@@ -133,12 +133,17 @@ def test_abstract_conductor_is_an_abc():
 
 
 def test_roughness_formulation_is_swappable():
-    conductor = RoughConductor(1.68e-8, roughness=HammerstadRoughness(2e-6))
+    conductor = RoughConductor(1 / 1.68e-8, roughness=HammerstadRoughness(2e-6))
     assert isinstance(conductor.roughness, HammerstadRoughness)
     assert jnp.allclose(conductor.roughness.roughness, 2e-6)
 
 
 def test_as_conductor_converters():
-    assert jnp.allclose(as_conductor(1.68e-8).rho, 1.68e-8)
-    rough = RoughConductor(1.68e-8, roughness=1e-6)
+    assert jnp.allclose(as_conductor(5.8e7).sigma, 5.8e7)
+    rough = RoughConductor(5.8e7, roughness=1e-6)
     assert as_conductor(rough) is rough
+
+
+def test_as_conductor_rejects_resistivity_regime_scalar():
+    with pytest.raises(ValueError, match="from_rho"):
+        as_conductor(1.68e-8)

--- a/tests/test_materials/test_serialization.py
+++ b/tests/test_materials/test_serialization.py
@@ -20,8 +20,8 @@ MATERIALS = [
     MultipoleDebye(ep_inf=2.0, poles=[(1.0, 1e9), (0.5, 1e10)]),
     ColeCole(2.0, 1.0, 1e9, 0.3),
     TabulatedDielectric(f=jnp.array([1e9, 2e9]), ep_r=jnp.array([4.0 - 0.1j, 3.8 - 0.2j])),
-    BulkConductor(1.68e-8),
-    RoughConductor(1.68e-8, roughness=1e-6),
+    BulkConductor(5.8e7),
+    RoughConductor(5.8e7, roughness=1e-6),
 ]
 
 

--- a/tests/test_materials/test_substrate.py
+++ b/tests/test_materials/test_substrate.py
@@ -18,7 +18,7 @@ def freq():
 
 def test_substrate_coerces_loose_materials():
     """Scalars are coerced by the same converters the lines use."""
-    substrate = Substrate(h=1.6e-3, dielectric=4.3, conductor=1.72e-8)
+    substrate = Substrate(h=1.6e-3, dielectric=4.3, conductor=5.8e7)
 
     assert isinstance(substrate.dielectric, ConstantDielectric)
     assert isinstance(substrate.conductor, BulkConductor)
@@ -71,7 +71,7 @@ def test_microstrip_substrate_and_loose_forms_are_identical(freq):
         w=3e-3,
         h=1.6e-3,
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
-        conductor=BulkConductor(rho=1.72e-8),
+        conductor=BulkConductor(sigma=1 / 1.72e-8),
         length=0.1,
     )
     grouped = MicrostripLine(
@@ -79,7 +79,7 @@ def test_microstrip_substrate_and_loose_forms_are_identical(freq):
         substrate=Substrate(
             h=1.6e-3,
             dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
-            conductor=BulkConductor(rho=1.72e-8),
+            conductor=BulkConductor(sigma=1 / 1.72e-8),
         ),
         length=0.1,
     )

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -127,7 +127,7 @@ def test_coaxial_line_impedance(basic_freq):
         d_in=0.9e-3,
         d_out=2.95e-3,
         dielectric=ConstantDielectric(ep_r=2.25, tand=0.0),
-        conductor=BulkConductor(rho=0.0),
+        conductor=BulkConductor(sigma=jnp.inf),
         length=1.0,
     )
     
@@ -150,7 +150,7 @@ def test_coaxial_static_conductivity_has_analytic_dc_conductance():
         d_in=d_in,
         d_out=d_out,
         dielectric=ConstantDielectric(ep_r=2.25, sigma=sigma),
-        conductor=BulkConductor(rho=0.0),
+        conductor=BulkConductor(sigma=jnp.inf),
         length=1.0,
     )
 
@@ -173,7 +173,7 @@ def test_coaxial_permeability_comes_from_the_dielectric(basic_freq):
             d_in=0.9e-3,
             d_out=2.95e-3,
             dielectric=dielectric,
-            conductor=BulkConductor(rho=0.0),
+            conductor=BulkConductor(sigma=jnp.inf),
             length=1.0,
         )
 
@@ -195,15 +195,17 @@ def test_coaxial_magnetic_loss_enters_the_series_resistance(basic_freq):
     class LossyMagnetic(ConstantDielectric):
         def properties(self, freq):
             properties = super().properties(freq)
-            return properties._replace(
-                mu_r=(4.0 - 0.5j) * jnp.ones(freq.npoints, dtype=complex)
+            return eqx.tree_at(
+                lambda p: p.mu_r,
+                properties,
+                (4.0 - 0.5j) * jnp.ones(freq.npoints, dtype=complex),
             )
 
     line = CoaxialLine(
         d_in=0.9e-3,
         d_out=2.95e-3,
         dielectric=LossyMagnetic(ep_r=2.25, tand=0.0),
-        conductor=BulkConductor(rho=0.0),
+        conductor=BulkConductor(sigma=jnp.inf),
         length=1.0,
     )
     immittance = line.immittance(basic_freq)
@@ -217,24 +219,24 @@ def test_coaxial_magnetic_loss_enters_the_series_resistance(basic_freq):
 
 
 def test_microstrip_line_default_construction_has_conductor_loss(basic_freq):
-    """A default-constructed line has nonzero, rho-sensitive attenuation.
+    """A default-constructed line has nonzero, sigma-sensitive attenuation.
 
     Regression for the bug where Wheeler's conductor-loss correction was
     guarded on `substrate.t is not None`, and `t` defaults to `None`: a
     default-constructed line (dispersion=KirschningJansenMicrostripDispersion,
-    t=None) had `rho` completely inert.
+    t=None) had `sigma` completely inert.
     """
-    def alpha(rho):
+    def alpha(sigma):
         line = MicrostripLine(
             dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
-            conductor=BulkConductor(rho=rho),
+            conductor=BulkConductor(sigma=sigma),
             length=0.1,
         )
         _, gamma_length = line.zc_and_gammaL(basic_freq)
         return jnp.real(gamma_length / line.length)
 
-    alpha_lossless = alpha(0.0)
-    alpha_lossy = alpha(1.68e-8)
+    alpha_lossless = alpha(jnp.inf)
+    alpha_lossy = alpha(1 / 1.68e-8)
 
     assert jnp.all(alpha_lossless == 0.0)
     assert jnp.all(alpha_lossy > alpha_lossless)
@@ -247,7 +249,7 @@ def test_microstrip_line_impedance(basic_freq):
         w=3.0e-3,
         h=1.6e-3,
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
-        conductor=BulkConductor(rho=0.0),
+        conductor=BulkConductor(sigma=jnp.inf),
         dispersion=None,
         length=0.1,
     )
@@ -275,7 +277,7 @@ def test_microstrip_line_ep_eff_and_w_eff_match_immittance_pipeline(basic_freq, 
         w=w,
         h=h,
         dielectric=ConstantDielectric(ep_r=ep_r, tand=0.01),
-        conductor=BulkConductor(rho=1.68e-8),
+        conductor=BulkConductor(sigma=1 / 1.68e-8),
         dispersion=dispersion,
         length=0.1,
     )
@@ -313,7 +315,7 @@ def test_microstrip_finite_thickness_has_dc_resistance_floor():
     floored = MicrostripLine(
         w=w, h=h, t=t,
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
-        conductor=BulkConductor(rho=rho),
+        conductor=BulkConductor(sigma=1 / rho),
         formulation=HammerstadJensenMicrostripFormulation(),
         length=0.1,
     )
@@ -323,7 +325,7 @@ def test_microstrip_finite_thickness_has_dc_resistance_floor():
     unfloored = MicrostripLine(
         w=w, h=h, t=None,
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
-        conductor=BulkConductor(rho=rho),
+        conductor=BulkConductor(sigma=1 / rho),
         length=0.1,
     )
     assert jnp.allclose(unfloored.immittance(dc).R, 0.0)
@@ -331,7 +333,7 @@ def test_microstrip_finite_thickness_has_dc_resistance_floor():
 
 def test_material_coercion():
     """Scalars and tuples coerce into the corresponding material modules."""
-    line = CoaxialLine(dielectric=(2.25, 0.001), conductor=1.68e-8, length=0.1)
+    line = CoaxialLine(dielectric=(2.25, 0.001), conductor=5.8e7, length=0.1)
 
     assert isinstance(line.dielectric, ConstantDielectric)
     assert isinstance(line.conductor, BulkConductor)
@@ -384,9 +386,9 @@ def test_coaxial_internal_impedance_tube():
 
 def test_rough_conductor_is_passed_to_coaxial_formulation():
     freq = Frequency.from_f(jnp.array([1e6, 1e9]))
-    smooth = CoaxialLine(conductor=BulkConductor(1.68e-8), length=0.1)
+    smooth = CoaxialLine(conductor=BulkConductor(1 / 1.68e-8), length=0.1)
     rough = CoaxialLine(
-        conductor=RoughConductor(1.68e-8, roughness=1e-6), length=0.1
+        conductor=RoughConductor(1 / 1.68e-8, roughness=1e-6), length=0.1
     )
     assert jnp.all(rough.immittance(freq).R > smooth.immittance(freq).R)
 
@@ -433,7 +435,7 @@ def test_dispersive_dielectric_is_grid_independent():
         d_in=0.9e-3,
         d_out=2.95e-3,
         dielectric=DjordjevicSarkar(ep_r=4.3, tand=0.02),
-        conductor=BulkConductor(rho=1.68e-8),
+        conductor=BulkConductor(sigma=1 / 1.68e-8),
         length=0.1,
     )
 
@@ -491,7 +493,7 @@ def test_dispersive_microstrip_routes_through_planar_quasi_static_to_immittance(
         h=0.5e-3,
         t=18e-6,
         dielectric=ConstantDielectric(ep_r=10.0, tand=0.05),
-        conductor=BulkConductor(rho=1e-6),
+        conductor=BulkConductor(sigma=1e6),
         formulation=formulation,
         dispersion=dispersion,
         length=0.1,
@@ -536,7 +538,7 @@ def test_microstrip_without_dispersion_preserves_quasi_static_immittance():
         w=3e-3,
         h=1.6e-3,
         dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
-        conductor=BulkConductor(rho=1.72e-8),
+        conductor=BulkConductor(sigma=1 / 1.72e-8),
         dispersion=None,
         length=0.1,
     )
@@ -585,7 +587,7 @@ def test_microstrip_dispersion_is_a_pure_dispersion_toggle():
             h=1.6e-3,
             t=35e-6,
             dielectric=ConstantDielectric(ep_r=4.3, tand=0.02),
-            conductor=BulkConductor(rho=1.72e-8),
+            conductor=BulkConductor(sigma=1 / 1.72e-8),
             formulation=HammerstadJensenMicrostripFormulation(),
             dispersion=dispersion,
             length=0.1,
@@ -649,7 +651,7 @@ def test_microstrip_near_air_has_finite_conductance_and_gradient():
             w=1e-3,
             h=1e-3,
             dielectric=ConstantDielectric(ep_r=ep_r, tand=0.02),
-            conductor=BulkConductor(rho=0.0),
+            conductor=BulkConductor(sigma=jnp.inf),
             length=0.1,
         )
         return jnp.real(line.s(freq)[-1, 0, 0])
@@ -658,7 +660,7 @@ def test_microstrip_near_air_has_finite_conductance_and_gradient():
         w=1e-3,
         h=1e-3,
         dielectric=ConstantDielectric(ep_r=1.0 + 1e-12, tand=0.02),
-        conductor=BulkConductor(rho=0.0),
+        conductor=BulkConductor(sigma=jnp.inf),
         length=0.1,
     )
     near_air_g = near_air.immittance(freq).G
@@ -666,7 +668,7 @@ def test_microstrip_near_air_has_finite_conductance_and_gradient():
         w=1e-3,
         h=1e-3,
         dielectric=ConstantDielectric(ep_r=1.0 + 2e-12, tand=0.02),
-        conductor=BulkConductor(rho=0.0),
+        conductor=BulkConductor(sigma=jnp.inf),
         length=0.1,
     ).immittance(freq).G
     assert jnp.all(jnp.isfinite(near_air_g))
@@ -748,7 +750,7 @@ def test_stripline_impedance_matches_pozar_design_example():
         w=w_over_b * b,
         b=b,
         dielectric=2.2,
-        conductor=BulkConductor(rho=0.0),
+        conductor=BulkConductor(sigma=jnp.inf),
         length=0.1,
     )
 
@@ -766,7 +768,7 @@ def test_stripline_dielectric_loss_is_the_homogeneous_limit():
         w=2.655e-3,
         b=3.2e-3,
         dielectric=ConstantDielectric(ep_r=2.2, tand=tand),
-        conductor=BulkConductor(rho=0.0),
+        conductor=BulkConductor(sigma=jnp.inf),
         length=1.0,
     )
 
@@ -785,15 +787,15 @@ def test_stripline_attenuation_matches_pozar_worked_example():
 
     freq = Frequency(start=10.0, stop=10.0, npoints=1, unit="GHz")
     geometry = dict(w=2.655e-3, b=3.2e-3, t=1e-5, length=1.0)
-    copper = BulkConductor(rho=1.72e-8)
+    copper = BulkConductor(sigma=1 / 1.72e-8)
 
     lossless = StriplineLine(
-        dielectric=2.2, conductor=BulkConductor(rho=0.0), **geometry
+        dielectric=2.2, conductor=BulkConductor(sigma=jnp.inf), **geometry
     )
     conductor_only = StriplineLine(dielectric=2.2, conductor=copper, **geometry)
     dielectric_only = StriplineLine(
         dielectric=ConstantDielectric(ep_r=2.2, tand=0.001),
-        conductor=BulkConductor(rho=0.0),
+        conductor=BulkConductor(sigma=jnp.inf),
         **geometry,
     )
 
@@ -814,7 +816,7 @@ def test_stripline_conductor_loss_scales_with_root_frequency():
         b=3.2e-3,
         t=35e-6,
         dielectric=2.2,
-        conductor=BulkConductor(rho=1.72e-8),
+        conductor=BulkConductor(sigma=1 / 1.72e-8),
         length=1.0,
     )
 
@@ -855,7 +857,7 @@ def test_stripline_narrow_strip_uses_the_fringing_correction():
     freq = Frequency(start=10.0, stop=10.0, npoints=1, unit="GHz")
     b = 3.2e-3
     narrow = StriplineLine(
-        w=0.2 * b, b=b, dielectric=2.2, conductor=BulkConductor(rho=0.0), length=0.1
+        w=0.2 * b, b=b, dielectric=2.2, conductor=BulkConductor(sigma=jnp.inf), length=0.1
     )
 
     w_e = 0.2 * b - (0.35 - 0.2) ** 2 * b
@@ -869,7 +871,7 @@ def test_stripline_high_impedance_branch_is_selected():
 
     freq = Frequency(start=10.0, stop=10.0, npoints=1, unit="GHz")
     geometry = dict(b=3.2e-3, t=35e-6, dielectric=2.2, length=1.0)
-    copper = BulkConductor(rho=1.72e-8)
+    copper = BulkConductor(sigma=1 / 1.72e-8)
 
     narrow = StriplineLine(w=0.2e-3, conductor=copper, **geometry)
     wide = StriplineLine(w=2.655e-3, conductor=copper, **geometry)

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -169,18 +169,25 @@ def _skrf_djordjevic_sarkar(*, ep_r, tand):
     return ep_r_of_f
 
 
+def _sigma_of_rho(rho):
+    """Conductivity equivalent of a resistivity, with the perfect-conductor limit at rho=0."""
+    return np.inf if rho == 0.0 else 1 / rho
+
+
 def _coax_pair(d_in, d_out, dielectric, rho, ep_r_of_f):
     """A ParamRF/scikit-rf builder pair for one coaxial geometry."""
+    sigma = _sigma_of_rho(rho)
+
     def line(length):
         return CoaxialLine(
             d_in=d_in, d_out=d_out, dielectric=dielectric,
-            conductor=BulkConductor(rho=rho), length=length,
+            conductor=BulkConductor(sigma=sigma), length=length,
         )
 
     def media(freq, z0_port=None):
         return Coaxial(
             freq, Dint=d_in, Dout=d_out, model="tesche", z0_port=z0_port,
-            sigma=np.inf if rho == 0.0 else 1 / rho,
+            sigma=sigma,
             dielectric={"ep_r": ep_r_of_f(np.asarray(freq.f))},
         )
 
@@ -302,7 +309,7 @@ def _microstrip_pair(*, w, h, t, ep_r, tand, rho, dispersion, diel, formulation,
         )
         return MicrostripLine(
             w=w, h=h, t=t, dielectric=dielectric,
-            conductor=BulkConductor(rho=rho),
+            conductor=BulkConductor(sigma=_sigma_of_rho(rho)),
             formulation=formulation(),
             dispersion=None if dispersion is None else dispersion(),
             length=length,


### PR DESCRIPTION
## Summary
- `BulkConductor`/`RoughConductor` are now constructed with `sigma` (S/m, copper default `5.8e7`) instead of `rho`, matching what `ConductorProperties` already reports; the reciprocal previously done in `properties()` is gone.
- `from_rho()` replaces `from_sigma()` as the convenience constructor for resistivity-sourced data (foil/plating datasheets).
- `as_conductor` and the `conductor=` shorthand on `CoaxialLine`, `MicrostripLine` and `StriplineLine` now interpret a scalar as a conductivity, and raise (naming `from_rho()`) for a value in the resistivity regime, and separately for `0` (the old `rho=0` "perfect conductor" idiom, which would otherwise silently build an infinitely resistive conductor instead).
- Docstrings, `#:` field comments and `**Mathematical Formulation**` blocks describe conductivity directly, with `References` sections kept.
- Also fixes a pre-existing, unrelated bug hit while touching `RoughConductor.properties()`: `ConductorProperties`/`DielectricProperties` are `eqx.Module`, not `NamedTuple`, so `._replace()` never worked on them — replaced with `eqx.tree_at()`.

## Test plan
- [x] `.venv/bin/python -m pytest` — 460 passed, 28 skipped
- [x] scikit-rf comparison tests pass at their existing recorded tolerances (none widened)
- [x] New test covering the resistivity-regime rejection and the `0` rejection in `as_conductor`
- [x] `/code-review` (Standards + Spec sub-agents) run against the diff; no hard violations found, one edge case (`as_conductor(0)`) fixed per spec review

Closes #94