### PR TITLE
Introduce the conductor cross-section shape layer, with coax as its first consumer

### DIFF
--- a/pmrf/materials/__init__.py
+++ b/pmrf/materials/__init__.py
@@ -32,6 +32,12 @@ from pmrf.materials.conductor import (
     RoughConductor as RoughConductor,
     as_conductor as as_conductor,
 )
+from pmrf.materials.conductor_shape import (
+    AbstractConductorShape as AbstractConductorShape,
+    HalfSpaceShape as HalfSpaceShape,
+    TescheRodShape as TescheRodShape,
+    TescheTubeShape as TescheTubeShape,
+)
 
 __all__ = [
     "AbstractDielectric",
@@ -50,6 +56,10 @@ __all__ = [
     "HammerstadRoughness",
     "RoughConductor",
     "as_conductor",
+    "AbstractConductorShape",
+    "HalfSpaceShape",
+    "TescheRodShape",
+    "TescheTubeShape",
     "Substrate",
     "as_substrate",
 ]

--- a/pmrf/materials/conductor_shape.py
+++ b/pmrf/materials/conductor_shape.py
@@ -1,0 +1,174 @@
+r"""
+Conductor cross-section shapes.
+
+A shape formulation is the layer between a conductor material and a line's
+geometry. Given the metal's intrinsic surface impedance
+$\zeta_c=\sqrt{j\omega\mu/\sigma}$ and a cross-section shape, it answers one
+question: what is the surface impedance, in ohm per square? Every entry
+returns $\zeta_c$ times a dimensionless shape factor; the geometry weight
+that turns this into a per-unit-length series impedance (e.g. $1/2\pi a$ for
+a round conductor) is supplied by the caller, not folded in here. This is
+what lets a coaxial shield and a microstrip trace share the same
+finite-thickness physics.
+"""
+from abc import abstractmethod
+
+import equinox as eqx
+import jax.numpy as jnp
+from scipy.constants import mu_0
+
+
+class AbstractConductorShape(eqx.Module):
+    r"""
+    Abstract base class for a conductor cross-section shape formulation.
+
+    A shape formulation is pure numerics, like a line
+    :mod:`~pmrf.models.components.lines.formulations` strategy: every
+    argument arrives as an already-evaluated array, so it can be checked
+    directly against the equations of the paper it comes from with no
+    ParamRF objects in sight. Concrete shapes differ in the geometry they
+    need -- a rod takes a radius, a tube a radius and a wall thickness, a
+    half-space none -- so only the common material arguments are fixed here.
+    """
+    @abstractmethod
+    def impedance(self, w, zeta_c, sigma, mu_r, **geometry) -> jnp.ndarray:
+        r"""
+        Return the surface impedance of this shape, in ohm per square.
+
+        Parameters
+        ----------
+        w : ArrayLike
+            Angular frequency in rad/s.
+        zeta_c : jnp.ndarray
+            Complex intrinsic surface impedance of the metal,
+            $\zeta_c=\sqrt{j\omega\mu/\sigma}$, in ohm per square.
+        sigma : jnp.ndarray
+            Bulk conductivity in S/m.
+        mu_r : jnp.ndarray
+            Relative permeability of the conductor.
+        **geometry
+            Shape-specific cross-section dimensions, in meters.
+
+        Returns
+        -------
+        jnp.ndarray
+            Surface impedance in ohm per square.
+        """
+        raise NotImplementedError
+
+
+class HalfSpaceShape(AbstractConductorShape):
+    r"""
+    Leontovich half-space boundary: the trivial shape factor.
+
+    **Mathematical Formulation**
+
+    $$Z_s = \zeta_c$$
+
+    A locally flat conductor carries no cross-section of its own, so the
+    surface impedance is the metal's intrinsic impedance, unweighted. Every
+    other shape in this layer approaches this one in the strong-skin limit,
+    where the skin depth is small compared to the radius of curvature.
+
+    **Validity**
+
+    Exact for a genuine half-space, and a good approximation for any surface
+    whose radius of curvature is large compared to the skin depth -- which is
+    also the regime every curved shape below converges to.
+
+    References
+    ----------
+    Leontovich, M. A. (1948). Approximate boundary conditions for the
+    electromagnetic field on the surface of a well-conducting medium, in
+    Investigations of Radiowave Propagation, Part II, 5-12. Academy of
+    Sciences, USSR.
+    """
+    def impedance(self, w, zeta_c, sigma, mu_r) -> jnp.ndarray:
+        return zeta_c
+
+
+def _tesche_circuit_impedance(zeta_c, r_dc_sq, l_int_sq, w):
+    """Blend Tesche's dc and high-frequency limits through his equivalent circuit."""
+    safe_w = jnp.where(w > 0, w, 1.0)
+    z = r_dc_sq + zeta_c / (1 + zeta_c / (1j * safe_w * l_int_sq))
+    return jnp.where(w > 0, z, r_dc_sq)
+
+
+class TescheRodShape(AbstractConductorShape):
+    r"""
+    Solid round conductor, via Tesche's equivalent circuit.
+
+    **Mathematical Formulation**
+
+    Tesche's circuit blends the exact per-unit-length dc resistance and
+    internal inductance of a round conductor,
+    $$R_{dc} = \frac{1}{\pi a^2\sigma},\qquad L_{int} = \frac{\mu}{8\pi},$$
+    into $Z = R_{dc} + \zeta_c/2\pi a\big/[1 + (\zeta_c/2\pi a)/(j\omega
+    L_{int})]$. This layer returns the equivalent surface impedance
+    $2\pi a Z$, so that the caller's own $1/2\pi a$ geometry weight
+    reproduces $Z$ exactly:
+    $$Z_s = R_{dc,sq} + \frac{\zeta_c}{1+\zeta_c/(j\omega L_{int,sq})},
+    \qquad R_{dc,sq}=\frac{2}{a\sigma},\quad L_{int,sq}=\frac{\mu a}{4}.$$
+
+    **Validity**
+
+    Interpolates between the exact dc resistance and the exact
+    high-frequency skin-effect impedance of a round conductor, so it carries
+    no geometric fit range. It is not exact at finite frequency: unlike a
+    genuine half-space, its strong-skin limit is not $\zeta_c$ but
+    $\zeta_c + R_{dc,sq}$ -- a known, persistent defect of the circuit
+    approximation, not a porting error (see ``tests/test_materials/
+    test_conductor_shape.py`` for the size of the departure).
+
+    References
+    ----------
+    Tesche, F. M. (2007). A Simple Model for the Line Parameters of a Lossy
+    Coaxial Cable Filled With a Nondispersive Dielectric. IEEE Transactions
+    on Electromagnetic Compatibility, 49(1), 12-17.
+    """
+    def impedance(self, w, zeta_c, sigma, mu_r, *, radius) -> jnp.ndarray:
+        r_dc_sq = 2 / (radius * sigma)
+        l_int_sq = mu_0 * mu_r * radius / 4
+        return _tesche_circuit_impedance(zeta_c, r_dc_sq, l_int_sq, w)
+
+
+class TescheTubeShape(AbstractConductorShape):
+    r"""
+    Tubular conductor of finite wall thickness, via Tesche's equivalent circuit.
+
+    **Mathematical Formulation**
+
+    With $q=(a/(a+t))^2$, the tube's per-unit-length dc resistance and
+    internal inductance are
+    $$R_{dc} = \frac{1}{2\pi a t\sigma},\qquad
+    L_{int} = \frac{\mu}{2\pi}\left[\frac{\ln(1+t/a)}{(1-q)^2}
+    + \frac{q-3}{4(1-q)}\right],$$
+    blended into $Z$ the same way as the solid rod. This layer returns
+    $2\pi a Z$:
+    $$Z_s = R_{dc,sq} + \frac{\zeta_c}{1+\zeta_c/(j\omega L_{int,sq})},
+    \qquad R_{dc,sq}=\frac{1}{t\sigma},\quad
+    L_{int,sq}=\mu a\left[\frac{\ln(1+t/a)}{(1-q)^2}+\frac{q-3}{4(1-q)}\right].$$
+
+    **Validity**
+
+    Same circuit approximation as the solid rod, so it shares the same
+    defect: its strong-skin limit is $\zeta_c + R_{dc,sq}$, not $\zeta_c$
+    exactly. In the infinite-wall limit ($t\to\infty$), $R_{dc,sq}\to0$ and
+    $L_{int,sq}\to\infty$, and this reduces to :class:`HalfSpaceShape` --
+    how :class:`~pmrf.models.components.lines.formulations.TescheCoaxialFormulation`
+    treats an outer shield whose wall thickness is not modelled.
+
+    References
+    ----------
+    Tesche, F. M. (2007). A Simple Model for the Line Parameters of a Lossy
+    Coaxial Cable Filled With a Nondispersive Dielectric. IEEE Transactions
+    on Electromagnetic Compatibility, 49(1), 12-17.
+    """
+    def impedance(self, w, zeta_c, sigma, mu_r, *, radius, thickness) -> jnp.ndarray:
+        a, t = radius, thickness
+        q = (a / (a + t)) ** 2
+        r_dc_sq = 1 / (t * sigma)
+        l_int_sq = mu_0 * mu_r * a * (
+            jnp.log1p(t / a) / (1 - q) ** 2 + (q - 3) / (4 * (1 - q))
+        )
+        return _tesche_circuit_impedance(zeta_c, r_dc_sq, l_int_sq, w)

--- a/pmrf/materials/conductor_shape.py
+++ b/pmrf/materials/conductor_shape.py
@@ -17,6 +17,8 @@ import equinox as eqx
 import jax.numpy as jnp
 from scipy.constants import mu_0
 
+from pmrf.materials.properties import ConductorProperties
+
 
 class AbstractConductorShape(eqx.Module):
     r"""
@@ -28,10 +30,10 @@ class AbstractConductorShape(eqx.Module):
     directly against the equations of the paper it comes from with no
     ParamRF objects in sight. Concrete shapes differ in the geometry they
     need -- a rod takes a radius, a tube a radius and a wall thickness, a
-    half-space none -- so only the common material arguments are fixed here.
+    half-space none -- so only the common material argument is fixed here.
     """
     @abstractmethod
-    def impedance(self, w, zeta_c, sigma, mu_r, **geometry) -> jnp.ndarray:
+    def impedance(self, w, conductor: ConductorProperties, **geometry) -> jnp.ndarray:
         r"""
         Return the surface impedance of this shape, in ohm per square.
 
@@ -39,13 +41,10 @@ class AbstractConductorShape(eqx.Module):
         ----------
         w : ArrayLike
             Angular frequency in rad/s.
-        zeta_c : jnp.ndarray
-            Complex intrinsic surface impedance of the metal,
-            $\zeta_c=\sqrt{j\omega\mu/\sigma}$, in ohm per square.
-        sigma : jnp.ndarray
-            Bulk conductivity in S/m.
-        mu_r : jnp.ndarray
-            Relative permeability of the conductor.
+        conductor : ConductorProperties
+            The metal's evaluated properties. ``conductor.zs`` is its
+            intrinsic surface impedance $\zeta_c=\sqrt{j\omega\mu/\sigma}$,
+            not yet weighted by this shape's factor.
         **geometry
             Shape-specific cross-section dimensions, in meters.
 
@@ -83,8 +82,8 @@ class HalfSpaceShape(AbstractConductorShape):
     Investigations of Radiowave Propagation, Part II, 5-12. Academy of
     Sciences, USSR.
     """
-    def impedance(self, w, zeta_c, sigma, mu_r) -> jnp.ndarray:
-        return zeta_c
+    def impedance(self, w, conductor: ConductorProperties) -> jnp.ndarray:
+        return conductor.zs
 
 
 def _tesche_circuit_impedance(zeta_c, r_dc_sq, l_int_sq, w):
@@ -126,10 +125,10 @@ class TescheRodShape(AbstractConductorShape):
     Coaxial Cable Filled With a Nondispersive Dielectric. IEEE Transactions
     on Electromagnetic Compatibility, 49(1), 12-17.
     """
-    def impedance(self, w, zeta_c, sigma, mu_r, *, radius) -> jnp.ndarray:
-        r_dc_sq = 2 / (radius * sigma)
-        l_int_sq = mu_0 * mu_r * radius / 4
-        return _tesche_circuit_impedance(zeta_c, r_dc_sq, l_int_sq, w)
+    def impedance(self, w, conductor: ConductorProperties, *, a) -> jnp.ndarray:
+        r_dc_sq = 2 / (a * conductor.sigma)
+        l_int_sq = mu_0 * conductor.mu_r * a / 4
+        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, l_int_sq, w)
 
 
 class TescheTubeShape(AbstractConductorShape):
@@ -164,11 +163,10 @@ class TescheTubeShape(AbstractConductorShape):
     Coaxial Cable Filled With a Nondispersive Dielectric. IEEE Transactions
     on Electromagnetic Compatibility, 49(1), 12-17.
     """
-    def impedance(self, w, zeta_c, sigma, mu_r, *, radius, thickness) -> jnp.ndarray:
-        a, t = radius, thickness
+    def impedance(self, w, conductor: ConductorProperties, *, a, t) -> jnp.ndarray:
         q = (a / (a + t)) ** 2
-        r_dc_sq = 1 / (t * sigma)
-        l_int_sq = mu_0 * mu_r * a * (
+        r_dc_sq = 1 / (t * conductor.sigma)
+        l_int_sq = mu_0 * conductor.mu_r * a * (
             jnp.log1p(t / a) / (1 - q) ** 2 + (q - 3) / (4 * (1 - q))
         )
-        return _tesche_circuit_impedance(zeta_c, r_dc_sq, l_int_sq, w)
+        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, l_int_sq, w)

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -239,12 +239,12 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
 
         L_ext = jnp.ones(freq.npoints) * mu / (2 * jnp.pi) * ln_b_over_a
 
-        rod_zs = TescheRodShape().impedance(w, conductor.zs, conductor.sigma, conductor.mu_r, radius=a)
+        rod_zs = TescheRodShape().impedance(w, conductor, a=a)
         Z_int = rod_zs / (2 * jnp.pi * a)
         # The model exposes only the shield's inner diameter, so its wall is
         # treated as infinitely thick, matching the usual coaxial idealisation:
         # the tube shape's own infinite-wall limit.
-        shield_zs = HalfSpaceShape().impedance(w, conductor.zs, conductor.sigma, conductor.mu_r)
+        shield_zs = HalfSpaceShape().impedance(w, conductor)
         Z_int = Z_int + shield_zs / (2 * jnp.pi * b)
 
         Z = 1j * w * L_ext + Z_int

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -28,63 +28,8 @@ import equinox as eqx
 
 from pmrf.frequency import Frequency
 from pmrf.materials import ConductorProperties, DielectricProperties
+from pmrf.materials.conductor_shape import HalfSpaceShape, TescheRodShape
 from pmrf.models.components.lines.base import ImmittanceResult
-
-
-def _tesche_internal_impedance(zs_over_radius, rdc, lint, w):
-    """Evaluate Tesche's equivalent circuit after geometry terms are known."""
-    safe_w = jnp.where(w > 0, w, 1.0)
-    zhf = zs_over_radius / (2 * jnp.pi)
-    z = rdc + zhf / (1 + zhf / (1j * safe_w * lint))
-    return jnp.where(w > 0, z, rdc)
-
-
-def rod_internal_impedance(zs, sigma, mu_r, radius, w):
-    r"""Return Tesche's eq. (11)--(14) impedance for a solid conductor.
-
-    Parameters
-    ----------
-    zs, sigma, mu_r : array-like
-        Surface impedance, conductivity and relative permeability.
-    radius : float
-        Conductor radius in meters.
-    w : array-like
-        Angular frequency in rad/s.
-
-    Returns
-    -------
-    array-like
-        Series impedance per unit length in ohm/m.
-    """
-    rdc = 1 / (jnp.pi * radius**2 * sigma)
-    lint = mu_0 * mu_r / (8 * jnp.pi)
-    return _tesche_internal_impedance(zs / radius, rdc, lint, w)
-
-
-def tube_internal_impedance(zs, sigma, mu_r, radius, thickness, w):
-    r"""Return Tesche's eq. (13)--(14) impedance for a tubular conductor.
-
-    Parameters
-    ----------
-    zs, sigma, mu_r : array-like
-        Surface impedance, conductivity and relative permeability.
-    radius, thickness : float
-        Inner radius and wall thickness in meters.
-    w : array-like
-        Angular frequency in rad/s.
-
-    Returns
-    -------
-    array-like
-        Series impedance per unit length in ohm/m.
-    """
-    rdc = 1 / (2 * jnp.pi * radius * thickness * sigma)
-    q = (radius / (radius + thickness)) ** 2
-    lint = mu_0 * mu_r / (2 * jnp.pi) * (
-        jnp.log1p(thickness / radius) / (1 - q) ** 2
-        + (q - 3) / (4 * (1 - q))
-    )
-    return _tesche_internal_impedance(zs / radius, rdc, lint, w)
 
 
 class PlanarQuasiStaticResult(eqx.Module):
@@ -249,15 +194,15 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     Y = \frac{j\omega 2\pi\varepsilon}{\ln(b/a)}$$
 
     which is $G + j\omega C$ with $C = 2\pi\Re(\varepsilon)/\ln(b/a)$ and
-    $G = -2\pi\omega\Im(\varepsilon)/\ln(b/a)$. For each conductor, Tesche's
-    equivalent circuit is
-    $$R_{dc} = \frac{1}{\pi a^2\sigma},\quad
-    L_{int} = \frac{\mu}{8\pi},\quad
-    Z = R_{dc} + \frac{Z_{hf}}{1 + Z_{hf}/(j\omega L_{int})},\quad
-    Z_{hf} = \frac{Z_s}{2\pi a}.$$
-    The outer shield is treated as infinitely thick because only its inner
-    diameter is part of :class:`CoaxialLine`; the finite-wall form is available
-    in :func:`tube_internal_impedance`.
+    $G = -2\pi\omega\Im(\varepsilon)/\ln(b/a)$. Each conductor's series
+    impedance is a shape's surface impedance charged over its circumference,
+    $Z = Z_s/2\pi r$: the inner conductor is a
+    :class:`~pmrf.materials.conductor_shape.TescheRodShape`, and the outer
+    shield -- treated as infinitely thick because only its inner diameter is
+    part of :class:`CoaxialLine` -- is the
+    :class:`~pmrf.materials.conductor_shape.HalfSpaceShape` limit that Tesche's
+    tube circuit approaches as its wall thickens; the finite-wall form is
+    :class:`~pmrf.materials.conductor_shape.TescheTubeShape`.
 
     A magnetic filling needs no special case. With complex $\mu_r$ the external
     term $j\omega L'$ acquires the real part $\omega\mu''\ln(b/a)/2\pi$, so
@@ -294,12 +239,13 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
 
         L_ext = jnp.ones(freq.npoints) * mu / (2 * jnp.pi) * ln_b_over_a
 
+        rod_zs = TescheRodShape().impedance(w, conductor.zs, conductor.sigma, conductor.mu_r, radius=a)
+        Z_int = rod_zs / (2 * jnp.pi * a)
         # The model exposes only the shield's inner diameter, so its wall is
-        # treated as infinitely thick, matching the usual coaxial idealisation.
-        Z_int = rod_internal_impedance(conductor.zs, conductor.sigma, conductor.mu_r, a, w)
-        # In the infinite-wall limit the tube's dc resistance vanishes and its
-        # internal inductance diverges, leaving only the high-frequency term.
-        Z_int = Z_int + conductor.zs / (2 * jnp.pi * b)
+        # treated as infinitely thick, matching the usual coaxial idealisation:
+        # the tube shape's own infinite-wall limit.
+        shield_zs = HalfSpaceShape().impedance(w, conductor.zs, conductor.sigma, conductor.mu_r)
+        Z_int = Z_int + shield_zs / (2 * jnp.pi * b)
 
         Z = 1j * w * L_ext + Z_int
         Y = 1j * w * 2 * jnp.pi * eps / ln_b_over_a

--- a/tests/test_materials/test_conductor_shape.py
+++ b/tests/test_materials/test_conductor_shape.py
@@ -1,0 +1,109 @@
+import jax.numpy as jnp
+import pytest
+from scipy.constants import mu_0
+
+from pmrf.frequency import Frequency
+from pmrf.materials.conductor_shape import (
+    HalfSpaceShape,
+    TescheRodShape,
+    TescheTubeShape,
+)
+
+
+@pytest.fixture
+def freq():
+    return Frequency(start=1.0, stop=20.0, npoints=20, unit='GHz')
+
+
+def _zeta_c(freq, sigma, mu_r=1.0):
+    return jnp.sqrt(1j * freq.w * mu_0 * mu_r / sigma)
+
+
+def test_half_space_is_the_trivial_shape_factor(freq):
+    """Leontovich's half-space carries no shape factor: Z_s == zeta_c exactly."""
+    sigma, mu_r = 5.8e7, 1.0
+    zeta_c = _zeta_c(freq, sigma, mu_r)
+
+    zs = HalfSpaceShape().impedance(freq.w, zeta_c, sigma, mu_r)
+
+    assert jnp.allclose(zs, zeta_c)
+
+
+def test_tesche_rod_matches_its_own_strong_skin_asymptote():
+    """Tesche's rod circuit is not exact, so it does not tend to zeta_c.
+
+    Its documented defect is that the strong-skin limit of the shape factor
+    is $1 + R_{dc,sq}/\\zeta_c$, not $1$: this is an algebraic identity of
+    the circuit (the high-frequency term of the blend saturates at
+    $\\zeta_c$), which holds once $\\zeta_c$ is large enough compared to
+    $R_{dc,sq}$ that the blend's own high-frequency term has converged --
+    a synthetic 100 EHz makes that comparison unambiguous, well past the
+    frequencies :class:`TescheCoaxialFormulation` is ever used at.
+    """
+    sigma, mu_r, radius = 5.8e7, 1.0, 0.455e-3
+    freq = Frequency.from_f(jnp.array([1e20]))
+    zeta_c = _zeta_c(freq, sigma, mu_r)
+
+    zs = TescheRodShape().impedance(freq.w, zeta_c, sigma, mu_r, radius=radius)
+
+    r_dc_sq = 2 / (radius * sigma)
+    expected_factor = 1 + r_dc_sq / zeta_c
+    assert jnp.allclose(zs / zeta_c, expected_factor, rtol=1e-6)
+
+
+def test_tesche_tube_matches_its_own_strong_skin_asymptote():
+    """Same defect as the rod, with the tube's own dc sheet resistance."""
+    sigma, mu_r, radius, thickness = 5.8e7, 1.0, 0.455e-3, 0.2e-3
+    freq = Frequency.from_f(jnp.array([1e20]))
+    zeta_c = _zeta_c(freq, sigma, mu_r)
+
+    zs = TescheTubeShape().impedance(
+        freq.w, zeta_c, sigma, mu_r, radius=radius, thickness=thickness
+    )
+
+    r_dc_sq = 1 / (thickness * sigma)
+    expected_factor = 1 + r_dc_sq / zeta_c
+    assert jnp.allclose(zs / zeta_c, expected_factor, rtol=1e-6)
+
+
+def test_tesche_shape_factors_tend_to_one_as_skin_effect_strengthens():
+    """Tesche's known, documented departure from the exact 1 shrinks with frequency.
+
+    At 20 GHz for a 0.455 mm inner radius the departure is on the order of
+    0.4%, matching the size quoted for this circuit approximation; it keeps
+    shrinking (roughly as $1/\\sqrt{f}$, since $\\zeta_c\\propto\\sqrt{f}$)
+    rather than sitting at a fixed offset, which is what distinguishes a
+    genuine asymptote from a bug.
+    """
+    sigma, mu_r, radius = 5.8e7, 1.0, 0.455e-3
+    low = Frequency.from_f(jnp.array([1e9]))
+    high = Frequency.from_f(jnp.array([20e9]))
+
+    def departure(freq):
+        zeta_c = _zeta_c(freq, sigma, mu_r)
+        zs = TescheRodShape().impedance(freq.w, zeta_c, sigma, mu_r, radius=radius)
+        return jnp.abs(zs / zeta_c - 1)
+
+    departure_low, departure_high = departure(low)[0], departure(high)[0]
+
+    assert departure_high < 0.01
+    assert departure_high < departure_low
+
+
+def test_tesche_tube_approaches_half_space_as_the_wall_thickens():
+    """A very thick tube is a half-space: TescheTubeShape's own limit.
+
+    $R_{dc,sq}=1/(t\\sigma)$ vanishes as the wall thickens, and $L_{int,sq}$
+    diverges (only logarithmically in $t$, so the wall must be made very
+    thick relative to the radius for the comparison to be tight).
+    """
+    sigma, mu_r, radius = 5.8e7, 1.0, 1e-3
+    freq = Frequency.from_f(jnp.array([1e9]))
+    zeta_c = _zeta_c(freq, sigma, mu_r)
+
+    thick_tube = TescheTubeShape().impedance(
+        freq.w, zeta_c, sigma, mu_r, radius=radius, thickness=1e6
+    )
+    half_space = HalfSpaceShape().impedance(freq.w, zeta_c, sigma, mu_r)
+
+    assert jnp.allclose(thick_tube, half_space, rtol=1e-3)

--- a/tests/test_materials/test_conductor_shape.py
+++ b/tests/test_materials/test_conductor_shape.py
@@ -3,6 +3,7 @@ import pytest
 from scipy.constants import mu_0
 
 from pmrf.frequency import Frequency
+from pmrf.materials import ConductorProperties
 from pmrf.materials.conductor_shape import (
     HalfSpaceShape,
     TescheRodShape,
@@ -15,18 +16,19 @@ def freq():
     return Frequency(start=1.0, stop=20.0, npoints=20, unit='GHz')
 
 
-def _zeta_c(freq, sigma, mu_r=1.0):
-    return jnp.sqrt(1j * freq.w * mu_0 * mu_r / sigma)
+def _conductor(freq, sigma, mu_r=1.0):
+    zeta_c = jnp.sqrt(1j * freq.w * mu_0 * mu_r / sigma)
+    ones = jnp.ones(freq.npoints)
+    return ConductorProperties(zeta_c, sigma * ones, mu_r * ones)
 
 
 def test_half_space_is_the_trivial_shape_factor(freq):
     """Leontovich's half-space carries no shape factor: Z_s == zeta_c exactly."""
-    sigma, mu_r = 5.8e7, 1.0
-    zeta_c = _zeta_c(freq, sigma, mu_r)
+    conductor = _conductor(freq, sigma=5.8e7)
 
-    zs = HalfSpaceShape().impedance(freq.w, zeta_c, sigma, mu_r)
+    zs = HalfSpaceShape().impedance(freq.w, conductor)
 
-    assert jnp.allclose(zs, zeta_c)
+    assert jnp.allclose(zs, conductor.zs)
 
 
 def test_tesche_rod_matches_its_own_strong_skin_asymptote():
@@ -40,30 +42,28 @@ def test_tesche_rod_matches_its_own_strong_skin_asymptote():
     a synthetic 100 EHz makes that comparison unambiguous, well past the
     frequencies :class:`TescheCoaxialFormulation` is ever used at.
     """
-    sigma, mu_r, radius = 5.8e7, 1.0, 0.455e-3
+    sigma, a = 5.8e7, 0.455e-3
     freq = Frequency.from_f(jnp.array([1e20]))
-    zeta_c = _zeta_c(freq, sigma, mu_r)
+    conductor = _conductor(freq, sigma)
 
-    zs = TescheRodShape().impedance(freq.w, zeta_c, sigma, mu_r, radius=radius)
+    zs = TescheRodShape().impedance(freq.w, conductor, a=a)
 
-    r_dc_sq = 2 / (radius * sigma)
-    expected_factor = 1 + r_dc_sq / zeta_c
-    assert jnp.allclose(zs / zeta_c, expected_factor, rtol=1e-6)
+    r_dc_sq = 2 / (a * sigma)
+    expected_factor = 1 + r_dc_sq / conductor.zs
+    assert jnp.allclose(zs / conductor.zs, expected_factor, rtol=1e-6)
 
 
 def test_tesche_tube_matches_its_own_strong_skin_asymptote():
     """Same defect as the rod, with the tube's own dc sheet resistance."""
-    sigma, mu_r, radius, thickness = 5.8e7, 1.0, 0.455e-3, 0.2e-3
+    sigma, a, t = 5.8e7, 0.455e-3, 0.2e-3
     freq = Frequency.from_f(jnp.array([1e20]))
-    zeta_c = _zeta_c(freq, sigma, mu_r)
+    conductor = _conductor(freq, sigma)
 
-    zs = TescheTubeShape().impedance(
-        freq.w, zeta_c, sigma, mu_r, radius=radius, thickness=thickness
-    )
+    zs = TescheTubeShape().impedance(freq.w, conductor, a=a, t=t)
 
-    r_dc_sq = 1 / (thickness * sigma)
-    expected_factor = 1 + r_dc_sq / zeta_c
-    assert jnp.allclose(zs / zeta_c, expected_factor, rtol=1e-6)
+    r_dc_sq = 1 / (t * sigma)
+    expected_factor = 1 + r_dc_sq / conductor.zs
+    assert jnp.allclose(zs / conductor.zs, expected_factor, rtol=1e-6)
 
 
 def test_tesche_shape_factors_tend_to_one_as_skin_effect_strengthens():
@@ -75,14 +75,14 @@ def test_tesche_shape_factors_tend_to_one_as_skin_effect_strengthens():
     rather than sitting at a fixed offset, which is what distinguishes a
     genuine asymptote from a bug.
     """
-    sigma, mu_r, radius = 5.8e7, 1.0, 0.455e-3
+    sigma, a = 5.8e7, 0.455e-3
     low = Frequency.from_f(jnp.array([1e9]))
     high = Frequency.from_f(jnp.array([20e9]))
 
     def departure(freq):
-        zeta_c = _zeta_c(freq, sigma, mu_r)
-        zs = TescheRodShape().impedance(freq.w, zeta_c, sigma, mu_r, radius=radius)
-        return jnp.abs(zs / zeta_c - 1)
+        conductor = _conductor(freq, sigma)
+        zs = TescheRodShape().impedance(freq.w, conductor, a=a)
+        return jnp.abs(zs / conductor.zs - 1)
 
     departure_low, departure_high = departure(low)[0], departure(high)[0]
 
@@ -97,13 +97,11 @@ def test_tesche_tube_approaches_half_space_as_the_wall_thickens():
     diverges (only logarithmically in $t$, so the wall must be made very
     thick relative to the radius for the comparison to be tight).
     """
-    sigma, mu_r, radius = 5.8e7, 1.0, 1e-3
+    sigma, a = 5.8e7, 1e-3
     freq = Frequency.from_f(jnp.array([1e9]))
-    zeta_c = _zeta_c(freq, sigma, mu_r)
+    conductor = _conductor(freq, sigma)
 
-    thick_tube = TescheTubeShape().impedance(
-        freq.w, zeta_c, sigma, mu_r, radius=radius, thickness=1e6
-    )
-    half_space = HalfSpaceShape().impedance(freq.w, zeta_c, sigma, mu_r)
+    thick_tube = TescheTubeShape().impedance(freq.w, conductor, a=a, t=1e6)
+    half_space = HalfSpaceShape().impedance(freq.w, conductor)
 
     assert jnp.allclose(thick_tube, half_space, rtol=1e-3)

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -25,9 +25,9 @@ from pmrf.materials import (
     DjordjevicSarkar,
     RoughConductor,
 )
+from pmrf.materials.conductor_shape import TescheTubeShape
 from pmrf.models.components.lines.formulations import (
     TescheCoaxialFormulation,
-    tube_internal_impedance,
     KirschningJansenMicrostripDispersion,
 )
 
@@ -380,7 +380,8 @@ def test_coaxial_internal_impedance_tube():
         sigma=float(sigma[0]), tout=thickness, model="tesche",
     )
     expected = reference._conductor_impedance(radius, thickness, None)
-    actual = tube_internal_impedance(zs, sigma, mu, radius, thickness, freq.w)
+    zs_sq = TescheTubeShape().impedance(freq.w, zs, sigma, mu, radius=radius, thickness=thickness)
+    actual = zs_sq / (2 * jnp.pi * radius)
     assert jnp.allclose(actual, expected)
 
 

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -380,7 +380,8 @@ def test_coaxial_internal_impedance_tube():
         sigma=float(sigma[0]), tout=thickness, model="tesche",
     )
     expected = reference._conductor_impedance(radius, thickness, None)
-    zs_sq = TescheTubeShape().impedance(freq.w, zs, sigma, mu, radius=radius, thickness=thickness)
+    conductor = ConductorProperties(zs, sigma, mu)
+    zs_sq = TescheTubeShape().impedance(freq.w, conductor, a=radius, t=thickness)
     actual = zs_sq / (2 * jnp.pi * radius)
     assert jnp.allclose(actual, expected)
 


### PR DESCRIPTION
## Summary
- Introduces `pmrf.materials.conductor_shape` — an `AbstractConductorShape` layer (`HalfSpaceShape`, `TescheRodShape`, `TescheTubeShape`) that returns surface impedance in ohm per square as ζc × a dimensionless shape factor, with geometry weights left to the caller.
- Rewires `TescheCoaxialFormulation.immittance` to consume the layer, removing the old free functions fused into the coaxial side (`rod_internal_impedance`, `tube_internal_impedance`, `_tesche_internal_impedance`); this is a pure prefactor move with no numerical output changes.
- Adds a correctness test that each *exact* shape factor tends to 1 in the strong-skin limit, and separately records Tesche's documented departure from it (`1 + 2πa·R_dc/ζc`), rather than asserting exactly 1 for the circuit approximation.

Closes #96

## Test plan
- [x] `pytest tests/test_materials/test_conductor_shape.py` — new shape-layer tests
- [x] `pytest tests/test_models/test_lines.py tests/test_models/test_lines_skrf_matrix.py` — coaxial tests unchanged in behavior, including the scikit-rf `model='tesche'` agreement
- [x] Full suite: `pytest` (466 passed, 28 skipped)
- [x] Reviewed via `/code-review` (Standards + Spec axes); addressed the naming/data-clump findings in a follow-up commit