### PR TITLE
Exact Schelkunoff solid rod as the default coax inner conductor

### DIFF
--- a/pmrf/materials/__init__.py
+++ b/pmrf/materials/__init__.py
@@ -35,6 +35,7 @@ from pmrf.materials.conductor import (
 from pmrf.materials.conductor_shape import (
     AbstractConductorShape as AbstractConductorShape,
     HalfSpaceShape as HalfSpaceShape,
+    SchelkunoffRodShape as SchelkunoffRodShape,
     TescheRodShape as TescheRodShape,
     TescheTubeShape as TescheTubeShape,
 )
@@ -58,6 +59,7 @@ __all__ = [
     "as_conductor",
     "AbstractConductorShape",
     "HalfSpaceShape",
+    "SchelkunoffRodShape",
     "TescheRodShape",
     "TescheTubeShape",
     "Substrate",

--- a/pmrf/materials/conductor_shape.py
+++ b/pmrf/materials/conductor_shape.py
@@ -221,7 +221,10 @@ class SchelkunoffRodShape(AbstractConductorShape):
         # and keep the argument away from the pole so the gradient stays
         # finite. A perfect conductor is the other unevaluable argument:
         # gamma is infinite there, but zeta_c is zero, so the shape factor
-        # never has to be evaluated at all.
+        # never has to be evaluated at all -- which is why the final guard
+        # below is the narrower `w > 0`: an infinite sigma needs a safe
+        # Bessel argument, but its zero zeta_c already gives the right
+        # answer, and 2/(a*sigma) is likewise zero there.
         gamma_a = conductor.sigma * conductor.zs * a
         evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
         safe_gamma_a = jnp.where(evaluable, gamma_a, 1.0)

--- a/pmrf/materials/conductor_shape.py
+++ b/pmrf/materials/conductor_shape.py
@@ -18,6 +18,7 @@ import jax.numpy as jnp
 from scipy.constants import mu_0
 
 from pmrf.materials.properties import ConductorProperties
+from pmrf.math.bessel import i0_over_i1
 
 
 class AbstractConductorShape(eqx.Module):
@@ -111,13 +112,19 @@ class TescheRodShape(AbstractConductorShape):
 
     **Validity**
 
-    Interpolates between the exact dc resistance and the exact
-    high-frequency skin-effect impedance of a round conductor, so it carries
-    no geometric fit range. It is not exact at finite frequency: unlike a
-    genuine half-space, its strong-skin limit is not $\zeta_c$ but
+    Interpolates between the exact dc resistance and the bare half-space
+    impedance $\zeta_c$, so it carries no geometric fit range. It is not
+    exact at finite frequency, and it does not reach the exact
+    high-frequency limit of a round conductor either: the true strong-skin
+    expansion of :class:`SchelkunoffRodShape` is
+    $\zeta_c(1 + 1/2\gamma a + \ldots)$, and the circuit never produces
+    that $1/2\gamma a$ curvature term. Its own strong-skin limit is instead
     $\zeta_c + R_{dc,sq}$ -- a known, persistent defect of the circuit
     approximation, not a porting error (see ``tests/test_materials/
-    test_conductor_shape.py`` for the size of the departure).
+    test_conductor_shape.py`` for the size of the departure). The error is
+    a *shape* error, so refitting $\sigma$ does not absorb it; prefer
+    :class:`SchelkunoffRodShape` unless the Bessel evaluation is too
+    expensive.
 
     References
     ----------
@@ -170,3 +177,54 @@ class TescheTubeShape(AbstractConductorShape):
             jnp.log1p(t / a) / (1 - q) ** 2 + (q - 3) / (4 * (1 - q))
         )
         return _tesche_circuit_impedance(conductor.zs, r_dc_sq, l_int_sq, w)
+
+
+class SchelkunoffRodShape(AbstractConductorShape):
+    r"""
+    Solid round conductor, exact.
+
+    **Mathematical Formulation**
+
+    Schelkunoff solves Maxwell's equations inside the rod rather than
+    interpolating between its limits. His eq. (65), the internal impedance
+    per unit length of a solid cylinder of radius $a$, is
+    $$Z = \frac{\gamma}{2\pi a\sigma}\,\frac{I_0(\gamma a)}{I_1(\gamma a)},
+    \qquad \gamma=\sqrt{j\omega\mu\sigma}.$$
+    Since $\zeta_c=\sqrt{j\omega\mu/\sigma}=\gamma/\sigma$, the shape
+    factor this layer returns -- with the caller supplying its own
+    $1/2\pi a$ geometry weight -- is simply the Bessel ratio:
+    $$Z_s = \zeta_c\,\frac{I_0(\gamma a)}{I_1(\gamma a)}.$$
+
+    Both limits follow with no special case. As $\gamma a\to0$,
+    $I_0/I_1\to2/\gamma a$ and $Z_s\to2/a\sigma$, which is the exact dc
+    sheet resistance $\pi a^2$ times $1/\pi a^2\sigma$; as
+    $\gamma a\to\infty$, $I_0/I_1\to1+1/2\gamma a$, so the shape
+    approaches :class:`HalfSpaceShape` with the leading curvature
+    correction that :class:`TescheRodShape` cannot reproduce.
+
+    **Validity**
+
+    Exact for a homogeneous, isotropic, non-magnetic-hysteresis solid rod
+    carrying axially symmetric current, at every frequency. The remaining
+    error is the numerics of :func:`~pmrf.math.bessel.i0_over_i1`, below
+    3.1e-8 relative on the $\gamma$ ray.
+
+    References
+    ----------
+    Schelkunoff, S. A. (1934). The Electromagnetic Theory of Coaxial
+    Transmission Lines and Cylindrical Shields. Bell System Technical
+    Journal, 13(4), 532-579. Eq. (65).
+    """
+    def impedance(self, w, conductor: ConductorProperties, *, a) -> jnp.ndarray:
+        # gamma = sigma * zeta_c vanishes at dc, where the ratio has a pole
+        # that exactly cancels zeta_c's zero. Take that limit analytically
+        # and keep the argument away from the pole so the gradient stays
+        # finite. A perfect conductor is the other unevaluable argument:
+        # gamma is infinite there, but zeta_c is zero, so the shape factor
+        # never has to be evaluated at all.
+        gamma_a = conductor.sigma * conductor.zs * a
+        evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
+        safe_gamma_a = jnp.where(evaluable, gamma_a, 1.0)
+        zs = conductor.zs * i0_over_i1(safe_gamma_a)
+        r_dc_sq = 2 / (a * conductor.sigma)
+        return jnp.where(w > 0, zs, r_dc_sq)

--- a/pmrf/math/__init__.py
+++ b/pmrf/math/__init__.py
@@ -2,6 +2,10 @@
 Core maths functions.
 """
 
+from pmrf.math.bessel import (
+    i0_over_i1 as i0_over_i1,
+)
+
 import pmrf.math.aggregations as aggregations
 from pmrf.math.aggregations import (
     weighted_sum as weighted_sum,
@@ -55,6 +59,7 @@ from pmrf.math.misc import *
 
 __all__ = [
     "aggregations",
+    "i0_over_i1",
     "complex_2_magnitude",
     "complex_2_db",
     "complex_2_db10",

--- a/pmrf/math/__init__.py
+++ b/pmrf/math/__init__.py
@@ -2,10 +2,6 @@
 Core maths functions.
 """
 
-from pmrf.math.bessel import (
-    i0_over_i1 as i0_over_i1,
-)
-
 import pmrf.math.aggregations as aggregations
 from pmrf.math.aggregations import (
     weighted_sum as weighted_sum,
@@ -44,6 +40,11 @@ from pmrf.math.conversions import (
     complexify as complexify,
     CONVERSION_LOOKUP as CONVERSION_LOOKUP,
 )
+import pmrf.math.bessel as bessel
+from pmrf.math.bessel import (
+    i0_over_i1 as i0_over_i1,
+)
+
 import pmrf.math.losses as losses
 from pmrf.math.losses import (
     mean_squared_error as mean_squared_error,
@@ -59,6 +60,7 @@ from pmrf.math.misc import *
 
 __all__ = [
     "aggregations",
+    "bessel",
     "i0_over_i1",
     "complex_2_magnitude",
     "complex_2_db",

--- a/pmrf/math/bessel.py
+++ b/pmrf/math/bessel.py
@@ -1,0 +1,96 @@
+r"""
+Modified Bessel functions for complex arguments.
+
+JAX ships :func:`jax.scipy.special.i0e` and :func:`~jax.scipy.special.i1e`
+for real arguments only, but cylindrical-conductor physics needs $I_0$ and
+$I_1$ at the complex propagation constant $\gamma a=\sqrt{j\omega\mu\sigma}\,a$.
+What that physics actually needs is never $I_0$ or $I_1$ alone but their
+ratio, which is bounded everywhere off the imaginary axis, so this module
+evaluates the ratio directly rather than two exponentially large numbers
+that are then divided.
+"""
+import jax.numpy as jnp
+
+#: Number of power-series terms used below :data:`I_RATIO_SERIES_CUTOFF`.
+_SERIES_TERMS = 40
+
+#: $|x|$ above which the ratio switches from the power series to the
+#: asymptotic expansion. The two agree to 3e-8 relative here, and better on
+#: either side; raising it trades series terms for accuracy at the seam.
+I_RATIO_SERIES_CUTOFF = 20.0
+
+#: Coefficients of $x^{-n}$, $n=0\ldots5$, in the large-argument expansion of
+#: $I_0(x)/I_1(x)$, obtained by dividing the standard asymptotic series
+#: $I_\nu(x)\sim e^x(1-(\mu-1)/8x+\ldots)/\sqrt{2\pi x}$ with $\mu=4\nu^2$.
+_ASYMPTOTIC_COEFFS = (1.0, 1 / 2, 3 / 8, 3 / 8, 63 / 128, 27 / 32)
+
+
+def _i_ratio_series(x):
+    """Evaluate $I_0(x)/I_1(x)$ from the ascending power series."""
+    k = jnp.arange(_SERIES_TERMS)
+    half = x[..., None] / 2
+    # (x/2)^{2k}/(k!)^2 as a running product, so no factorial ever overflows.
+    step = jnp.where(k == 0, 1.0, (half ** 2) / jnp.where(k == 0, 1.0, k) ** 2)
+    terms = jnp.cumprod(step, axis=-1)
+    i0 = jnp.sum(terms, axis=-1)
+    i1 = jnp.sum(terms * half / (k + 1), axis=-1)
+    return i0 / i1
+
+
+def _i_ratio_asymptotic(x):
+    """Evaluate $I_0(x)/I_1(x)$ from the large-argument expansion."""
+    inv = 1 / x
+    out = jnp.zeros_like(x)
+    for c in reversed(_ASYMPTOTIC_COEFFS):
+        out = out * inv + c
+    return out
+
+
+def i0_over_i1(x: jnp.ndarray) -> jnp.ndarray:
+    r"""
+    Ratio $I_0(x)/I_1(x)$ of modified Bessel functions, for complex $x$.
+
+    **Mathematical Formulation**
+
+    Below $|x|=20$ the ascending series is summed directly,
+    $$I_0(x)=\sum_{k\ge0}\frac{(x/2)^{2k}}{(k!)^2},\qquad
+    I_1(x)=\sum_{k\ge0}\frac{(x/2)^{2k+1}}{k!\,(k+1)!},$$
+    to 40 terms; above it the ratio is taken from the large-argument
+    expansion
+    $$\frac{I_0(x)}{I_1(x)}\sim 1+\frac{1}{2x}+\frac{3}{8x^2}
+    +\frac{3}{8x^3}+\frac{63}{128x^4}+\frac{27}{32x^5}.$$
+    The small-argument limit $I_0/I_1\to2/x$ falls out of the series with no
+    special case, which is what makes the dc limit of a cylindrical
+    conductor exact rather than patched.
+
+    **Validity**
+
+    Measured against :func:`scipy.special.ive` over $|x|\in[10^{-6},10^4]$:
+    worst relative error 3.1e-8, at the switch point, for $|\arg x|$ up to
+    $60^\circ$ -- which covers the $45^\circ$ ray
+    $\gamma=\sqrt{j\omega\mu\sigma}$ that a good conductor sits on. The
+    large-argument expansion is an asymptotic series about the positive real
+    axis and degrades as $\arg x\to90^\circ$ (2e-6 at $70^\circ$, 6e-2 at
+    $85^\circ$); this function is not for arguments near the imaginary axis.
+    See ``tests/test_math/test_bessel.py`` for the per-regime tolerances.
+    Both branches are evaluated on safe arguments, so :func:`jax.grad` is
+    finite throughout; the derivative jump at the seam is 1.4e-4 relative.
+    $x=0$ is a genuine pole of the ratio and is the caller's to handle.
+
+    Parameters
+    ----------
+    x : jnp.ndarray
+        Argument, real or complex.
+
+    Returns
+    -------
+    jnp.ndarray
+        $I_0(x)/I_1(x)$.
+    """
+    x = jnp.asarray(x)
+    small = jnp.abs(x) < I_RATIO_SERIES_CUTOFF
+    # Each branch is evaluated on an argument the other branch's regime
+    # cannot make overflow, so the unused branch never poisons the gradient.
+    x_series = jnp.where(small, x, I_RATIO_SERIES_CUTOFF)
+    x_asymptotic = jnp.where(small, I_RATIO_SERIES_CUTOFF, x)
+    return jnp.where(small, _i_ratio_series(x_series), _i_ratio_asymptotic(x_asymptotic))

--- a/pmrf/math/bessel.py
+++ b/pmrf/math/bessel.py
@@ -11,13 +11,13 @@ that are then divided.
 """
 import jax.numpy as jnp
 
-#: Number of power-series terms used below :data:`I_RATIO_SERIES_CUTOFF`.
+# Number of power-series terms used below the cutoff.
 _SERIES_TERMS = 40
 
 #: $|x|$ above which the ratio switches from the power series to the
 #: asymptotic expansion. The two agree to 3e-8 relative here, and better on
 #: either side; raising it trades series terms for accuracy at the seam.
-I_RATIO_SERIES_CUTOFF = 20.0
+I0_OVER_I1_SERIES_CUTOFF = 20.0
 
 #: Coefficients of $x^{-n}$, $n=0\ldots5$, in the large-argument expansion of
 #: $I_0(x)/I_1(x)$, obtained by dividing the standard asymptotic series
@@ -88,9 +88,9 @@ def i0_over_i1(x: jnp.ndarray) -> jnp.ndarray:
         $I_0(x)/I_1(x)$.
     """
     x = jnp.asarray(x)
-    small = jnp.abs(x) < I_RATIO_SERIES_CUTOFF
+    small = jnp.abs(x) < I0_OVER_I1_SERIES_CUTOFF
     # Each branch is evaluated on an argument the other branch's regime
     # cannot make overflow, so the unused branch never poisons the gradient.
-    x_series = jnp.where(small, x, I_RATIO_SERIES_CUTOFF)
-    x_asymptotic = jnp.where(small, I_RATIO_SERIES_CUTOFF, x)
+    x_series = jnp.where(small, x, I0_OVER_I1_SERIES_CUTOFF)
+    x_asymptotic = jnp.where(small, I0_OVER_I1_SERIES_CUTOFF, x)
     return jnp.where(small, _i_ratio_series(x_series), _i_ratio_asymptotic(x_asymptotic))

--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -89,6 +89,7 @@ from pmrf.models.components.lines.physical import (
 
 from pmrf.models.components.lines.formulations import (
     AbstractCoaxialFormulation as AbstractCoaxialFormulation,
+    SchelkunoffCoaxialFormulation as SchelkunoffCoaxialFormulation,
     TescheCoaxialFormulation as TescheCoaxialFormulation,
     AbstractMicrostripFormulation as AbstractMicrostripFormulation,
     WheelerMicrostripFormulation as WheelerMicrostripFormulation,

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -28,7 +28,12 @@ import equinox as eqx
 
 from pmrf.frequency import Frequency
 from pmrf.materials import ConductorProperties, DielectricProperties
-from pmrf.materials.conductor_shape import HalfSpaceShape, TescheRodShape
+from pmrf.materials.conductor_shape import (
+    AbstractConductorShape,
+    HalfSpaceShape,
+    SchelkunoffRodShape,
+    TescheRodShape,
+)
 from pmrf.models.components.lines.base import ImmittanceResult
 
 
@@ -180,6 +185,39 @@ class AbstractCoaxialFormulation(eqx.Module):
         raise NotImplementedError
 
 
+def _coaxial_immittance(freq: Frequency, *, d_in, d_out, dielectric: DielectricProperties, conductor: ConductorProperties, inner_shape: AbstractConductorShape) -> ImmittanceResult:
+    """Assemble a coaxial line's immittance around a choice of inner-conductor shape.
+
+    Everything but the inner rod is common to every coaxial formulation here:
+    the external inductance and the shunt admittance are pure geometry, and
+    the shield's contribution is the half-space limit. The formulations
+    differ only in how the solid centre conductor's cross-section is solved.
+    """
+    eps = epsilon_0 * dielectric.ep_r
+    mu = mu_0 * dielectric.mu_r
+    w = freq.w
+
+    d_out = eqx.error_if(d_out, d_out - d_in <= 0, "d_out must exceed d_in")
+    a, b = d_in / 2, d_out / 2
+    ln_b_over_a = jnp.log(b / a)
+
+    L_ext = jnp.ones(freq.npoints) * mu / (2 * jnp.pi) * ln_b_over_a
+
+    rod_zs = inner_shape.impedance(w, conductor, a=a)
+    Z_int = rod_zs / (2 * jnp.pi * a)
+    # The model exposes only the shield's inner diameter, so its wall is
+    # treated as infinitely thick, matching the usual coaxial idealisation:
+    # the tube shape's own infinite-wall limit.
+    shield_zs = HalfSpaceShape().impedance(w, conductor)
+    Z_int = Z_int + shield_zs / (2 * jnp.pi * b)
+
+    Z = 1j * w * L_ext + Z_int
+    Y = 1j * w * 2 * jnp.pi * eps / ln_b_over_a
+    Y = Y + 2 * jnp.pi * dielectric.sigma / ln_b_over_a
+
+    return ImmittanceResult(Z=Z, Y=Y, w=w)
+
+
 class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     r"""
     Coaxial line formulation using Tesche's equivalent-circuit approximation.
@@ -212,8 +250,13 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
 
     The equivalent circuit is not an empirical fit to a width ratio, so it
     carries no geometric fit range: it interpolates between the exact DC
-    resistance and the exact high-frequency skin-effect impedance of a round
-    conductor. The transmission-line description itself is the limit: it assumes
+    resistance and the bare half-space impedance $\zeta_c$. That is not the
+    exact high-frequency limit of a round conductor -- the circuit reaches
+    $R_{dc} + Z_{hf}$ and never captures the $1/2\gamma a$ curvature term of
+    the exact solution -- so it is an approximation to
+    :class:`SchelkunoffCoaxialFormulation` at every finite frequency, worst
+    for thin inner conductors at low frequency. The transmission-line
+    description itself is the further limit: it assumes
     the TEM mode, so it holds below the TE11 cutoff
     $f_c \approx c / \left[\pi (a + b) \sqrt{\varepsilon_r \mu_r}\right]$.
     Above that, higher-order modes propagate and a single per-unit-length
@@ -229,29 +272,51 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     and Cylindrical Shields. Bell System Technical Journal, 13(4), 532-579.
     """
     def immittance(self, freq: Frequency, *, d_in, d_out, dielectric: DielectricProperties, conductor: ConductorProperties) -> ImmittanceResult:
-        eps = epsilon_0 * dielectric.ep_r
-        mu = mu_0 * dielectric.mu_r
-        w = freq.w
+        return _coaxial_immittance(
+            freq, d_in=d_in, d_out=d_out, dielectric=dielectric,
+            conductor=conductor, inner_shape=TescheRodShape(),
+        )
 
-        d_out = eqx.error_if(d_out, d_out - d_in <= 0, "d_out must exceed d_in")
-        a, b = d_in / 2, d_out / 2
-        ln_b_over_a = jnp.log(b / a)
 
-        L_ext = jnp.ones(freq.npoints) * mu / (2 * jnp.pi) * ln_b_over_a
+class SchelkunoffCoaxialFormulation(AbstractCoaxialFormulation):
+    r"""
+    Coaxial line formulation using Schelkunoff's exact cylindrical solution.
 
-        rod_zs = TescheRodShape().impedance(w, conductor, a=a)
-        Z_int = rod_zs / (2 * jnp.pi * a)
-        # The model exposes only the shield's inner diameter, so its wall is
-        # treated as infinitely thick, matching the usual coaxial idealisation:
-        # the tube shape's own infinite-wall limit.
-        shield_zs = HalfSpaceShape().impedance(w, conductor)
-        Z_int = Z_int + shield_zs / (2 * jnp.pi * b)
+    **Mathematical Formulation**
 
-        Z = 1j * w * L_ext + Z_int
-        Y = 1j * w * 2 * jnp.pi * eps / ln_b_over_a
-        Y = Y + 2 * jnp.pi * dielectric.sigma / ln_b_over_a
+    The external inductance and shunt admittance are the same pure geometry
+    as in :class:`TescheCoaxialFormulation`,
+    $$L' = \frac{\mu_0 \mu_r}{2\pi} \ln\left(\frac{b}{a}\right)
+    \qquad
+    Y = \frac{j\omega 2\pi\varepsilon}{\ln(b/a)},$$
+    and so is the shield's half-space contribution $\zeta_c/2\pi b$. What
+    differs is the solid inner conductor, which is
+    :class:`~pmrf.materials.conductor_shape.SchelkunoffRodShape` --
+    Schelkunoff's eq. (65) rather than an equivalent circuit:
+    $$Z_{inner} = \frac{\zeta_c}{2\pi a}\,
+    \frac{I_0(\gamma a)}{I_1(\gamma a)},\qquad
+    \gamma = \sqrt{j\omega\mu\sigma}.$$
 
-        return ImmittanceResult(Z=Z, Y=Y, w=w)
+    **Validity**
+
+    Exact for the inner conductor at every frequency, dc included, so unlike
+    Tesche it leaves no frequency-shaped residual for a conductivity fit to
+    absorb. The shield remains infinitely thick, since only its inner
+    diameter is part of :class:`CoaxialLine`. The transmission-line
+    description is still the outer limit: it assumes the TEM mode, so it
+    holds below the TE11 cutoff
+    $f_c \approx c / \left[\pi (a + b) \sqrt{\varepsilon_r \mu_r}\right]$.
+
+    References
+    ----------
+    Schelkunoff, S. A. (1934). The Electromagnetic Theory of Coaxial Transmission Lines
+    and Cylindrical Shields. Bell System Technical Journal, 13(4), 532-579. Eq. (65).
+    """
+    def immittance(self, freq: Frequency, *, d_in, d_out, dielectric: DielectricProperties, conductor: ConductorProperties) -> ImmittanceResult:
+        return _coaxial_immittance(
+            freq, d_in=d_in, d_out=d_out, dielectric=dielectric,
+            conductor=conductor, inner_shape=SchelkunoffRodShape(),
+        )
 
 
 class AbstractMicrostripFormulation(eqx.Module):

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -29,6 +29,7 @@ from pmrf.models.components.lines.formulations import (
     CohnStriplineFormulation,
     KirschningJansenMicrostripDispersion,
     PlanarQuasiStaticResult,
+    SchelkunoffCoaxialFormulation,
     TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
     _wheeler_conductor_loss_factor,
@@ -230,7 +231,9 @@ class CoaxialLine(AbstractImmittanceLine):
     r"""
     Coaxial line defined directly by its physical geometry and material modules.
     
-    Uses :class:`TescheCoaxialFormulation` as the default mathematical formulation.
+    Uses :class:`SchelkunoffCoaxialFormulation` -- the exact cylindrical solution --
+    as the default mathematical formulation. :class:`TescheCoaxialFormulation` remains
+    selectable as the cheaper, Bessel-free alternative and as an independent cross-check.
 
     Example
     --------
@@ -265,7 +268,7 @@ class CoaxialLine(AbstractImmittanceLine):
     conductor : AbstractConductor, default=BulkConductor()
         The conductor material of both conductors. A scalar conductivity in
         S/m is coerced into a :class:`~pmrf.materials.BulkConductor`.
-    formulation : AbstractCoaxialFormulation, default=TescheCoaxialFormulation()
+    formulation : AbstractCoaxialFormulation, default=SchelkunoffCoaxialFormulation()
         The closed-form physics used to compute the immittance.
     """
     #: Inner conductor diameter
@@ -285,7 +288,7 @@ class CoaxialLine(AbstractImmittanceLine):
     )
     
     #: The underlying physics formulation
-    formulation: AbstractCoaxialFormulation = field(default_factory=TescheCoaxialFormulation)
+    formulation: AbstractCoaxialFormulation = field(default_factory=SchelkunoffCoaxialFormulation)
 
     def immittance(self, freq: Frequency) -> ImmittanceResult:
         return self.formulation.immittance(

--- a/tests/test_materials/test_conductor_shape.py
+++ b/tests/test_materials/test_conductor_shape.py
@@ -1,11 +1,15 @@
+import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from scipy.constants import mu_0
+from scipy.special import ive
 
 from pmrf.frequency import Frequency
-from pmrf.materials import ConductorProperties
+from pmrf.materials import BulkConductor, ConductorProperties
 from pmrf.materials.conductor_shape import (
     HalfSpaceShape,
+    SchelkunoffRodShape,
     TescheRodShape,
     TescheTubeShape,
 )
@@ -105,3 +109,105 @@ def test_tesche_tube_approaches_half_space_as_the_wall_thickens():
     half_space = HalfSpaceShape().impedance(freq.w, conductor)
 
     assert jnp.allclose(thick_tube, half_space, rtol=1e-3)
+
+
+def test_schelkunoff_rod_matches_scipy_bessel_ratio():
+    """The shape factor is Schelkunoff eq. (65), checked against scipy directly."""
+    sigma, a = 5.8e7, 0.455e-3
+    freq = Frequency(start=1.0, stop=20.0, npoints=20, unit='GHz')
+    conductor = _conductor(freq, sigma)
+
+    zs = SchelkunoffRodShape().impedance(freq.w, conductor, a=a)
+
+    gamma_a = np.sqrt(1j * np.asarray(freq.w) * mu_0 * sigma) * a
+    expected = np.asarray(conductor.zs) * ive(0, gamma_a) / ive(1, gamma_a)
+    assert np.allclose(np.asarray(zs), expected, rtol=1e-10)
+
+
+def test_schelkunoff_rod_reproduces_the_dc_resistance_without_a_special_case():
+    """At dc the Bessel ratio's pole cancels zeta_c's zero, giving 1/(pi a^2 sigma).
+
+    The dc point itself is the where-branch, but the limit is approached
+    continuously from above: 1 Hz already lands on the same number, which is
+    what shows the branch is a limit rather than a patch.
+    """
+    sigma, a = 5.8e7, 0.455e-3
+    freq = Frequency.from_f(jnp.array([0.0, 1.0]))
+    conductor = _conductor(freq, sigma)
+
+    z = SchelkunoffRodShape().impedance(freq.w, conductor, a=a) / (2 * jnp.pi * a)
+
+    r_dc = 1 / (jnp.pi * a**2 * sigma)
+    assert jnp.allclose(jnp.real(z), r_dc, rtol=1e-9)
+
+
+def test_schelkunoff_rod_tends_to_the_half_space_plus_curvature():
+    """The strong-skin limit is $\\zeta_c(1 + 1/2\\gamma a)$, not $\\zeta_c$.
+
+    This curvature term is exactly what :class:`TescheRodShape` cannot
+    produce, and it is a real effect: at 20 GHz it is still 0.05% of the
+    shape factor for a 0.455 mm radius.
+    """
+    sigma, a = 5.8e7, 0.455e-3
+    freq = Frequency.from_f(jnp.array([20e9]))
+    conductor = _conductor(freq, sigma)
+
+    zs = SchelkunoffRodShape().impedance(freq.w, conductor, a=a)
+
+    gamma_a = conductor.sigma * conductor.zs * a
+    assert jnp.allclose(zs / conductor.zs, 1 + 1 / (2 * gamma_a), rtol=1e-4)
+    assert jnp.abs(1 / (2 * gamma_a))[0] > 1e-4
+
+
+def test_tesche_rod_departs_from_schelkunoff_by_a_shape_error():
+    """The Tesche error is frequency-shaped, so refitting sigma cannot absorb it.
+
+    Removing the best-fit global scale from the ratio of the two shape
+    factors over 10-500 MHz leaves a residual of several percent for a thin
+    inner conductor -- the number that motivates making Schelkunoff the
+    default.
+    """
+    sigma, a = 5.8e7, 0.255e-3  # RG405-like inner conductor
+    freq = Frequency(start=10.0, stop=500.0, npoints=51, unit='MHz')
+    conductor = _conductor(freq, sigma)
+
+    tesche = TescheRodShape().impedance(freq.w, conductor, a=a)
+    exact = SchelkunoffRodShape().impedance(freq.w, conductor, a=a)
+
+    ratio = jnp.real(tesche) / jnp.real(exact)
+    residual = jnp.max(jnp.abs(ratio / jnp.mean(ratio) - 1))
+    assert 0.03 < residual < 0.12
+
+
+def test_schelkunoff_rod_gradients_are_finite_including_at_dc():
+    """Fitting needs finite d/dsigma and d/df everywhere, dc included.
+
+    The gradient is taken through :class:`BulkConductor` rather than through
+    a hand-built ``zeta_c``: $\\zeta_c=\\sqrt{j\\omega\\mu/\\sigma}$ has an
+    infinite $\\omega$-derivative at dc of its own, which every shape in
+    this module would inherit, and the material is where that is handled.
+    """
+    a = 0.455e-3
+
+    def resistance(sigma, f):
+        freq = Frequency.from_f(jnp.atleast_1d(f))
+        conductor = BulkConductor(sigma=sigma).properties(freq)
+        return jnp.real(SchelkunoffRodShape().impedance(freq.w, conductor, a=a))[0]
+
+    for f in [0.0, 1e3, 1e9]:
+        d_sigma, d_f = jax.grad(resistance, argnums=(0, 1))(5.8e7, f)
+        assert jnp.isfinite(d_sigma) and jnp.isfinite(d_f)
+
+
+def test_schelkunoff_rod_is_lossless_for_a_perfect_conductor():
+    """An infinite sigma sends gamma to infinity and zeta_c to zero: Z_s is 0.
+
+    The Bessel argument is unevaluable there, so the shape has to recognise
+    the limit rather than propagate a nan through it.
+    """
+    freq = Frequency.from_f(jnp.array([0.0, 1e9]))
+    conductor = _conductor(freq, sigma=jnp.inf)
+
+    zs = SchelkunoffRodShape().impedance(freq.w, conductor, a=0.455e-3)
+
+    assert jnp.all(zs == 0)

--- a/tests/test_math/test_bessel.py
+++ b/tests/test_math/test_bessel.py
@@ -1,0 +1,78 @@
+"""The complex Bessel ratio that the exact cylindrical conductor rests on.
+
+scipy is the reference here rather than a recorded ParamRF output: the point
+of these tests is that the hand-rolled JAX evaluator reproduces a known
+special function, not that it keeps doing whatever it does now.
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from scipy.special import ive
+
+from pmrf.math.bessel import I_RATIO_SERIES_CUTOFF, i0_over_i1
+
+
+def _reference(x):
+    """$I_0/I_1$ from scipy, via the exponentially scaled forms whose scalings cancel."""
+    return ive(0, x) / ive(1, x)
+
+
+@pytest.mark.parametrize(
+    # Both branches, and the seam between them, are separately in range.
+    "lo, hi, rtol, regime",
+    [
+        (1e-6, 1e-2, 5e-15, "small argument, where the ratio is essentially 2/x"),
+        (1e-2, 19.0, 1e-12, "power series"),
+        (19.0, 21.0, 5e-8, "the switch between the two branches"),
+        (21.0, 1e2, 5e-8, "asymptotic expansion, just past the switch"),
+        (1e2, 1e4, 5e-12, "asymptotic expansion, deep in its own regime"),
+    ],
+)
+@pytest.mark.parametrize("arg_deg", [0.0, 45.0, 60.0])
+def test_matches_scipy_over_the_argument_range(lo, hi, rtol, regime, arg_deg):
+    """45 degrees is the ray gamma = sqrt(j*w*mu*sigma) sits on; 0 and 60 bracket it."""
+    magnitude = np.logspace(np.log10(lo), np.log10(hi), 400)
+    x = magnitude * np.exp(1j * np.deg2rad(arg_deg))
+
+    got = np.asarray(i0_over_i1(jnp.asarray(x)))
+
+    assert np.abs(got / _reference(x) - 1).max() < rtol, regime
+
+
+def test_small_argument_tends_to_two_over_x():
+    """The dc limit of a cylindrical conductor is this limit, with no special case."""
+    x = jnp.asarray([1e-8, 1e-6, 1e-4]) * jnp.exp(1j * jnp.pi / 4)
+
+    assert jnp.allclose(i0_over_i1(x), 2 / x, rtol=1e-8)
+
+
+def test_large_argument_tends_to_one_plus_half_inverse():
+    """The strong-skin limit: a half-space plus the leading curvature term."""
+    x = jnp.asarray([1e3, 1e4]) * jnp.exp(1j * jnp.pi / 4)
+
+    assert jnp.allclose(i0_over_i1(x), 1 + 1 / (2 * x), rtol=1e-6)
+
+
+def test_gradient_is_finite_across_the_branch_switch():
+    """Both branches are evaluated on safe arguments, so neither poisons the other."""
+    def real_part(m):
+        return jnp.real(i0_over_i1(m * jnp.exp(1j * jnp.pi / 4)))
+
+    grads = jax.vmap(jax.grad(real_part))(
+        jnp.asarray([1e-6, 1.0, I_RATIO_SERIES_CUTOFF, 1e3, 1e4])
+    )
+
+    assert jnp.all(jnp.isfinite(grads))
+
+
+def test_the_derivative_jump_at_the_seam_is_small():
+    """The seam is a switch, not a blend, so record how big its kink actually is."""
+    def real_part(m):
+        return jnp.real(i0_over_i1(m * jnp.exp(1j * jnp.pi / 4)))
+
+    eps = 1e-6
+    below = jax.grad(real_part)(I_RATIO_SERIES_CUTOFF - eps)
+    above = jax.grad(real_part)(I_RATIO_SERIES_CUTOFF + eps)
+
+    assert abs(above / below - 1) < 2e-4

--- a/tests/test_math/test_bessel.py
+++ b/tests/test_math/test_bessel.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from scipy.special import ive
 
-from pmrf.math.bessel import I_RATIO_SERIES_CUTOFF, i0_over_i1
+from pmrf.math.bessel import I0_OVER_I1_SERIES_CUTOFF, i0_over_i1
 
 
 def _reference(x):
@@ -60,7 +60,7 @@ def test_gradient_is_finite_across_the_branch_switch():
         return jnp.real(i0_over_i1(m * jnp.exp(1j * jnp.pi / 4)))
 
     grads = jax.vmap(jax.grad(real_part))(
-        jnp.asarray([1e-6, 1.0, I_RATIO_SERIES_CUTOFF, 1e3, 1e4])
+        jnp.asarray([1e-6, 1.0, I0_OVER_I1_SERIES_CUTOFF, 1e3, 1e4])
     )
 
     assert jnp.all(jnp.isfinite(grads))
@@ -72,7 +72,7 @@ def test_the_derivative_jump_at_the_seam_is_small():
         return jnp.real(i0_over_i1(m * jnp.exp(1j * jnp.pi / 4)))
 
     eps = 1e-6
-    below = jax.grad(real_part)(I_RATIO_SERIES_CUTOFF - eps)
-    above = jax.grad(real_part)(I_RATIO_SERIES_CUTOFF + eps)
+    below = jax.grad(real_part)(I0_OVER_I1_SERIES_CUTOFF - eps)
+    above = jax.grad(real_part)(I0_OVER_I1_SERIES_CUTOFF + eps)
 
     assert abs(above / below - 1) < 2e-4

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -57,6 +57,8 @@ from pmrf.models import (
     HammerstadJensenMicrostripFormulation,
     KirschningJansenMicrostripDispersion,
     MicrostripLine,
+    SchelkunoffCoaxialFormulation,
+    TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
 )
 
@@ -174,19 +176,29 @@ def _sigma_of_rho(rho):
     return np.inf if rho == 0.0 else 1 / rho
 
 
-def _coax_pair(d_in, d_out, dielectric, rho, ep_r_of_f):
+#: The conductor model each side is put on, kept in step so a case can never
+#: compare ParamRF's inner-conductor physics against scikit-rf's other one.
+_COAX_MODELS = {
+    "tesche": TescheCoaxialFormulation,
+    "schelkunoff": SchelkunoffCoaxialFormulation,
+}
+
+
+def _coax_pair(d_in, d_out, dielectric, rho, ep_r_of_f, model="tesche"):
     """A ParamRF/scikit-rf builder pair for one coaxial geometry."""
     sigma = _sigma_of_rho(rho)
+    formulation = _COAX_MODELS[model]()
 
     def line(length):
         return CoaxialLine(
             d_in=d_in, d_out=d_out, dielectric=dielectric,
             conductor=BulkConductor(sigma=sigma), length=length,
+            formulation=formulation,
         )
 
     def media(freq, z0_port=None):
         return Coaxial(
-            freq, Dint=d_in, Dout=d_out, model="tesche", z0_port=z0_port,
+            freq, Dint=d_in, Dout=d_out, model=model, z0_port=z0_port,
             sigma=sigma,
             dielectric={"ep_r": ep_r_of_f(np.asarray(freq.f))},
         )
@@ -259,6 +271,89 @@ COAX_CASES = [
             _skrf_djordjevic_sarkar(ep_r=4.3, tand=0.02),
         ),
         length=0.1, z0=50.0, tol=_COAX_EXACT,
+    ),
+]
+
+#: Both sides solve the same Schelkunoff eq. (65) for the inner rod, but the
+#: shields differ: ParamRF charges the shield a half-space $\zeta_c$, while
+#: scikit-rf with ``tout=None`` evaluates Schelkunoff eq. (74) for a tube of
+#: infinite wall, which keeps the shield's own $K_0/K_1$ curvature. Only the
+#: shield's inner diameter is part of :class:`CoaxialLine`, so that
+#: correction is deliberately not modelled; the tolerances below are the
+#: measured size of that one difference, recorded per case, not a floor
+#: widened until a case passed. G and C never touch the conductors and stay
+#: at round-off in all three.
+_SHIELD_NOTE = (
+    "ParamRF models the shield as a Leontovich half-space and scikit-rf as an "
+    "infinitely thick Schelkunoff tube. Neither side is wrong: the shield's "
+    "wall thickness is not part of CoaxialLine, so its curvature correction "
+    "is out of the model by construction. The difference is largest at the "
+    "low-frequency end, where the shield is only a few skin depths deep."
+)
+
+#: The infinite-wall shield's internal inductance diverges logarithmically as
+#: $\omega\to0$ -- an infinitely thick return conductor stores unbounded
+#: internal flux -- while a half-space shield stores none. The two therefore
+#: describe different things below the skin-effect onset rather than
+#: disagreeing numerically, so L is compared only above 1 MHz.
+_SHIELD_L_NOTE = (
+    "Below the skin-effect onset the two shield models are not comparable at "
+    "all: scikit-rf's infinite wall has a logarithmically divergent internal "
+    "inductance and ParamRF's half-space has none. " + _SHIELD_NOTE
+)
+
+_SHIELD_L_FLOOR = 1e6
+
+
+def _shield_tol(*, R, L, zc, alpha, beta, s):
+    """Tolerances for a Schelkunoff case, keyed the same way as ``_COAX_EXACT``."""
+    return {
+        "R": (R, 1e-14), "L": (L, 0.0), "G": (1e-9, 0.0), "C": (1e-9, 0.0),
+        "zc": (zc, 0.0), "alpha": (alpha, 0.0), "beta": (beta, 0.0),
+        "s": (0.0, s),
+    }
+
+
+_SHIELD_NOTES = {q: _SHIELD_NOTE for q in ("R", "zc", "alpha", "beta", "s")} | {
+    "L": _SHIELD_L_NOTE
+}
+
+COAX_CASES += [
+    Case(
+        id="rg58_ptfe_copper_schelkunoff",
+        purpose="The default formulation on the nominal cable: the exact "
+                "cylindrical inner conductor, against scikit-rf's own Bessel "
+                "solution of the same Schelkunoff equation.",
+        **_coax_pair(0.9e-3, 2.95e-3, ConstantDielectric(ep_r=2.25, tand=1e-3),
+                    RHO_COPPER, lambda f: _coax_ep_r(2.25, 1e-3, f=f),
+                    model="schelkunoff"),
+        length=0.5, z0=50.0,
+        tol=_shield_tol(R=2e-2, L=1e-5, zc=1e-2, alpha=2e-2, beta=1e-2, s=5e-6),
+        notes=_SHIELD_NOTES, f_min={"L": _SHIELD_L_FLOOR},
+    ),
+    Case(
+        id="semirigid_small_diameters_steel_schelkunoff",
+        purpose="Stress on the default formulation: small diameters and a "
+                "stainless conductor put the dc-to-skin transition, where "
+                "Tesche is worst, right inside the band.",
+        **_coax_pair(0.51e-3, 1.68e-3, ConstantDielectric(ep_r=2.1, tand=2e-4),
+                    RHO_STEEL, lambda f: _coax_ep_r(2.1, 2e-4, f=f),
+                    model="schelkunoff"),
+        length=0.25, z0=50.0,
+        tol=_shield_tol(R=2e-2, L=5e-3, zc=1e-2, alpha=2e-2, beta=1e-2, s=5e-4),
+        notes=_SHIELD_NOTES, f_min={"L": _SHIELD_L_FLOOR},
+    ),
+    Case(
+        id="foam_large_diameter_ratio_schelkunoff",
+        purpose="Boundary on the default formulation: a large b/a, where the "
+                "thin inner conductor dominates the loss and the shield "
+                "difference is correspondingly small.",
+        **_coax_pair(0.3e-3, 7.0e-3, ConstantDielectric(ep_r=1.2, tand=1e-4),
+                    RHO_COPPER, lambda f: _coax_ep_r(1.2, 1e-4, f=f),
+                    model="schelkunoff"),
+        length=0.2, z0=75.0,
+        tol=_shield_tol(R=1e-3, L=1e-6, zc=5e-4, alpha=1e-3, beta=5e-4, s=5e-7),
+        notes=_SHIELD_NOTES, f_min={"L": _SHIELD_L_FLOOR},
     ),
 ]
 


### PR DESCRIPTION
Closes #97.

Tesche's equivalent circuit is an interpolation between limiting circuits, not the exact intermediate solution. Its attenuation error is a *shape* error — 5.3% for RG58 and 7.9% for RG405 over 10–500 MHz after removing a best-fit global scale — so refitting conductivity does not absorb it. This adds Schelkunoff eq. (65) and makes it the default; Tesche stays selectable as the cheap, Bessel-free alternative and as an independent cross-check.

## What landed

- **`pmrf/math/bessel.py`** — `i0_over_i1(x)` for complex `x`, since JAX has no complex Bessel functions. 40-term ascending series below |x| = 20, asymptotic expansion above, both branches evaluated on safe arguments so `jax.grad` is finite throughout.
- **`SchelkunoffRodShape`** — `Zs = ζc·I₀(γa)/I₁(γa)`, the exact solid cylinder. The dc limit `I₀/I₁ → 2/x` reproduces `1/(πa²σ)`; a perfect conductor is the other unevaluable argument and is handled by the same `where` pattern.
- **`SchelkunoffCoaxialFormulation`**, now `CoaxialLine`'s default. The body shared with Tesche moved into `_coaxial_immittance`, so the two formulations differ only in the inner-conductor shape.
- Tesche's docstrings corrected in both files: the circuit reaches `R_dc + Z_hf`, never the `1/2γa` curvature term of the exact solution.

## Validation

`i0_over_i1` is pinned against `scipy.special.ive` per regime over |x| ∈ [1e-6, 1e4] and |arg x| ≤ 60°, which covers the 45° ray `γ = √(jωμσ)`:

| regime | rtol |
|---|---|
| small argument (≈ 2/x) | 5e-15 |
| power series | 1e-12 |
| across the branch switch | 5e-8 |
| asymptotic, just past the switch | 5e-8 |
| asymptotic, deep in its own regime | 5e-12 |

The large-argument expansion is asymptotic about the positive real axis and degrades toward the imaginary axis (2e-6 at 70°, 6e-2 at 85°); that limit is documented, and no physics argument goes there. `SchelkunoffRodShape` itself is pinned against scipy at rtol 1e-10, plus tests for the dc limit, the strong-skin `ζc(1 + 1/2γa)` limit, finite gradients w.r.t. σ and f including at dc, and the perfect-conductor case.

Three Schelkunoff cases were added to the scikit-rf matrix. Full suite: 497 passed, 28 skipped.

## Two things worth a reviewer's judgement

**scikit-rf agreement is 0.15–0.27%, not round-off.** The residual is entirely the shield, not the rod: scikit-rf's `schelkunoff` model also applies eq. (74) with an infinite wall to the *outer* conductor (its K₀/K₁ curvature, 0.5–0.9% of the shield impedance at 10 MHz), whereas ParamRF keeps the half-space shield because `CoaxialLine` exposes only the shield's inner diameter. I read that as in scope — #97 scopes the work to the solid rod and says nothing about the shield — and recorded it per case in `_SHIELD_NOTE` rather than widening a global tolerance. `L` additionally carries a 1 MHz floor: the infinite-wall shield's internal inductance diverges logarithmically as ω→0 and a half-space's is zero, so below the skin-effect onset the two model different things rather than disagreeing numerically. Closing that gap needs a `SchelkunoffShieldShape` on K₀/K₁ plus a wall thickness on `CoaxialLine` — worth its own issue if exact agreement is wanted.

**The dc branch is a hard-coded closed form.** `jnp.where(w > 0, zs, 2/(a·σ))`. The issue says only γ→0 needs the `where` pattern, but the `where` still needs a value there, and `ζc·ratio(safe)` gives 0 rather than `R_dc`. The drift risk is real, so the test pins both the dc point and 1 Hz to `1/(πa²σ)`: if 1 Hz ever stops agreeing with the branch, it fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqykVh35heyjGy28wZMEmU