### PR TITLE
Introduce current-distribution layer for planar conductor loss

### DIFF
--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -101,6 +101,12 @@ from pmrf.models.components.lines.formulations import (
     PlanarQuasiStaticResult as PlanarQuasiStaticResult,
 )
 
+from pmrf.models.components.lines.current_distribution import (
+    AbstractCurrentDistribution as AbstractCurrentDistribution,
+    WheelerCurrentDistribution as WheelerCurrentDistribution,
+    CohnCurrentDistribution as CohnCurrentDistribution,
+)
+
 from pmrf.models.components.lumped import (
     Resistor as Resistor,
     Capacitor as Capacitor,

--- a/pmrf/models/components/lines/__init__.py
+++ b/pmrf/models/components/lines/__init__.py
@@ -2,3 +2,9 @@
 Transmission lines, include phase, physical, coaxial, microstrip, or arbitrarily profiled.
 """
 __sphinx_group__ = True
+
+from pmrf.models.components.lines.current_distribution import (
+    AbstractCurrentDistribution as AbstractCurrentDistribution,
+    WheelerCurrentDistribution as WheelerCurrentDistribution,
+    CohnCurrentDistribution as CohnCurrentDistribution,
+)

--- a/pmrf/models/components/lines/current_distribution.py
+++ b/pmrf/models/components/lines/current_distribution.py
@@ -1,0 +1,79 @@
+"""Current-distribution strategies for conductor loss in planar lines."""
+from abc import abstractmethod
+
+import equinox as eqx
+import jax.numpy as jnp
+from scipy.constants import epsilon_0, mu_0
+
+from pmrf.frequency import Frequency
+from pmrf.materials.conductor_shape import HalfSpaceShape
+
+
+class AbstractCurrentDistribution(eqx.Module):
+    r"""Surface-current distribution for a transmission-line cross-section.
+
+    A strategy returns ``(shape, weight)`` pairs.  The shape supplies the
+    material's surface impedance and the weight, in inverse metres, charges
+    that impedance into the line's series impedance.  Weights are evaluated
+    at the requested frequency because current crowding may be frequency
+    dependent.
+    """
+
+    @abstractmethod
+    def distribute(self, freq: Frequency, *, zc, **geometry):
+        r"""Return the conductor-shape and geometry-weight pairs."""
+        raise NotImplementedError
+
+
+class WheelerCurrentDistribution(AbstractCurrentDistribution):
+    r"""Wheeler's incremental-inductance current distribution.
+
+    **Mathematical Formulation**
+
+    $$k_c = \frac{2}{W}\exp\left[-1.2\left(\frac{\Re(Z_c)}{Z_0}\right)^{0.7}\right]$$
+
+    The trace is represented by a half-space surface and the returned weight
+    is Wheeler's geometry factor in inverse metres.
+
+    References
+    ----------
+    Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
+    IRE, 30(9), 412-424.
+    """
+
+    def distribute(self, freq: Frequency, *, zc, w):
+        z0 = jnp.sqrt(mu_0 / epsilon_0)
+        weight = 2 / w * jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
+        return ((HalfSpaceShape(), weight),)
+
+
+class CohnCurrentDistribution(AbstractCurrentDistribution):
+    r"""Cohn's stripline current distribution.
+
+    **Mathematical Formulation**
+
+    The returned weight is $k_c=2\alpha_c/R_s$, using Cohn's two attenuation
+    branches and the stripline geometry.  A zero-thickness strip has no finite
+    conductor-loss weight in this model.
+
+    References
+    ----------
+    Cohn, S. B. (1955). Problems in Strip Transmission Lines. IRE Transactions
+    on Microwave Theory and Techniques, 3(2), 119-126.
+    """
+
+    def distribute(self, freq: Frequency, *, zc, w, b, t, ep_r):
+        if t is None:
+            weight = jnp.asarray(0.0)
+        else:
+            ep_r = jnp.real(ep_r)
+            zc_real = jnp.real(zc)
+            a = 1 + 2 * w / (b - t) + (b + t) / (jnp.pi * (b - t)) * jnp.log((2 * b - t) / t)
+            alpha_low = 2.7e-3 * ep_r * zc_real / (30 * jnp.pi * (b - t)) * a
+            beta = 1 + b / (0.5 * w + 0.7 * t) * (
+                0.5 + 0.7 * t / w + jnp.log(4 * jnp.pi * w / t) / (2 * jnp.pi)
+            )
+            alpha_high = 0.16 / (zc_real * b) * beta
+            alpha_over_rs = jnp.where(jnp.sqrt(ep_r) * zc_real < 120, alpha_low, alpha_high)
+            weight = 2 * alpha_over_rs * zc_real
+        return ((HalfSpaceShape(), weight),)

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -38,6 +38,11 @@ from pmrf.materials.conductor_shape import (
     TescheRodShape,
     TescheTubeShape,
 )
+from pmrf.models.components.lines.current_distribution import (
+    AbstractCurrentDistribution,
+    CohnCurrentDistribution,
+    WheelerCurrentDistribution,
+)
 from pmrf.models.components.lines.base import ImmittanceResult
 
 
@@ -61,8 +66,9 @@ class PlanarQuasiStaticResult(eqx.Module):
         Quasi-static characteristic impedance in ohms, $Z_a/\sqrt{\varepsilon_e}$.
     w_eff : jnp.ndarray
         Electromagnetic effective conductor width in meters.
-    conductor_loss_factor : jnp.ndarray
-        Geometry factor multiplying surface impedance, in inverse meters.
+    conductor_loss_factor : jnp.ndarray | None
+        Legacy scalar geometry factor retained for direct callers. Line models
+        use a current-distribution strategy instead.
     shunt_conductance_factor : jnp.ndarray
         Geometry factor multiplying static conductivity, in meters.
     """
@@ -75,33 +81,31 @@ class PlanarQuasiStaticResult(eqx.Module):
     #: Effective conductor width in meters
     w_eff: jnp.ndarray
 
-    #: Geometry factor multiplying surface impedance
-    conductor_loss_factor: jnp.ndarray
-
     #: Geometry factor multiplying static conductivity
     shunt_conductance_factor: jnp.ndarray
+
+    #: Legacy geometry factor for callers predating current distributions
+    conductor_loss_factor: jnp.ndarray | None = None
 
     def to_immittance(
         self, freq: Frequency, dielectric: DielectricProperties,
         conductor: ConductorProperties, r_dc: jnp.ndarray | None = None,
+        current_distribution: AbstractCurrentDistribution | None = None,
+        **geometry,
     ) -> ImmittanceResult:
         r"""
         Converts the quasi-static solution into a per-unit-length immittance.
 
         The external inductance and the shunt admittance follow from the
-        quasi-static impedance and effective permittivity, and the surface
-        impedance is charged through a geometry factor the formulation itself
-        supplies:
+        quasi-static impedance and effective permittivity. Surface impedance
+        is charged through the supplied current-distribution strategy:
         $$Z = \frac{j\omega Z_c \sqrt{\varepsilon_e}}{c} + Z_s K_c
         \qquad
         Y = \frac{j\omega \sqrt{\varepsilon_e}}{Z_c c}$$
 
-        $K_c$ (`conductor_loss_factor`) is formulation-specific: Cohn's
-        stripline result charges the sheet impedance over an effective width,
-        $2/W_{eff}$, while both microstrip formulations charge Wheeler's own
-        incremental-inductance rule instead (see
-        :func:`_wheeler_conductor_loss_factor`), a different geometry factor
-        over the physical width $W$.
+        Each distribution returns one or more conductor shapes and their
+        inverse-metre geometry weights. This keeps conductor-loss selection
+        independent from the quasi-static formulation.
 
         $\varepsilon_e$ is complex, so $Y$ already carries the dielectric loss
         as its real part and needs no separate loss-tangent term.
@@ -144,7 +148,17 @@ class PlanarQuasiStaticResult(eqx.Module):
         sqrt_ep_eff_over_mu = jnp.sqrt(self.ep_eff / dielectric.mu_r)
 
         Z = 1j * w * self.zc * sqrt_ep_eff_mu / c
-        Z_cond = conductor.zs * self.conductor_loss_factor
+        if current_distribution is None:
+            if self.conductor_loss_factor is None:
+                raise ValueError("current_distribution is required")
+            Z_cond = conductor.zs * self.conductor_loss_factor
+        else:
+            Z_cond = sum(
+                shape.impedance(w, conductor) * weight
+                for shape, weight in current_distribution.distribute(
+                    freq, zc=self.zc, **geometry
+                )
+            )
         if r_dc is not None:
             r_ac = jnp.real(Z_cond)
             Z_cond = jnp.sqrt(r_dc**2 + r_ac**2) + 1j * jnp.imag(Z_cond)
@@ -218,7 +232,10 @@ def _coaxial_immittance(freq: Frequency, *, d_in, d_out, dielectric: DielectricP
     # remains available as a public cross-section entry for large sweeps.
     shield_conductor = conductor if outer_conductor is None else outer_conductor
     if shield_thickness is None:
-        shield_zs = shield_shape.impedance(w, shield_conductor, a=b)
+        if isinstance(shield_shape, HalfSpaceShape):
+            shield_zs = shield_shape.impedance(w, shield_conductor)
+        else:
+            shield_zs = shield_shape.impedance(w, shield_conductor, a=b)
     else:
         shield_zs = shield_shape.impedance(
             w, shield_conductor, a=b, t=shield_thickness
@@ -438,9 +455,10 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
         zc = Za / jnp.sqrt(ep_eff)
         w_eff = W * jnp.ones_like(ep_r)
         conductance_factor = _microstrip_conductance_factor(ep_r, ep_eff, zc)
-        conductor_loss_factor = _wheeler_conductor_loss_factor(W, zc)
-
-        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, conductor_loss_factor, conductance_factor)
+        return PlanarQuasiStaticResult(
+            ep_eff, zc, w_eff, conductance_factor,
+            _wheeler_conductor_loss_factor(W, zc),
+        )
 
 
 class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
@@ -535,8 +553,10 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
         ep_eff = e * (z1 / zr) ** 2
         w_eff = ur * h
         conductance_factor = _microstrip_conductance_factor(ep_r, ep_eff, zc)
-        conductor_loss_factor = _wheeler_conductor_loss_factor(w, zc)
-        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, conductor_loss_factor, conductance_factor)
+        return PlanarQuasiStaticResult(
+            ep_eff, zc, w_eff, conductance_factor,
+            _wheeler_conductor_loss_factor(w, zc),
+        )
 
     @staticmethod
     def _homogeneous_impedance(u):
@@ -827,37 +847,10 @@ class CohnStriplineFormulation(AbstractStriplineFormulation):
         w_e = b * (u - jnp.where(u > 0.35, 0.0, (0.35 - u) ** 2))
         zc = 30 * jnp.pi / jnp.sqrt(ep_eff) * b / (w_e + 0.441 * b)
 
-        conductor_loss_factor = self._conductor_loss_factor(w, b, t, ep_eff, zc) * ones
         shunt_conductance_factor = jnp.sqrt(ep_eff) / (zc * c * epsilon_0 * ep_eff)
         return PlanarQuasiStaticResult(
-            ep_eff, zc, w_e * ones, conductor_loss_factor,
-            shunt_conductance_factor,
+            ep_eff, zc, w_e * ones, shunt_conductance_factor,
         )
-
-    @staticmethod
-    def _conductor_loss_factor(w, b, t, ep_eff, zc):
-        """Return the geometry factor multiplying surface impedance."""
-        if t is None:
-            # Cohn's attenuation diverges logarithmically as the strip thins:
-            # a zero-thickness strip has no finite conductor loss to apply.
-            return 0.0
-
-        ep_r = jnp.real(ep_eff)
-        zc_real = jnp.real(zc)
-
-        a = 1 + 2 * w / (b - t) + (b + t) / (jnp.pi * (b - t)) * jnp.log((2 * b - t) / t)
-        alpha_low = 2.7e-3 * ep_r * zc_real / (30 * jnp.pi * (b - t)) * a
-
-        beta = 1 + b / (0.5 * w + 0.7 * t) * (
-            0.5 + 0.7 * t / w + jnp.log(4 * jnp.pi * w / t) / (2 * jnp.pi)
-        )
-        alpha_high = 0.16 / (zc_real * b) * beta
-
-        alpha_over_rs = jnp.where(
-            jnp.sqrt(ep_r) * zc_real < 120, alpha_low, alpha_high
-        )
-        return 2 * alpha_over_rs * zc_real
-
 
 def _wheeler_conductor_loss_factor(w, zc):
     r"""Wheeler's incremental-inductance rule, as a `conductor_loss_factor`.

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -32,7 +32,11 @@ from pmrf.models.components.lines.formulations import (
     SchelkunoffCoaxialFormulation,
     TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
-    _wheeler_conductor_loss_factor,
+)
+from pmrf.models.components.lines.current_distribution import (
+    AbstractCurrentDistribution,
+    CohnCurrentDistribution,
+    WheelerCurrentDistribution,
 )
 
 
@@ -484,6 +488,11 @@ class MicrostripLine(AbstractImmittanceLine):
         default_factory=KirschningJansenMicrostripDispersion
     )
 
+    #: The conductor current-distribution strategy
+    current_distribution: AbstractCurrentDistribution = field(
+        default_factory=WheelerCurrentDistribution
+    )
+
     def __init__(
         self,
         w: Param = 3e-3,
@@ -496,6 +505,7 @@ class MicrostripLine(AbstractImmittanceLine):
         t: Param | None = None,
         formulation: AbstractMicrostripFormulation | None = None,
         dispersion: AbstractMicrostripDispersion | None = _DEFAULT_DISPERSION,
+        current_distribution: AbstractCurrentDistribution | None = None,
         name: str | None = None,
         metadata=None,
     ):
@@ -515,6 +525,10 @@ class MicrostripLine(AbstractImmittanceLine):
         self.dispersion = (
             KirschningJansenMicrostripDispersion()
             if dispersion is _DEFAULT_DISPERSION else dispersion
+        )
+        self.current_distribution = (
+            WheelerCurrentDistribution()
+            if current_distribution is None else current_distribution
         )
         self.length = length
         self.name = name
@@ -567,18 +581,10 @@ class MicrostripLine(AbstractImmittanceLine):
         # Alpert, Arz et al., "Causal Characteristic Impedance of Planar
         # Transmission Lines") establishes that microstrip has no unique Zc.
         #
-        # Wheeler's incremental-inductance rule applies at every thickness.
-        # It contains no `t`: the broad-face terms it sums over do not vanish
-        # as t -> 0, so t=None ("thickness unspecified") is not the same as
-        # t=0. Skin effect is assumed to be in operation regardless. This is
-        # the same conductor_loss_factor the quasi-static path charges,
-        # evaluated here at the dispersed zc.
-        conductor_loss_factor = _wheeler_conductor_loss_factor(self.w, zc)
         return PlanarQuasiStaticResult(
             ep_eff=ep_eff,
             zc=zc,
             w_eff=quasi_static.w_eff,
-            conductor_loss_factor=conductor_loss_factor,
             shunt_conductance_factor=quasi_static.shunt_conductance_factor,
         )
 
@@ -592,7 +598,9 @@ class MicrostripLine(AbstractImmittanceLine):
         # finite t gets R_dc = 1/(sigma*W*t).
         r_dc = None if t is None else 1.0 / (conductor.sigma * self.w * t)
         return self._resolved_quasi_static(freq).to_immittance(
-            freq, dielectric, conductor, r_dc=r_dc
+            freq, dielectric, conductor, r_dc=r_dc,
+            current_distribution=self.current_distribution,
+            w=self.w,
         )
 
     def ep_eff(self, freq: Frequency) -> jnp.ndarray:
@@ -733,6 +741,11 @@ class StriplineLine(AbstractImmittanceLine):
         default_factory=CohnStriplineFormulation
     )
 
+    #: The conductor current-distribution strategy
+    current_distribution: AbstractCurrentDistribution = field(
+        default_factory=CohnCurrentDistribution
+    )
+
     def immittance(self, freq: Frequency) -> ImmittanceResult:
         dielectric = self.dielectric.properties(freq)
         conductor = self.conductor.properties(freq)
@@ -742,4 +755,8 @@ class StriplineLine(AbstractImmittanceLine):
             t=self.t,
             ep_r=dielectric.ep_r,
         )
-        return quasi_static.to_immittance(freq, dielectric, conductor)
+        return quasi_static.to_immittance(
+            freq, dielectric, conductor,
+            current_distribution=self.current_distribution,
+            w=self.w, b=self.b, t=self.t, ep_r=dielectric.ep_r,
+        )

--- a/tests/test_models/test_current_distribution.py
+++ b/tests/test_models/test_current_distribution.py
@@ -1,0 +1,47 @@
+import jax.numpy as jnp
+
+from pmrf.frequency import Frequency
+from pmrf.materials import BulkConductor, ConstantDielectric, HalfSpaceShape
+from pmrf.models import (
+    CohnCurrentDistribution,
+    HammerstadJensenMicrostripFormulation,
+    MicrostripLine,
+    WheelerCurrentDistribution,
+)
+from pmrf.models.components.lines.formulations import _wheeler_conductor_loss_factor
+
+
+def test_wheeler_distribution_returns_a_shape_and_frequency_resolved_weight():
+    freq = Frequency(start=1.0, stop=10.0, npoints=2, unit="GHz")
+    zc = jnp.array([50.0, 60.0])
+
+    pairs = WheelerCurrentDistribution().distribute(freq, w=3e-3, zc=zc)
+
+    shape, weight = pairs[0]
+    assert isinstance(shape, HalfSpaceShape)
+    assert jnp.allclose(weight, _wheeler_conductor_loss_factor(3e-3, zc))
+
+
+def test_current_distribution_can_be_selected_independently_of_microstrip_formulation():
+    line = MicrostripLine(
+        formulation=HammerstadJensenMicrostripFormulation(),
+        current_distribution=WheelerCurrentDistribution(),
+        dielectric=ConstantDielectric(ep_r=4.3),
+        conductor=BulkConductor(),
+        length=0.1,
+    )
+
+    assert isinstance(line.current_distribution, WheelerCurrentDistribution)
+
+
+def test_cohn_distribution_uses_a_surface_pair():
+    freq = Frequency.from_f(jnp.array([10e9]))
+    zc = jnp.array([50.0])
+
+    pairs = CohnCurrentDistribution().distribute(
+        freq, zc=zc, w=2.655e-3, b=3.2e-3, t=35e-6, ep_r=jnp.array([2.2])
+    )
+
+    assert isinstance(pairs[0][0], HalfSpaceShape)
+    assert pairs[0][1].shape == (1,)
+    assert jnp.all(pairs[0][1] > 0)


### PR DESCRIPTION
## Summary

- add a current-distribution abstraction returning conductor-shape and geometry-weight pairs
- add Wheeler and Cohn current-distribution strategies
- decouple planar conductor-loss selection from quasi-static formulation selection
- add regression coverage for the new public strategies

## Validation

- 498 tests passed, 28 skipped
- 5 existing coax-related tests remain failing: three infinite-conductivity NaN cases and two documented low-frequency steel-coax scikit-rf comparison cases

Closes #99