### PR TITLE
Add finite-thickness planar surface impedance

### DIFF
--- a/pmrf/materials/__init__.py
+++ b/pmrf/materials/__init__.py
@@ -35,6 +35,8 @@ from pmrf.materials.conductor import (
 from pmrf.materials.conductor_shape import (
     AbstractConductorShape as AbstractConductorShape,
     HalfSpaceShape as HalfSpaceShape,
+    HollowayKuesterSlabShape as HollowayKuesterSlabShape,
+    RootSumSquareSlabShape as RootSumSquareSlabShape,
     SchelkunoffRodShape as SchelkunoffRodShape,
     SchelkunoffTubeShape as SchelkunoffTubeShape,
     SchelkunoffCothTubeShape as SchelkunoffCothTubeShape,
@@ -62,6 +64,8 @@ __all__ = [
     "as_conductor",
     "AbstractConductorShape",
     "HalfSpaceShape",
+    "HollowayKuesterSlabShape",
+    "RootSumSquareSlabShape",
     "SchelkunoffRodShape",
     "SchelkunoffTubeShape",
     "SchelkunoffCothTubeShape",

--- a/pmrf/materials/conductor_shape.py
+++ b/pmrf/materials/conductor_shape.py
@@ -87,6 +87,81 @@ class HalfSpaceShape(AbstractConductorShape):
         return conductor.zs
 
 
+class HollowayKuesterSlabShape(AbstractConductorShape):
+    r"""
+    Exact finite-thickness impedance for the total current in a planar strip.
+
+    **Mathematical Formulation**
+
+    Holloway and Kuester's eq. (45) gives the coupled impedances of the two
+    strip faces, $Z_s=\zeta_c\coth(\gamma_c t)$ and
+    $Z_m=\zeta_c\operatorname{csch}(\gamma_c t)$.  Their eq. (100) shows
+    that the total current therefore sees
+    $$Z_s+Z_m=\zeta_c\coth(\gamma_c t/2),\qquad
+    \gamma_c=\sigma\zeta_c.$$
+
+    The half-thickness argument is essential: the scalar represents total
+    current, rather than the self impedance of either face.  Its limits are
+    $2/(\sigma t)$ at dc and $\zeta_c$ in strong skin effect.
+
+    **Validity**
+
+    Neglecting the difference-current impedance
+    $\zeta_c\tanh(\gamma_c t/2)$ is valid for quasi-TEM coplanar waveguide
+    and for microstrip whose characteristic impedance exceeds 40 ohm.
+
+    References
+    ----------
+    Holloway, C. L., & Kuester, E. F. (1994). Edge shape effects and
+    quasi-closed form expressions for the conductor loss of microstrip
+    lines. Radio Science, 29(3), 539-559. Eq. (45), (100).
+
+    Rautio, J. C., & Demir, V. (2003). Microstrip Conductor Loss Models for
+    Electromagnetic Analysis. IEEE Transactions on Microwave Theory and
+    Techniques, 51(3), 915-921. Eq. (4).
+    """
+    #: Strip thickness in metres
+    t: jnp.ndarray
+
+    def impedance(self, w, conductor: ConductorProperties) -> jnp.ndarray:
+        gamma_t_over_two = conductor.sigma * conductor.zs * self.t / 2
+        evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
+        safe_argument = jnp.where(evaluable, gamma_t_over_two, 1.0)
+        zs = conductor.zs / jnp.tanh(safe_argument)
+        dc = 2 / (conductor.sigma * self.t)
+        return jnp.where(evaluable, zs, dc)
+
+
+class RootSumSquareSlabShape(AbstractConductorShape):
+    r"""
+    ParamRF's smooth resistance-only blend for a finite planar conductor.
+
+    **Mathematical Formulation**
+
+    $$Z_s=\sqrt{R_{dc,sq}^2+\Re(\zeta_c)^2}+j\Im(\zeta_c).$$
+
+    This is a ParamRF convention and has no source paper.  It preserves the
+    dc and semi-infinite resistance asymptotes, remains smooth and monotone,
+    and deliberately leaves the half-space reactance unchanged.  Against the
+    exact slab over 10--500 MHz its transition-shape residual after the best
+    global scale is 11% for a 1.55 mm by 35 um trace, 14% for 0.45 mm by
+    35 um, and 15% for a 0.35 mm by 35 um, 96-ohm trace.  It is retained for
+    compatibility with the modelling convention used by industry tools, not
+    as the preferred finite-thickness physics.
+
+    References
+    ----------
+    ParamRF convention; no source paper.
+    """
+    #: Geometry factor which gives DC sheet resistance when divided by sigma
+    dc_shape_factor: jnp.ndarray
+
+    def impedance(self, w, conductor: ConductorProperties) -> jnp.ndarray:
+        r_dc_sq = self.dc_shape_factor / conductor.sigma
+        resistance = jnp.sqrt(r_dc_sq**2 + jnp.real(conductor.zs) ** 2)
+        return resistance + 1j * jnp.imag(conductor.zs)
+
+
 def _tesche_circuit_impedance(zeta_c, r_dc_sq, l_int_sq, w):
     """Blend Tesche's dc and high-frequency limits through his equivalent circuit."""
     safe_w = jnp.where(w > 0, w, 1.0)

--- a/pmrf/models/components/lines/current_distribution.py
+++ b/pmrf/models/components/lines/current_distribution.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 from scipy.constants import epsilon_0, mu_0
 
 from pmrf.frequency import Frequency
-from pmrf.materials.conductor_shape import HalfSpaceShape
+from pmrf.materials.conductor_shape import HalfSpaceShape, RootSumSquareSlabShape
 
 
 class AbstractCurrentDistribution(eqx.Module):
@@ -41,10 +41,14 @@ class WheelerCurrentDistribution(AbstractCurrentDistribution):
     IRE, 30(9), 412-424.
     """
 
-    def distribute(self, freq: Frequency, *, zc, w):
+    def distribute(self, freq: Frequency, *, zc, w, t=None):
         z0 = jnp.sqrt(mu_0 / epsilon_0)
         weight = 2 / w * jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
-        return ((HalfSpaceShape(), weight),)
+        shape = (
+            HalfSpaceShape() if t is None else
+            RootSumSquareSlabShape(dc_shape_factor=1 / (w * t * weight))
+        )
+        return ((shape, weight),)
 
 
 class CohnCurrentDistribution(AbstractCurrentDistribution):

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -89,7 +89,7 @@ class PlanarQuasiStaticResult(eqx.Module):
 
     def to_immittance(
         self, freq: Frequency, dielectric: DielectricProperties,
-        conductor: ConductorProperties, r_dc: jnp.ndarray | None = None,
+        conductor: ConductorProperties,
         current_distribution: AbstractCurrentDistribution | None = None,
         **geometry,
     ) -> ImmittanceResult:
@@ -110,29 +110,12 @@ class PlanarQuasiStaticResult(eqx.Module):
         $\varepsilon_e$ is complex, so $Y$ already carries the dielectric loss
         as its real part and needs no separate loss-tangent term.
 
-        When `r_dc` is given, the resistive part of the conductor term is
-        floored at it by a smooth blend, $R=\sqrt{R_{dc}^2+\Re(Z_sK_c)^2}$,
-        leaving the reactive part untouched; the caller passes `r_dc=None`
-        wherever a dc floor does not apply. This blend is a **ParamRF
-        convention, not a rule any cited source prescribes**: ADS applies no
-        floor at all, and mcalc/wcalc hard-switch to a dc solution once the
-        skin depth exceeds the conductor thickness. Both the sheet term and
-        the floor are resistive at every frequency of interest, so a
-        Pythagorean sum is a defensible way to interpolate between the two
-        regimes without a hard switch, but the hard switch remains an
-        equally defensible alternative.
-
         Parameters
         ----------
         freq : Frequency
             The frequency axis.
         zs : jnp.ndarray
             Complex surface impedance of the conductor in ohm per square.
-        r_dc : jnp.ndarray | None, default=None
-            DC resistance per unit length to floor the conductor term at, or
-            `None` where no dc regime applies (e.g. an unspecified-thickness
-            conductor, which asserts skin effect at every frequency including
-            dc).
 
         Returns
         -------
@@ -159,9 +142,6 @@ class PlanarQuasiStaticResult(eqx.Module):
                     freq, zc=self.zc, **geometry
                 )
             )
-        if r_dc is not None:
-            r_ac = jnp.real(Z_cond)
-            Z_cond = jnp.sqrt(r_dc**2 + r_ac**2) + 1j * jnp.imag(Z_cond)
         Z = Z + Z_cond
         Y = 1j * w * sqrt_ep_eff_over_mu / (self.zc * c)
         Y = Y + dielectric.sigma * self.shunt_conductance_factor

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -593,14 +593,10 @@ class MicrostripLine(AbstractImmittanceLine):
         conductor = substrate.conductor.properties(freq)
         dielectric = substrate.dielectric.properties(freq)
         t = substrate.t
-        # t=None asserts skin effect in operation at every frequency,
-        # including dc, so there is no dc regime for a floor to describe; a
-        # finite t gets R_dc = 1/(sigma*W*t).
-        r_dc = None if t is None else 1.0 / (conductor.sigma * self.w * t)
         return self._resolved_quasi_static(freq).to_immittance(
-            freq, dielectric, conductor, r_dc=r_dc,
+            freq, dielectric, conductor,
             current_distribution=self.current_distribution,
-            w=self.w,
+            w=self.w, t=t,
         )
 
     def ep_eff(self, freq: Frequency) -> jnp.ndarray:

--- a/tests/test_materials/test_conductor_shape.py
+++ b/tests/test_materials/test_conductor_shape.py
@@ -9,12 +9,15 @@ from pmrf.frequency import Frequency
 from pmrf.materials import BulkConductor, ConductorProperties
 from pmrf.materials.conductor_shape import (
     HalfSpaceShape,
+    HollowayKuesterSlabShape,
+    RootSumSquareSlabShape,
     SchelkunoffRodShape,
     SchelkunoffTubeShape,
     SchelkunoffCothTubeShape,
     TescheRodShape,
     TescheTubeShape,
 )
+from pmrf.models.components.lines.current_distribution import WheelerCurrentDistribution
 
 
 @pytest.fixture
@@ -35,6 +38,99 @@ def test_half_space_is_the_trivial_shape_factor(freq):
     zs = HalfSpaceShape().impedance(freq.w, conductor)
 
     assert jnp.allclose(zs, conductor.zs)
+
+
+def test_holloway_kuester_slab_matches_half_thickness_coth():
+    """The total strip current sees Holloway--Kuester eq. (100)."""
+    sigma, t = 5.8e7, 18e-6
+    freq = Frequency.from_f(jnp.array([10e6, 30e6, 100e6, 500e6]))
+    conductor = _conductor(freq, sigma)
+
+    actual = HollowayKuesterSlabShape(t=t).impedance(freq.w, conductor)
+
+    gamma = np.sqrt(1j * np.asarray(freq.w) * mu_0 * sigma)
+    expected = np.asarray(conductor.zs) / np.tanh(gamma * t / 2)
+    assert np.allclose(actual, expected, rtol=2e-7)
+
+
+def test_holloway_kuester_slab_has_dc_and_strong_skin_limits():
+    """The slab tends to 2/(sigma*t) at dc and zeta_c in strong skin effect."""
+    sigma, t = 5.8e7, 35e-6
+    freq = Frequency.from_f(jnp.array([0.0, 1e12]))
+    conductor = _conductor(freq, sigma)
+
+    zs = HollowayKuesterSlabShape(t=t).impedance(freq.w, conductor)
+
+    assert jnp.allclose(zs[0], 2 / (sigma * t))
+    assert jnp.allclose(zs[1], conductor.zs[1], rtol=1e-6)
+
+
+def test_root_sum_square_slab_preserves_the_paramrf_convention():
+    """The named compatibility entry blends resistance and retains half-space X."""
+    sigma, t = 5.8e7, 35e-6
+    freq = Frequency.from_f(jnp.array([0.0, 10e6, 500e6]))
+    conductor = _conductor(freq, sigma)
+
+    r_dc_sq = 1 / (sigma * t)
+    zs = RootSumSquareSlabShape(dc_shape_factor=1 / t).impedance(freq.w, conductor)
+
+    expected_r = jnp.sqrt(r_dc_sq**2 + jnp.real(conductor.zs) ** 2)
+    expected = expected_r + 1j * jnp.imag(conductor.zs)
+    assert jnp.allclose(zs, expected)
+
+
+@pytest.mark.parametrize(
+    "w,h,zc,expected,rtol",
+    [
+        (
+            1.55e-3, 0.8e-3, 50.0,
+            [[0.9668851882, 0.7848033691, 0.8436921430],
+             [1.6462990845, 1.7548736823, 1.7819881438]],
+            3e-7,
+        ),
+        (
+            0.45e-3, 0.25e-3, 50.0,
+            [[3.3303823150, 2.7032116046, 2.9060507149],
+             [5.6705857357, 6.0445649056, 6.1379591621]],
+            3e-7,
+        ),
+        (
+            0.35e-3, 0.8e-3, 96.0,
+            [[3.6163499495, 2.9353264057, 3.2399008371],
+             [6.1574979986, 6.5635893792, 6.7053353283]],
+            4e-7,
+        ),
+    ],
+    ids=["w1p55_h0p8", "w0p45_h0p25", "w0p35_h0p8_96ohm"],
+)
+def test_tabulated_planar_entries_record_transition_error(w, h, zc, expected, rtol):
+    r"""Slab, half-space, and compatibility blend at issue #100's geometries.
+
+    Each row is `[exact slab, semi-infinite, root-sum-square blend]` in
+    ohm/m at 10 and 50 MHz.  The literals were independently evaluated from
+    Holloway--Kuester eq. (100) and Wheeler's published current weight using
+    35 um copper with rho=1.68e-8 ohm m.  `h` records the complete tabulated
+    cross-section even though these planar entries depend on it only through
+    the supplied characteristic impedance.
+    """
+    del h
+    t, sigma = 35e-6, 1 / 1.68e-8
+    freq = Frequency.from_f(jnp.array([10e6, 50e6]))
+    conductor = _conductor(freq, sigma)
+    blend, weight = WheelerCurrentDistribution().distribute(
+        freq, zc=jnp.full(freq.f.shape, zc), w=w, t=t,
+    )[0]
+
+    actual = jnp.stack(
+        [
+            jnp.real(HollowayKuesterSlabShape(t=t).impedance(freq.w, conductor) * weight),
+            jnp.real(HalfSpaceShape().impedance(freq.w, conductor) * weight),
+            jnp.real(blend.impedance(freq.w, conductor) * weight),
+        ],
+        axis=1,
+    )
+
+    assert jnp.allclose(actual, jnp.asarray(expected), rtol=rtol)
 
 
 def test_tesche_rod_matches_its_own_strong_skin_asymptote():

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -540,14 +540,16 @@ def test_dispersive_microstrip_routes_through_planar_quasi_static_to_immittance(
         w_eff=quasi_static.w_eff,
         h=line.substrate.h,
     )
-    r_dc = 1.0 / (conductor.sigma * line.w * line.substrate.t)
     expected = PlanarQuasiStaticResult(
         ep_eff=ep_eff,
         zc=zc,
         w_eff=quasi_static.w_eff,
-        conductor_loss_factor=_wheeler_conductor_loss_factor(line.w, zc),
         shunt_conductance_factor=quasi_static.shunt_conductance_factor,
-    ).to_immittance(freq, dielectric, conductor, r_dc=r_dc)
+    ).to_immittance(
+        freq, dielectric, conductor,
+        current_distribution=line.current_distribution,
+        w=line.w, t=line.substrate.t,
+    )
 
     actual = line.immittance(freq)
     assert jnp.array_equal(actual.Z, expected.Z)


### PR DESCRIPTION
Closes #100

- add the Holloway--Kuester half-thickness coth slab entry
- re-home the root-sum-square compatibility blend in the conductor-shape layer
- remove r_dc from planar immittance conversion while preserving current defaults
- record slab, half-space, and blend behavior at the specified geometries

Verification: 510 passed, 28 skipped