### PR TITLE
Add microstrip trace and ground current split

### DIFF
--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -104,6 +104,7 @@ from pmrf.models.components.lines.formulations import (
 from pmrf.models.components.lines.current_distribution import (
     AbstractCurrentDistribution as AbstractCurrentDistribution,
     WheelerCurrentDistribution as WheelerCurrentDistribution,
+    TraceGroundCurrentDistribution as TraceGroundCurrentDistribution,
     CohnCurrentDistribution as CohnCurrentDistribution,
 )
 

--- a/pmrf/models/components/lines/__init__.py
+++ b/pmrf/models/components/lines/__init__.py
@@ -6,5 +6,6 @@ __sphinx_group__ = True
 from pmrf.models.components.lines.current_distribution import (
     AbstractCurrentDistribution as AbstractCurrentDistribution,
     WheelerCurrentDistribution as WheelerCurrentDistribution,
+    TraceGroundCurrentDistribution as TraceGroundCurrentDistribution,
     CohnCurrentDistribution as CohnCurrentDistribution,
 )

--- a/pmrf/models/components/lines/current_distribution.py
+++ b/pmrf/models/components/lines/current_distribution.py
@@ -6,7 +6,17 @@ import jax.numpy as jnp
 from scipy.constants import epsilon_0, mu_0
 
 from pmrf.frequency import Frequency
-from pmrf.materials.conductor_shape import HalfSpaceShape, RootSumSquareSlabShape
+from pmrf.materials.conductor_shape import (
+    HalfSpaceShape,
+    HollowayKuesterSlabShape,
+    RootSumSquareSlabShape,
+)
+
+
+def _wheeler_current_factor(zc):
+    """Return Wheeler's dimensionless current-crowding factor."""
+    z0 = jnp.sqrt(mu_0 / epsilon_0)
+    return jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
 
 
 class AbstractCurrentDistribution(eqx.Module):
@@ -41,14 +51,89 @@ class WheelerCurrentDistribution(AbstractCurrentDistribution):
     IRE, 30(9), 412-424.
     """
 
-    def distribute(self, freq: Frequency, *, zc, w, t=None):
-        z0 = jnp.sqrt(mu_0 / epsilon_0)
-        weight = 2 / w * jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
+    def distribute(self, freq: Frequency, *, zc, w, t=None, conductor=None, **geometry):
+        weight = 2 / w * _wheeler_current_factor(zc)
         shape = (
             HalfSpaceShape() if t is None else
             RootSumSquareSlabShape(dc_shape_factor=1 / (w * t * weight))
         )
         return ((shape, weight),)
+
+
+class TraceGroundCurrentDistribution(AbstractCurrentDistribution):
+    r"""Independent microstrip trace and ground-plane current distributions.
+
+    **Mathematical Formulation**
+
+    Holloway and Kuester's ground-plane current density for a uniform strip
+    current is
+
+    $$\frac{J_g(x)}{I}=\frac{1}{\pi W}\left[
+    \tan^{-1}\left(\frac{2x-W}{2h}\right)-
+    \tan^{-1}\left(\frac{2x+W}{2h}\right)\right].$$
+
+    Defining the effective ground width by
+    $1/W_g=\int_{-\infty}^{\infty}|J_g/I|^2dx$ gives
+
+    $$\frac{1}{W_g}=\frac{2}{\pi W^2}\left[
+    W\tan^{-1}\left(\frac{W}{2h}\right)-
+    h\log\left(1+\frac{W^2}{4h^2}\right)\right].$$
+
+    The trace uses the finite-thickness total-current slab. Its weight moves
+    from $1/(2W)$ at dc, which gives the exact trace resistance
+    $1/(\sigma Wt)$, to Wheeler's $2K_i/W$ strong-skin trace weight. The
+    transition is $|\tanh(\gamma_ct/2)|$, the same dimensionless penetration
+    factor appearing in the slab impedance. The ground is deliberately held
+    at its strong-skin half-space form because its dc resistance depends on
+    plane width and copper thickness, neither of which microstrip supplies.
+
+    $K_i$ is applied to both trace and ground. Holloway and Kuester derive the
+    ground distribution independently of Wheeler's trace-crowding correction,
+    so this is a convenient shared edge-crowding convention rather than a
+    claim that their ground expression contains $K_i$. Omitting it from the
+    ground increases the strong-skin result by about 4--5% for ordinary
+    microstrip. Even with it, the split is intentionally not Wheeler's rule:
+    it adds a separately integrated ground loss, giving about 14% more loss
+    for representative 50-ohm lines.
+
+    References
+    ----------
+    Holloway, C. L., & Kuester, E. F. (1995). Closed-form expressions for the
+    current density on the ground plane of a microstrip line, with application
+    to ground plane loss. IEEE Transactions on Microwave Theory and Techniques,
+    43(5), 1204-1208. Correction, 54(11), 4018-4019 (2006).
+
+    Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
+    IRE, 30(9), 412-424.
+
+    Holloway, C. L., & Kuester, E. F. (1994). Edge shape effects and
+    quasi-closed form expressions for the conductor loss of microstrip lines.
+    Radio Science, 29(3), 539-559.
+    """
+
+    def distribute(self, freq: Frequency, *, zc, w, h, t=None, conductor=None):
+        ki = _wheeler_current_factor(zc)
+
+        u_over_two = w / (2 * h)
+        inverse_ground_width = 2 / (jnp.pi * w**2) * (
+            w * jnp.arctan(u_over_two) - h * jnp.log1p(u_over_two**2)
+        )
+        ground_pair = (HalfSpaceShape(), ki * inverse_ground_width)
+
+        if t is None:
+            return ((HalfSpaceShape(), 2 * ki / w), ground_pair)
+        if conductor is None:
+            raise ValueError("conductor properties are required for finite thickness")
+
+        evaluable = (freq.w > 0) & jnp.isfinite(conductor.sigma)
+        safe_sigma = jnp.where(evaluable, conductor.sigma, 1.0)
+        safe_zs = jnp.where(evaluable, conductor.zs, 0.0)
+        safe_gamma_t_over_two = safe_sigma * safe_zs * t / 2
+        penetration = jnp.where(
+            evaluable, jnp.abs(jnp.tanh(safe_gamma_t_over_two)), 0.0,
+        )
+        trace_weight = 1 / (2 * w) + penetration * (2 * ki / w - 1 / (2 * w))
+        return ((HollowayKuesterSlabShape(t=t), trace_weight), ground_pair)
 
 
 class CohnCurrentDistribution(AbstractCurrentDistribution):
@@ -66,7 +151,7 @@ class CohnCurrentDistribution(AbstractCurrentDistribution):
     on Microwave Theory and Techniques, 3(2), 119-126.
     """
 
-    def distribute(self, freq: Frequency, *, zc, w, b, t, ep_r):
+    def distribute(self, freq: Frequency, *, zc, w, b, t, ep_r, conductor=None):
         if t is None:
             weight = jnp.asarray(0.0)
         else:

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -42,6 +42,7 @@ from pmrf.models.components.lines.current_distribution import (
     AbstractCurrentDistribution,
     CohnCurrentDistribution,
     WheelerCurrentDistribution,
+    _wheeler_current_factor,
 )
 from pmrf.models.components.lines.base import ImmittanceResult
 
@@ -139,7 +140,7 @@ class PlanarQuasiStaticResult(eqx.Module):
             Z_cond = sum(
                 shape.impedance(w, conductor) * weight
                 for shape, weight in current_distribution.distribute(
-                    freq, zc=self.zc, **geometry
+                    freq, zc=self.zc, conductor=conductor, **geometry
                 )
             )
         Z = Z + Z_cond
@@ -860,9 +861,7 @@ def _wheeler_conductor_loss_factor(w, zc):
     Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
     IRE, 30(9), 412-424.
     """
-    z0 = jnp.sqrt(mu_0 / epsilon_0)
-    current_distribution = jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
-    return 2 / w * current_distribution
+    return 2 / w * _wheeler_current_factor(zc)
 
 
 def _microstrip_conductance_factor(ep_r, ep_eff, zc):

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -27,6 +27,7 @@ from pmrf.models.components.lines.formulations import (
     AbstractMicrostripFormulation,
     AbstractStriplineFormulation,
     CohnStriplineFormulation,
+    HammerstadJensenMicrostripFormulation,
     KirschningJansenMicrostripDispersion,
     PlanarQuasiStaticResult,
     SchelkunoffCoaxialFormulation,
@@ -36,6 +37,7 @@ from pmrf.models.components.lines.formulations import (
 from pmrf.models.components.lines.current_distribution import (
     AbstractCurrentDistribution,
     CohnCurrentDistribution,
+    TraceGroundCurrentDistribution,
     WheelerCurrentDistribution,
 )
 
@@ -331,7 +333,10 @@ class MicrostripLine(AbstractImmittanceLine):
     r"""
     Microstrip line defined by standard geometry and material modules.
     
-    Uses :class:`WheelerMicrostripFormulation` for the default mathematical formulation.
+    Uses :class:`HammerstadJensenMicrostripFormulation` for the default
+    quasi-static geometry and :class:`TraceGroundCurrentDistribution` for
+    conductor loss. Wheeler's formulation and current distribution remain
+    independently selectable.
 
     The quasi-static formulation returns a :class:`PlanarQuasiStaticResult`.
     :meth:`PlanarQuasiStaticResult.to_immittance` converts it directly whether
@@ -367,39 +372,24 @@ class MicrostripLine(AbstractImmittanceLine):
     is the exact loss perturbation of the effective-permittivity model, following
     Schneider's energy-perturbation derivation.
 
-    Wheeler's incremental-inductance rule (:func:`_wheeler_conductor_loss_factor`)
-    is the single conductor-loss term charged on both paths:
-    $$\alpha_c=\frac{\Re(Z_s)}{\Re(Z_{c,loss})W}
-    \exp\left[-1.2\left(\frac{\Re(Z_{c,loss})}{Z_0}\right)^{0.7}\right],$$
-    applied unconditionally, over the physical width $W$ rather than any
-    thickness-widened one. So ``dispersion=None`` is a pure dispersion toggle:
-    the quasi-static formulation's own `conductor_loss_factor` charges the
-    same rule at $Z_{c,loss}=Z_{c,0}$, and the dispersion path charges it
-    again at the dispersed $Z_{c,loss}$. The rule contains no $t$: it sums
-    over every receded conductor surface, and the broad-face terms do not
-    vanish as $t\to0$. So $t=\text{None}$ ("thickness unspecified") is not
-    the same input as $t=0$; it is read as skin effect being in operation
-    regardless, which is the good-faith default since Wheeler's $R_s$ is
-    itself a thick-conductor result. $t$ only refines the geometry (through
-    the quasi-static formulation, where supported), it does not gate whether
-    conductor loss is applied. This is a ParamRF convention, not a correction
-    of Kirschning-Jansen: K-J's $Z_c$ is a power-current quasi-TEM modal
-    quantity, chosen by Jansen & Koster for its weak frequency dependence, and
-    NIST (Williams, Alpert, Arz et al., *Causal Characteristic Impedance of
-    Planar Transmission Lines*) establishes that microstrip has no unique
-    $Z_c$.
+    Conductor loss is charged as separate trace and ground-plane terms. For a
+    known thickness, the trace uses Holloway and Kuester's finite slab and is
+    anchored at its exact $R_{dc}=1/(\sigma Wt)$ limit. Its strong-skin weight
+    approaches Wheeler's trace weight. The ground effective width comes from
+    integrating Holloway and Kuester's closed-form ground current density; its
+    term stays on the strong-skin half-space law because finite plane width and
+    ground copper thickness are not inputs. See
+    :class:`TraceGroundCurrentDistribution` for the equations and the explicit
+    current-crowding convention. If $t$ is unspecified, both terms use their
+    strong-skin shapes and no dc trace limit is asserted.
 
-    The sheet model above gives $R\to0$ as $f\to0$, which is wrong for a
-    trace of known thickness: a finite $t$ gets a dc floor
-    $R_{dc}=1/(\sigma Wt)$, blended smoothly with the skin-effect term as
-    $R=\sqrt{R_{dc}^2+R_{ac}^2}$ (see
-    :meth:`~pmrf.models.components.lines.formulations.PlanarQuasiStaticResult.to_immittance`).
-    $t=\text{None}$ gets no floor: it asserts skin effect in operation at
-    every frequency including dc, so there is no dc regime for a floor to
-    describe, matching ADS, which applies no floor at all. The blend itself
-    is a ParamRF convention rather than a rule any cited source prescribes
-    -- mcalc/wcalc hard-switch to a dc solution once skin depth exceeds
-    thickness instead, an equally defensible alternative.
+    The same current-distribution strategy is evaluated after optional modal
+    dispersion, so ``dispersion=None`` remains a pure dispersion toggle. This
+    is a ParamRF convention, not a correction of Kirschning-Jansen: K-J's
+    $Z_c$ is a power-current quasi-TEM modal quantity, chosen by Jansen and
+    Koster for its weak frequency dependence, and NIST (Williams, Alpert, Arz
+    et al., *Causal Characteristic Impedance of Planar Transmission Lines*)
+    establishes that microstrip has no unique $Z_c$.
 
     Example
     --------
@@ -443,22 +433,28 @@ class MicrostripLine(AbstractImmittanceLine):
         S/m is coerced into a :class:`~pmrf.materials.BulkConductor`.
     t : Param | None, default=None
         Thickness of the conductor. ``None`` means the thickness is
-        unspecified, not that it is zero: skin effect is assumed to be in
-        operation regardless, and Wheeler's conductor-loss correction (which
-        does not depend on `t`) is applied unconditionally. Wheeler's
-        quasi-static formulation requires ``None``; thickness-aware
-        formulations such as Hammerstad--Jensen use a positive value to
-        refine the geometry.
-    formulation : AbstractMicrostripFormulation, default=WheelerMicrostripFormulation()
+        unspecified, not that it is zero. A positive value enables both the
+        finite-thickness geometry correction and exact slab cross-section;
+        ``None`` retains their strong-skin limits.
+    formulation : AbstractMicrostripFormulation, default=HammerstadJensenMicrostripFormulation()
         The closed-form physics used to compute the quasi-static solution.
     dispersion : AbstractMicrostripDispersion | None, default=KirschningJansenMicrostripDispersion()
         The modal-dispersion correction. ``None`` disables modal dispersion and
         preserves the quasi-static immittance path.
+    current_distribution : AbstractCurrentDistribution, default=TraceGroundCurrentDistribution()
+        The conductor-current strategy. Pass
+        :class:`WheelerCurrentDistribution` to retain the standard single-term
+        Wheeler model used by ADS and scikit-rf.
 
     References
     ----------
     Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
     IRE, 30(9), 412-424.
+
+    Holloway, C. L., & Kuester, E. F. (1995). Closed-form expressions for the
+    current density on the ground plane of a microstrip line, with application
+    to ground plane loss. IEEE Transactions on Microwave Theory and Techniques,
+    43(5), 1204-1208.
 
     Schneider, M. V. (1969). Dielectric Loss in Integrated Microwave Circuits.
     Bell System Technical Journal, 48(7).
@@ -481,7 +477,9 @@ class MicrostripLine(AbstractImmittanceLine):
     substrate: Substrate = field(default_factory=Substrate, converter=as_substrate)
 
     #: The underlying physics formulation
-    formulation: AbstractMicrostripFormulation = field(default_factory=WheelerMicrostripFormulation)
+    formulation: AbstractMicrostripFormulation = field(
+        default_factory=HammerstadJensenMicrostripFormulation
+    )
 
     #: The modal-dispersion formulation, or None to disable it
     dispersion: AbstractMicrostripDispersion | None = field(
@@ -490,7 +488,7 @@ class MicrostripLine(AbstractImmittanceLine):
 
     #: The conductor current-distribution strategy
     current_distribution: AbstractCurrentDistribution = field(
-        default_factory=WheelerCurrentDistribution
+        default_factory=TraceGroundCurrentDistribution
     )
 
     def __init__(
@@ -520,14 +518,15 @@ class MicrostripLine(AbstractImmittanceLine):
         self.w = w
         self.substrate = Substrate(**given) if substrate is None else substrate
         self.formulation = (
-            WheelerMicrostripFormulation() if formulation is None else formulation
+            HammerstadJensenMicrostripFormulation()
+            if formulation is None else formulation
         )
         self.dispersion = (
             KirschningJansenMicrostripDispersion()
             if dispersion is _DEFAULT_DISPERSION else dispersion
         )
         self.current_distribution = (
-            WheelerCurrentDistribution()
+            TraceGroundCurrentDistribution()
             if current_distribution is None else current_distribution
         )
         self.length = length
@@ -596,7 +595,7 @@ class MicrostripLine(AbstractImmittanceLine):
         return self._resolved_quasi_static(freq).to_immittance(
             freq, dielectric, conductor,
             current_distribution=self.current_distribution,
-            w=self.w, t=t,
+            w=self.w, h=substrate.h, t=t,
         )
 
     def ep_eff(self, freq: Frequency) -> jnp.ndarray:

--- a/tests/test_models/test_current_distribution.py
+++ b/tests/test_models/test_current_distribution.py
@@ -1,11 +1,17 @@
 import jax.numpy as jnp
 
 from pmrf.frequency import Frequency
-from pmrf.materials import BulkConductor, ConstantDielectric, HalfSpaceShape
+from pmrf.materials import (
+    BulkConductor,
+    ConstantDielectric,
+    HalfSpaceShape,
+    HollowayKuesterSlabShape,
+)
 from pmrf.models import (
     CohnCurrentDistribution,
     HammerstadJensenMicrostripFormulation,
     MicrostripLine,
+    TraceGroundCurrentDistribution,
     WheelerCurrentDistribution,
 )
 from pmrf.models.components.lines.formulations import _wheeler_conductor_loss_factor
@@ -45,3 +51,55 @@ def test_cohn_distribution_uses_a_surface_pair():
     assert isinstance(pairs[0][0], HalfSpaceShape)
     assert pairs[0][1].shape == (1,)
     assert jnp.all(pairs[0][1] > 0)
+
+
+def test_trace_ground_distribution_reproduces_published_ground_effective_widths():
+    """The ground weight integrates Holloway--Kuester's current density."""
+    freq = Frequency.from_f(jnp.array([10e9]))
+    conductor = BulkConductor(sigma=5.8e7).properties(freq)
+
+    for width_over_height, expected in [(1.94, 3.67), (1.80, 3.90), (0.44, 14.5)]:
+        w = width_over_height * 1e-3
+        pairs = TraceGroundCurrentDistribution().distribute(
+            freq, zc=jnp.array([50.0]), w=w, h=1e-3, t=35e-6,
+            conductor=conductor,
+        )
+        _, ground_weight = pairs[1]
+        ki = jnp.exp(-1.2 * (50.0 / 376.730313668) ** 0.7)
+        ground_effective_width = ki / ground_weight[0]
+        assert jnp.isclose(ground_effective_width / w, expected, rtol=8e-3)
+
+
+def test_trace_ground_distribution_returns_independent_trace_and_ground_pairs():
+    freq = Frequency.from_f(jnp.array([0.0, 100e9]))
+    conductor = BulkConductor(sigma=5.8e7).properties(freq)
+
+    pairs = TraceGroundCurrentDistribution().distribute(
+        freq, zc=jnp.array([50.0, 50.0]), w=3e-3, h=1.6e-3,
+        t=35e-6, conductor=conductor,
+    )
+
+    assert isinstance(pairs[0][0], HollowayKuesterSlabShape)
+    assert isinstance(pairs[1][0], HalfSpaceShape)
+    assert jnp.isclose(pairs[0][1][0], 1 / (2 * 3e-3))
+    assert pairs[0][1][1] > pairs[0][1][0]
+
+
+def test_microstrip_split_default_has_true_trace_dc_and_documented_skin_limit():
+    sigma, w, h, t = 5.8e7, 1.94e-3, 1e-3, 35e-6
+    freq = Frequency.from_f(jnp.array([0.0, 1e12]))
+    line = MicrostripLine(
+        w=w, h=h, t=t, dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
+        conductor=BulkConductor(sigma=sigma), dispersion=None, length=0.1,
+    )
+
+    resistance = line.immittance(freq).R
+    ki = jnp.exp(-1.2 * (jnp.real(line._resolved_quasi_static(freq).zc) / 376.730313668) ** 0.7)
+    expected_skin_weight = 2 * ki[-1] / w + ki[-1] / (3.6671708626520503 * w)
+    wheeler_skin_weight = 2 * ki[-1] / w
+    surface_resistance = jnp.real(line.substrate.conductor.properties(freq).zs[-1])
+
+    assert isinstance(line.current_distribution, TraceGroundCurrentDistribution)
+    assert jnp.isclose(resistance[0], 1 / (sigma * w * t), rtol=1e-6)
+    assert jnp.isclose(resistance[-1], surface_resistance * expected_skin_weight, rtol=2e-6)
+    assert jnp.isclose(expected_skin_weight / wheeler_skin_weight, 1.13634, rtol=2e-5)

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -548,7 +548,7 @@ def test_dispersive_microstrip_routes_through_planar_quasi_static_to_immittance(
     ).to_immittance(
         freq, dielectric, conductor,
         current_distribution=line.current_distribution,
-        w=line.w, t=line.substrate.t,
+        w=line.w, h=line.substrate.h, t=line.substrate.t,
     )
 
     actual = line.immittance(freq)
@@ -584,6 +584,10 @@ def test_microstrip_without_dispersion_preserves_quasi_static_immittance():
         freq,
         line.substrate.dielectric.properties(freq),
         line.substrate.conductor.properties(freq),
+        current_distribution=line.current_distribution,
+        w=line.w,
+        h=line.substrate.h,
+        t=line.substrate.t,
     )
     assert jnp.array_equal(actual.Z, expected.Z)
     assert jnp.array_equal(actual.Y, expected.Y)
@@ -593,7 +597,7 @@ def test_microstrip_dispersion_is_a_pure_dispersion_toggle():
     """Turning dispersion off must not change *which* conductor loss applies.
 
     Both the quasi-static path (``PlanarQuasiStaticResult.to_immittance``) and
-    the dispersion path charge Wheeler's incremental-inductance rule, so
+    the dispersion path charge the selected trace/ground strategy, so
     disabling dispersion with an identity dispersion formulation (one that
     hands the quasi-static ep_eff/zc straight through, unchanged) reproduces
     the quasi-static attenuation to the accuracy of the quasi-static path's

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -59,6 +59,7 @@ from pmrf.models import (
     MicrostripLine,
     SchelkunoffCoaxialFormulation,
     TescheCoaxialFormulation,
+    WheelerCurrentDistribution,
     WheelerMicrostripFormulation,
 )
 
@@ -371,6 +372,7 @@ def _microstrip_pair(*, w, h, t, ep_r, tand, rho, dispersion, diel, formulation,
             conductor=BulkConductor(sigma=_sigma_of_rho(rho)),
             formulation=formulation(),
             dispersion=None if dispersion is None else dispersion(),
+            current_distribution=WheelerCurrentDistribution(),
             length=length,
         )
 
@@ -673,6 +675,36 @@ def test_microstrip_matches_skrf_s_parameters(case):
     _assert_close(line.s(WIDEBAND, z0=case.z0), expected, "s", case)
 
 
+def test_split_microstrip_records_its_deliberate_departure_from_skrf_wheeler():
+    r"""The new default and scikit-rf deliberately charge different surfaces.
+
+    At this 49-ohm strong-skin cross-section, scikit-rf's MLine uses its
+    Wheeler-based conductor correction. ParamRF instead sums the finite-slab
+    trace and the independently integrated Holloway--Kuester ground current.
+    The resulting attenuation is 1.13612 times scikit-rf's value for this case,
+    at the bottom of the 12--30% band in which Holloway and Kuester report
+    Wheeler underpredicting measured loss. This is partial corroboration, not
+    proof that the split closes that experimental gap; the per-case tolerance
+    records the comparison without treating either approximation as ground
+    truth.
+    """
+    freq = Frequency.from_f(jnp.array([100e9]))
+    line = MicrostripLine(
+        w=1.94e-3, h=1e-3, t=35e-6,
+        dielectric=ConstantDielectric(ep_r=4.3, tand=0.0),
+        conductor=BulkConductor(sigma=5.8e7),
+        dispersion=None, length=0.1,
+    )
+    media = MLine(
+        freq.to_skrf(), w=1.94e-3, h=1e-3, t=35e-6,
+        ep_r=4.3, tand=0.0, rho=1 / 5.8e7, rough=0.0,
+        model="hammerstadjensen", disp="none", diel="frequencyinvariant",
+    )
+
+    actual_alpha = jnp.real(line.zc_and_gammaL(freq)[1] / line.length)
+    assert jnp.allclose(actual_alpha / media.alpha_conductor, 1.136124, rtol=3e-6)
+
+
 def _wide_low_er_lossy_line(*, t, dispersion):
     """The ``wide_low_er_lossy_quasi_static`` cross-section, at a given `t`.
 
@@ -689,6 +721,7 @@ def _wide_low_er_lossy_line(*, t, dispersion):
         conductor=base.substrate.conductor,
         formulation=base.formulation,
         dispersion=dispersion,
+        current_distribution=base.current_distribution,
         length=case.length,
     )
 


### PR DESCRIPTION
Closes #101

- add independent trace and ground-plane current-distribution pairs
- integrate Holloway-Kuester ground current density and finite-slab trace physics
- make the split strategy and Hammerstad-Jensen geometry the microstrip defaults
- retain Wheeler as an explicitly selectable scikit-rf-compatible strategy
- document and test DC, strong-skin, and deliberate scikit-rf departures

Verification: 516 passed, 28 skipped; post-review line regressions 92 passed.