### PR TITLE
Add finite-thickness stripline conductor loss

### DIFF
--- a/pmrf/models/components/lines/current_distribution.py
+++ b/pmrf/models/components/lines/current_distribution.py
@@ -19,6 +19,16 @@ def _wheeler_current_factor(zc):
     return jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
 
 
+def _slab_penetration(freq, conductor, t):
+    """Return the guarded finite-slab penetration transition."""
+    evaluable = (freq.w > 0) & jnp.isfinite(conductor.sigma)
+    safe_sigma = jnp.where(evaluable, conductor.sigma, 1.0)
+    safe_zs = jnp.where(evaluable, conductor.zs, 0.0)
+    return jnp.where(
+        evaluable, jnp.abs(jnp.tanh(safe_sigma * safe_zs * t / 2)), 0.0,
+    )
+
+
 class AbstractCurrentDistribution(eqx.Module):
     r"""Surface-current distribution for a transmission-line cross-section.
 
@@ -125,13 +135,7 @@ class TraceGroundCurrentDistribution(AbstractCurrentDistribution):
         if conductor is None:
             raise ValueError("conductor properties are required for finite thickness")
 
-        evaluable = (freq.w > 0) & jnp.isfinite(conductor.sigma)
-        safe_sigma = jnp.where(evaluable, conductor.sigma, 1.0)
-        safe_zs = jnp.where(evaluable, conductor.zs, 0.0)
-        safe_gamma_t_over_two = safe_sigma * safe_zs * t / 2
-        penetration = jnp.where(
-            evaluable, jnp.abs(jnp.tanh(safe_gamma_t_over_two)), 0.0,
-        )
+        penetration = _slab_penetration(freq, conductor, t)
         trace_weight = 1 / (2 * w) + penetration * (2 * ki / w - 1 / (2 * w))
         return ((HollowayKuesterSlabShape(t=t), trace_weight), ground_pair)
 
@@ -141,14 +145,37 @@ class CohnCurrentDistribution(AbstractCurrentDistribution):
 
     **Mathematical Formulation**
 
-    The returned weight is $k_c=2\alpha_c/R_s$, using Cohn's two attenuation
-    branches and the stripline geometry.  A zero-thickness strip has no finite
-    conductor-loss weight in this model.
+    Cohn's $k_c=2\alpha_c Z_c/R_s$ is an effective strong-skin weight for the
+    centre strip and both ground planes together.  When the centre-strip
+    thickness is known, ParamRF charges that weight through Holloway and
+    Kuester's total-current slab and interpolates the weight from $1/(2W)$ at
+    dc to $k_c$ in strong skin effect according to the ParamRF convention
+
+    $$k(f)=\frac{1}{2W}+|\tanh(\gamma_cT/2)|
+    \left(k_c-\frac{1}{2W}\right).$$
+
+    This gives the centre strip's exact
+    $R_{dc}=1/(\sigma WT)$ while preserving Cohn's complete high-frequency
+    result and replacing the half-space internal reactance.
+
+    Ground-plane loss is not added as a separate pair.  Unlike microstrip,
+    symmetric stripline already has both returns folded into Cohn's effective
+    geometry factor; adding ground half-spaces would double-count them.  Their
+    finite-thickness dc resistance also cannot be determined without ground
+    thickness and width inputs.  A strip with unspecified thickness retains
+    the existing zero conductor-loss convention because Cohn's finite-$T$
+    expression diverges as $T\to0$.
 
     References
     ----------
     Cohn, S. B. (1955). Problems in Strip Transmission Lines. IRE Transactions
     on Microwave Theory and Techniques, 3(2), 119-126.
+
+    Holloway, C. L., & Kuester, E. F. (1994). Edge shape effects and
+    quasi-closed form expressions for the conductor loss of microstrip lines.
+    Radio Science, 29(3), 539-559.
+
+    ParamRF finite-strip interpolation convention; no external source.
     """
 
     def distribute(self, freq: Frequency, *, zc, w, b, t, ep_r, conductor=None):
@@ -164,5 +191,10 @@ class CohnCurrentDistribution(AbstractCurrentDistribution):
             )
             alpha_high = 0.16 / (zc_real * b) * beta
             alpha_over_rs = jnp.where(jnp.sqrt(ep_r) * zc_real < 120, alpha_low, alpha_high)
-            weight = 2 * alpha_over_rs * zc_real
-        return ((HalfSpaceShape(), weight),)
+            skin_weight = 2 * alpha_over_rs * zc_real
+            if conductor is None:
+                raise ValueError("conductor properties are required for finite thickness")
+            penetration = _slab_penetration(freq, conductor, t)
+            weight = 1 / (2 * w) + penetration * (skin_weight - 1 / (2 * w))
+        shape = HalfSpaceShape() if t is None else HollowayKuesterSlabShape(t=t)
+        return ((shape, weight),)

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -658,10 +658,20 @@ class StriplineLine(AbstractImmittanceLine):
 
     The quasi-static formulation returns $(\varepsilon_e, Z_c, W_{eff})$, and
     :meth:`PlanarQuasiStaticResult.to_immittance` converts them directly:
-    $$Z = \frac{j\omega Z_c\sqrt{\varepsilon_e}}{c} + \frac{2Z_s}{W_{eff}}
+    $$Z = \frac{j\omega Z_c\sqrt{\varepsilon_e}}{c} + Z_{c,\mathrm{cond}}
     \qquad
     Y = \frac{j\omega\sqrt{\varepsilon_e}}{Z_c c}.$$
-    See :class:`CohnStriplineFormulation` for the geometry.
+    For known centre-strip thickness, $Z_{c,\mathrm{cond}}$ uses Holloway and
+    Kuester's finite total-current slab, anchored at the model-resolvable
+    centre-strip resistance $R_{dc,trace}=1/(\sigma WT)$ and converging to Cohn's published conductor-loss
+    factor in strong skin effect.  Cohn's factor already includes the centre
+    strip and both symmetric ground returns, so ground loss is not charged a
+    second time.  The complete physical stripline DC resistance would also
+    require ground-plane width and thickness, which this geometry does not
+    supply.  This differs from microstrip, whose trace and single ground
+    distributions are independently available and therefore charged as
+    separate terms.  See :class:`CohnCurrentDistribution` for the transition
+    and :class:`CohnStriplineFormulation` for the geometry.
 
     Example
     --------
@@ -706,6 +716,10 @@ class StriplineLine(AbstractImmittanceLine):
     ----------
     Cohn, S. B. (1955). Problems in Strip Transmission Lines. IRE Transactions
     on Microwave Theory and Techniques, 3(2), 119-126.
+
+    Holloway, C. L., & Kuester, E. F. (1994). Edge shape effects and
+    quasi-closed form expressions for the conductor loss of microstrip lines.
+    Radio Science, 29(3), 539-559.
 
     Pozar, D. M. (2011). Microwave Engineering (4th ed.), Section 3.7. Wiley.
     """

--- a/tests/test_models/test_current_distribution.py
+++ b/tests/test_models/test_current_distribution.py
@@ -43,12 +43,14 @@ def test_current_distribution_can_be_selected_independently_of_microstrip_formul
 def test_cohn_distribution_uses_a_surface_pair():
     freq = Frequency.from_f(jnp.array([10e9]))
     zc = jnp.array([50.0])
+    conductor = BulkConductor(sigma=5.8e7).properties(freq)
 
     pairs = CohnCurrentDistribution().distribute(
-        freq, zc=zc, w=2.655e-3, b=3.2e-3, t=35e-6, ep_r=jnp.array([2.2])
+        freq, zc=zc, w=2.655e-3, b=3.2e-3, t=35e-6,
+        ep_r=jnp.array([2.2]), conductor=conductor,
     )
 
-    assert isinstance(pairs[0][0], HalfSpaceShape)
+    assert isinstance(pairs[0][0], HollowayKuesterSlabShape)
     assert pairs[0][1].shape == (1,)
     assert jnp.all(pairs[0][1] > 0)
 

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -860,6 +860,57 @@ def test_stripline_conductor_loss_scales_with_root_frequency():
     assert jnp.allclose(alpha[2] / alpha[0], 10.0, rtol=1e-2)
 
 
+@pytest.mark.parametrize(
+    (
+        "w", "b", "t", "expected_transition_r", "transition_rtol",
+        "expected_transition_x", "transition_x_rtol", "expected_skin_weight",
+    ),
+    [
+        (
+            2.655e-3, 3.2e-3, 35e-6,
+            0.2766344102, 2e-8, 0.0129251261, 2e-8, 435.26525504,
+        ),
+        (
+            0.8e-3, 2.0e-3, 18e-6,
+            1.4432152717, 2e-8, 0.0178441363, 2e-8, 1291.40977227,
+        ),
+    ],
+)
+def test_stripline_finite_thickness_transitions_from_true_dc_to_cohn_skin_limit(
+    w, b, t, expected_transition_r, transition_rtol,
+    expected_transition_x, transition_x_rtol, expected_skin_weight,
+):
+    """Known strip thickness anchors DC without changing Cohn's skin limit."""
+    sigma = 5.8e7
+    freq = Frequency.from_f(jnp.array([0.0, 1e6, 1e13]))
+    line = StriplineLine(
+        w=w, b=b, t=t, dielectric=2.2,
+        conductor=BulkConductor(sigma=sigma), length=1.0,
+    )
+
+    resistance = line.immittance(freq).R
+    surface_resistance = jnp.real(line.conductor.properties(freq).zs)
+    ideal = StriplineLine(
+        w=w, b=b, t=t, dielectric=2.2,
+        conductor=BulkConductor(sigma=jnp.inf), length=1.0,
+    ).immittance(freq)
+    internal_reactance = freq.w * (line.immittance(freq).L - ideal.L)
+    half_space_impedance = line.conductor.properties(freq).zs * expected_skin_weight
+
+    assert jnp.isclose(resistance[0], 1 / (sigma * w * t), rtol=1e-6)
+    # Per-case checkpoints independently evaluated from the documented slab
+    # and interpolation equations, not from recorded ParamRF output.
+    assert jnp.isclose(resistance[1], expected_transition_r, rtol=transition_rtol)
+    assert jnp.isclose(
+        internal_reactance[1], expected_transition_x, rtol=transition_x_rtol,
+    )
+    assert resistance[1] > jnp.real(half_space_impedance[1])
+    assert internal_reactance[1] < jnp.imag(half_space_impedance[1])
+    assert jnp.isclose(
+        resistance[-1], surface_resistance[-1] * expected_skin_weight, rtol=2e-6,
+    )
+
+
 def test_stripline_accepts_a_dispersive_dielectric():
     """A dispersive material needs no stripline-specific code: eps_eff tracks it."""
     from pmrf.models import CohnStriplineFormulation, StriplineLine


### PR DESCRIPTION
Closes #102

## Summary
- anchor known-thickness stripline loss at the centre strip true DC resistance
- preserve Cohn's combined trace-and-ground strong-skin result
- use the finite total-current slab for resistance and internal reactance
- document why stripline ground loss is not charged separately
- add per-geometry DC, transition, half-space, and strong-skin checks

## Verification
- `.venv/bin/python -P -m pytest` (519 passed, 28 skipped)
- `.venv/bin/python -c "import pmrf"`
- `git diff --check`