### PR TITLE
Line-modelling architecture: conductor propagation constant through to CONTEXT.md and the ADR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,78 @@
+# ParamRF domain context
+
+Vocabulary for the transmission-line modelling layer. Terms here are the ones
+the code uses; prefer them over synonyms. Each entry points at the class that
+owns the maths rather than repeating it.
+
+## Line modelling
+
+A **line** (`pmrf.models.components.lines.physical`) owns geometry and material
+modules, evaluates them, and delegates the physics to strategy objects. Five
+strategy roles exist, each a separate field so a user can replace one without
+touching the others.
+
+### Formulation
+
+Closed-form quasi-static physics. It produces the complete electrical state a
+model needs to reach S-parameters: either a per-unit-length
+`ImmittanceResult` directly (coax), or a `PlanarQuasiStaticResult` the line
+converts into one (microstrip, stripline). A line has exactly one.
+See `pmrf.models.components.lines.formulations`.
+
+### Dispersion
+
+Modifies an existing quasi-static state with modal frequency dependence. It
+produces no state of its own, so it exists only where the cross-section is
+inhomogeneous and the mode is therefore not strictly TEM: microstrip has one
+(`KirschningJansenMicrostripDispersion`), homogeneously filled coax and
+stripline do not. `None` disables it.
+
+### ConductorShape
+
+Surface impedance per square for one conductor cross-section, as the metal's
+surface prefactor times a dimensionless shape factor. Pure numerics over an
+evaluated `ConductorProperties` and a set of named dimensions; the
+inverse-metre geometry weight that turns it into a per-unit-length impedance
+is the caller's. See `pmrf.materials.conductor_shape.AbstractConductorShape`
+for the normalisation convention that couples the two.
+
+### CurrentDistribution
+
+How a line's surface current divides across its conductors: it returns
+`(shape, weight)` pairs for a given cross-section and solved quasi-static
+state. It chooses shapes and weights only — dimensions reach a shape from the
+cross-section record. Each strategy is written for one planar line family and
+declares it in `cross_section_type`. Coax has no such layer (see ADR-0001).
+See `pmrf.models.components.lines.current_distribution`.
+
+### Roughness
+
+Modifies conductor behaviour rather than line state — it scales a surface
+impedance — so it belongs to the material, not the geometry: it is a field of
+`RoughConductor` in `pmrf.materials.conductor`.
+
+## Records at the boundaries
+
+These frozen records are the seams that keep `Param`s and `Module`s out of the
+physics classes, so a formulation or shape can be checked against its source
+paper with no ParamRF objects in sight.
+
+- **`ConductorProperties`**, **`DielectricProperties`**
+  (`pmrf.materials.properties`) — a material evaluated at a frequency. A
+  conductor carries the surface prefactor `zs`, the static conductivity
+  `sigma`, and `gamma(omega)`, the bulk diffusion constant, as *independent*
+  inputs (ADR-0001).
+- **`AbstractPlanarCrossSection`** (`MicrostripCrossSection`,
+  `StriplineCrossSection`) — one typed dimensions record per planar family,
+  handed to a current distribution at call time.
+- **`PlanarQuasiStaticResult`** — the solved quasi-static state of a planar
+  line: effective permittivity, characteristic impedance, effective width and
+  shunt-conductance factor.
+- **`ImmittanceResult`** — per-unit-length $(Z, Y)$, the internal currency
+  between a formulation and a line. $R$, $L$, $G$, $C$ are derived views.
+
+## Decisions
+
+`docs/adr/` records the decisions behind this layering. Read
+`docs/adr/0001-line-modelling-architecture.md` before changing a strategy
+interface or a default.

--- a/docs/adr/0001-line-modelling-architecture.md
+++ b/docs/adr/0001-line-modelling-architecture.md
@@ -1,0 +1,199 @@
+# ADR-0001: Line-modelling architecture
+
+Status: accepted (2026-09)
+
+## Context
+
+Transmission-line models grew from single closed-form functions into a layered
+set of strategy objects: a formulation, an optional dispersion, a conductor
+shape, a current distribution, and a roughness correction on the material.
+That layering forced a batch of decisions — several of them deliberate
+compromises — whose reasoning lived nowhere but in review threads. This record
+holds them. The vocabulary is in `CONTEXT.md`; the maths is in the class
+docstrings, and is not repeated here.
+
+## Decisions
+
+### 1. Cross-section normalisation: the RSS blend is the planar default, and the exact slab cannot be
+
+A conductor shape returns ohm/square, referred to the current *its own*
+cross-section carries; the caller multiplies by an inverse-metre geometry
+weight. For round conductors the two normalisations agree exactly:
+`SchelkunoffRodShape` is referred to the total rod current and the caller's
+weight is $1/2\pi a$.
+
+The planar case has no such agreement. `HollowayKuesterSlabShape` is the exact
+finite-thickness strip result, referred to the total strip current, so it wants
+a weight of $1/(2W)$ — for a 1.55 mm trace, $322.6\,\mathrm{m^{-1}}$. Wheeler's
+incremental-inductance weight, which the microstrip current distribution
+supplies, is $963.7\,\mathrm{m^{-1}}$ for that trace: a factor of **2.99**.
+
+That factor is physics, not a scale error. The two are different
+decompositions of the same problem: Wheeler's weight is an
+incremental-inductance result covering the ground plane and the edge crowding
+as well as the strip, while the slab is a one-dimensional strip-diffusion
+result containing neither. Under Wheeler's weight the exact slab returns
+0.925 ohm/m at dc for 35 um copper on that trace where the true value is
+0.3097 ohm/m. No rescaling repairs it: halving the slab to fix dc breaks the
+strong-skin asymptote by the same factor.
+
+Under a *frequency-independent* weight, therefore, exactly one entry is right
+at both asymptotes — `RootSumSquareSlabShape`, which reaches into the caller's
+normalisation through the optional `weight` argument to express its dc floor
+in per-unit-length terms. It is the planar default for that reason, not as a
+compatibility shim and not because it is the industry convention.
+
+**Known limitation.** The blend is right at both ends and wrong in between,
+and the error is in the reactance. Its internal inductance is 17.7x too large
+at 100 kHz for 35 um copper. Measured against the exact slab as $t/\delta$
+rises:
+
+| Frequency | $t/\delta$ | $X$ ratio (RSS / exact) |
+|---|---|---|
+| 100 kHz | 0.17 | 17.7 |
+| 1 MHz | 0.54 | 5.6 |
+| 5 MHz | 1.20 | 2.5 |
+| 10 MHz | 1.70 | 1.8 |
+| 50 MHz | 3.79 | 1.01 |
+
+So the default is accurate in resistance and in the strong-skin regime, and
+its internal reactance should not be trusted below roughly $t/\delta \approx 2$.
+The alternatives were: make the exact slab the default (rejected — it is
+wrong at dc by 2.99x under the only weight available); rescale the slab
+(rejected — fixes one asymptote and breaks the other); or split the weight
+into separate strip and ground-plane terms in the Holloway–Kuester manner,
+which is the only fix that is actually honest, and which ParamRF does not
+implement.
+
+### 2. The metal propagation constant is an explicit conductor property
+
+`ConductorProperties` carries `zs` (the surface prefactor) and `gamma(omega)`
+(the bulk diffusion constant) as independent inputs, with `gamma` computed
+from $\sigma$ and $\mu_r$ rather than recovered from `zs` as $\sigma\zeta_c$.
+
+The alternative — deriving one from the other — is an identity that holds only
+for a smooth bulk metal. A `RoughConductor` scales `zs` by the roughness
+factor $K$; recovering $\gamma$ from it would push $K$ into every $\gamma a$
+and $\gamma t$ in the cross-section physics, changing the *diffusion* inside
+the metal because its *surface* was treated. Roughness multiplies the
+prefactor only.
+
+### 3. A typed cross-section record per planar family
+
+A current distribution receives a frozen `MicrostripCrossSection` or
+`StriplineCrossSection` and declares which it accepts. Two alternatives were
+weighed:
+
+- **One flat record with optional fields for every family.** Rejected: no
+  stable set of cross-section quantities exists across families — coplanar
+  waveguide brings a gap width, suspended substrate an air gap, offset
+  stripline an offset — so the record would grow a nullable field per family
+  and every strategy would re-check which ones are populated.
+- **Loose keyword arguments.** Rejected: pairing a strategy with the wrong
+  family then fails as a missing-argument error deep in a call, instead of a
+  type error at the boundary.
+
+The comparable tools (scikit-rf, qucsator, wcalc) all use flat per-line-type
+parameter sets. That is workable in a procedural API where the line type
+selects the function; it does not survive strategies that are swappable
+independently of the line. Adopting the typed seam let the legacy
+conductor-loss path be deleted outright, closing the outstanding criterion of
+#99.
+
+### 4. Coax has no current-distribution layer
+
+Deliberately. A current distribution exists to model how current *chooses* to
+crowd across a cross-section — a fitted rule. In a coaxial line the current is
+where the geometry puts it: the inner conductor's whole current on its surface
+at radius $a$, the shield's return on its inner surface at radius $b$. The
+weights are therefore exact constants, $1/2\pi a$ and $1/2\pi b$, folded into
+the coaxial formulation, which selects shapes through `inner_shape` and
+`shield_shape` fields instead. Adding a distribution layer would wrap two
+constants in a strategy interface to satisfy symmetry with the planar lines,
+which is contortion, not architecture.
+
+### 5. Hammerstad–Jensen is the default microstrip formulation
+
+This is a breaking numeric change: existing microstrip results move, and no
+compatibility shim or opt-out flag was added. This ADR is the migration note.
+`WheelerMicrostripFormulation` (Wheeler 1977) remains available and selectable.
+
+The accuracy argument outweighs Wheeler's familiarity on two counts.
+Hammerstad–Jensen is thickness-aware, and quotes fit errors below 0.2% in
+$\varepsilon_e$ and 0.01–0.03% in $Z_L$ over its stated range. More
+decisively, Kirschning–Jansen dispersion — the default `dispersion` — was
+itself fitted against Hammerstad–Jensen's effective width, so the previous
+default paired a zero-thickness quasi-static formulation with a dispersion
+model fitted to a different one.
+
+Two related decisions:
+
+- **A formulation that cannot use an input declines it silently and locally.**
+  Wheeler 1977 accepts a stated thickness and ignores it in $\varepsilon_e$
+  and $Z_c$; the thickness still reaches the conductor-loss term. Emitting a
+  warning was rejected: under `jit` it fires at trace time, so it appears once
+  during compilation, not on the call the user made, and is silent on every
+  subsequent evaluation.
+- **The Wheeler name collides.** `WheelerMicrostripFormulation` is Wheeler
+  1977, a quasi-static impedance approximation; `WheelerCurrentDistribution`
+  is Wheeler 1942, the skin-effect loss rule and still the microstrip default.
+  They share only an author, and changing the formulation default does not
+  touch the loss rule.
+
+### 6. Characteristic impedance is $\sqrt{Z/Y}$, not Kirschning–Jansen's modal value
+
+Both the quasi-static and dispersed paths report $Z_c=\sqrt{Z/Y}$ from the
+line's own RLGC state. With dispersion enabled, the dispersed
+$(\varepsilon_e, Z_c)$ replace the quasi-static ones in a fresh
+`PlanarQuasiStaticResult` before conversion, so the dispersion path does not
+tautologically reproduce Kirschning–Jansen's modal $Z_c$.
+
+The alternative — reporting K–J's value directly — was rejected because
+microstrip has no unique characteristic impedance (NIST: Williams, Alpert,
+Arz et al., *Causal Characteristic Impedance of Planar Transmission Lines*).
+K–J's is a power-current quasi-TEM modal quantity, chosen by Jansen & Kirschning
+for its weak frequency dependence, which is a good property for a fitting
+target and not a reason to prefer it as the reported impedance of a circuit
+element. $\sqrt{Z/Y}$ is at least the impedance the rest of the simulator
+actually uses.
+
+### 7. Complex permittivity carries dielectric loss; static conductivity stays separate
+
+Dielectric loss is carried through the quasi-static and dispersion
+formulations as a complex permittivity, so it arrives in $\varepsilon_e$ and
+needs no separate attenuation term. Static bulk conductivity is *not* folded
+into that permittivity: as a $\sigma/j\omega\varepsilon_0$ term it is singular
+at dc. It is applied separately as $G=\sigma K_g$, using the geometric
+`shunt_conductance_factor` of the quasi-static result, which keeps the shunt
+conductance finite and nonzero down to dc.
+
+This matches ADS's documented treatment of permittivity as a complex material
+property, though the vendor documentation does not establish the expression
+used; the complex evaluation is the exact loss perturbation of the
+effective-permittivity model, following Schneider's energy-perturbation
+derivation.
+
+### 8. Unspecified thickness is not zero thickness
+
+`t=None` means the thickness was not stated, not that it is zero. It asserts
+that skin effect is in operation at every frequency, which is the good-faith
+default given that the underlying $R_s$ is itself a thick-conductor result, and
+it takes no dc resistance floor: there is no dc regime for a floor to describe.
+A stated positive $t$ gets the floor $R_{dc}=1/(\sigma W t)$, blended with the
+skin-effect term.
+
+The alternative reading — `None` as $t=0$, hence no conductor loss — would make
+an unstated dimension silently switch off physics. ADS likewise applies no
+floor at all. The blend used for a stated thickness is a ParamRF convention
+rather than a rule any cited source prescribes; mcalc and wcalc hard-switch to
+a dc solution once skin depth exceeds thickness, an equally defensible
+alternative.
+
+## Consequences
+
+- Microstrip numbers change with the Hammerstad–Jensen default; there is no
+  opt-out beyond passing `WheelerMicrostripFormulation()` explicitly.
+- Planar internal inductance below $t/\delta \approx 2$ is not trustworthy, and
+  will not be until separate strip and ground-plane weights exist.
+- A new planar family needs a cross-section record, not a new optional field.
+- A new conductor treatment scales `zs` and leaves `gamma` alone.

--- a/pmrf/materials/__init__.py
+++ b/pmrf/materials/__init__.py
@@ -39,8 +39,6 @@ from pmrf.materials.conductor_shape import (
     RootSumSquareSlabShape as RootSumSquareSlabShape,
     SchelkunoffRodShape as SchelkunoffRodShape,
     SchelkunoffTubeShape as SchelkunoffTubeShape,
-    SchelkunoffCothTubeShape as SchelkunoffCothTubeShape,
-    SchelkunoffInfiniteTubeShape as SchelkunoffInfiniteTubeShape,
     TescheRodShape as TescheRodShape,
     TescheTubeShape as TescheTubeShape,
 )
@@ -68,8 +66,6 @@ __all__ = [
     "RootSumSquareSlabShape",
     "SchelkunoffRodShape",
     "SchelkunoffTubeShape",
-    "SchelkunoffCothTubeShape",
-    "SchelkunoffInfiniteTubeShape",
     "TescheRodShape",
     "TescheTubeShape",
     "Substrate",

--- a/pmrf/materials/conductor_shape.py
+++ b/pmrf/materials/conductor_shape.py
@@ -32,22 +32,57 @@ class AbstractConductorShape(eqx.Module):
     ParamRF objects in sight. Concrete shapes differ in the geometry they
     need -- a rod takes a radius, a tube a radius and a wall thickness, a
     half-space none -- so only the common material argument is fixed here.
+
+    **Normalisation convention**
+
+    Every entry returns an impedance in ohm per square, referred to the
+    current its own cross-section carries, and the caller multiplies by an
+    inverse-metre geometry weight $k$ to obtain a per-unit-length series
+    impedance. The round entries and the caller agree on that normalisation
+    exactly: :class:`SchelkunoffRodShape` is referred to the total rod
+    current and the caller's weight is $1/2\pi a$, so the product is the
+    rod's true impedance at every frequency.
+
+    The planar entries do not have that luxury, because the planar weight in
+    use is Wheeler's incremental-inductance factor, which is a different
+    decomposition of the problem. :class:`HollowayKuesterSlabShape` is
+    referred to the *total strip current*, so reproducing the true dc
+    resistance $1/(\sigma W t)$ from its dc value $2/(\sigma t)$ requires a
+    weight of $1/(2W)$ -- for a 1.55 mm trace that is $322.6\,\mathrm{m^{-1}}$
+    against Wheeler's $963.7\,\mathrm{m^{-1}}$, a factor of **2.99**. The
+    discrepancy is real physics, not a scale error: Wheeler's weight is
+    larger because it is an incremental-inductance result covering the
+    ground plane and the edge crowding as well as the strip, while the slab
+    is a one-dimensional strip diffusion result containing neither. Under
+    Wheeler's weight the exact slab therefore returns 0.925 ohm/m at dc for
+    35 um copper on that trace where the true value is 0.3097 ohm/m, and no
+    rescaling repairs it: halving the slab to fix dc breaks the strong-skin
+    asymptote by the same factor.
+
+    A frequency-independent weight consequently admits only one entry that
+    is right at both ends, :class:`RootSumSquareSlabShape`, which reaches
+    into the caller's normalisation through the optional ``weight``
+    argument. That is why the blend is the planar default and not merely an
+    industry convention; the honest fix is separate strip and ground-plane
+    weights (Holloway--Kuester), which ParamRF does not implement.
     """
     @abstractmethod
-    def impedance(self, w, conductor: ConductorProperties, **geometry) -> jnp.ndarray:
+    def impedance(self, omega, conductor: ConductorProperties, **geometry) -> jnp.ndarray:
         r"""
         Return the surface impedance of this shape, in ohm per square.
 
         Parameters
         ----------
-        w : ArrayLike
-            Angular frequency in rad/s.
+        omega : ArrayLike
+            Angular frequency in rad/s. The frequency argument is *not*
+            named ``w``: under the symbol-named geometry convention ``w`` is
+            a strip width, which a planar entry takes at the same call.
         conductor : ConductorProperties
             The metal's evaluated properties. ``conductor.zs`` is the
             surface prefactor -- for a smooth bulk metal the intrinsic
             surface impedance $\zeta_c=\sqrt{j\omega\mu/\sigma}$, but a
             surface treatment such as roughness scales it -- and
-            ``conductor.gamma(w)`` is the diffusion constant
+            ``conductor.gamma(omega)`` is the diffusion constant
             $\gamma=\sqrt{j\omega\mu\sigma}$ inside the bulk, which supplies
             the dimensionless $\gamma a$ and $\gamma t$ arguments. The two
             are independent inputs: never recover one from the other via
@@ -60,6 +95,13 @@ class AbstractConductorShape(eqx.Module):
             takes a radius and a wall thickness and uses neither -- so a
             caller choosing between shapes never has to know which
             arguments a particular one reads.
+        weight : ArrayLike, optional
+            The inverse-metre geometry weight the caller is about to
+            multiply this entry's answer by, passed as part of the geometry
+            so that an entry whose dc floor is fixed in per-unit-length
+            terms can express that floor in the caller's normalisation. Only
+            :class:`RootSumSquareSlabShape` reads it; see the normalisation
+            note in :class:`AbstractConductorShape`.
 
         Returns
         -------
@@ -95,7 +137,7 @@ class HalfSpaceShape(AbstractConductorShape):
     Investigations of Radiowave Propagation, Part II, 5-12. Academy of
     Sciences, USSR.
     """
-    def impedance(self, w, conductor: ConductorProperties, **geometry) -> jnp.ndarray:
+    def impedance(self, omega, conductor: ConductorProperties, **geometry) -> jnp.ndarray:
         # Cross-section dimensions are accepted and ignored: a half-space has
         # none, and a caller choosing between shapes should not have to know
         # which of them take a radius or a wall thickness.
@@ -125,6 +167,25 @@ class HollowayKuesterSlabShape(AbstractConductorShape):
     $\zeta_c\tanh(\gamma_c t/2)$ is valid for quasi-TEM coplanar waveguide
     and for microstrip whose characteristic impedance exceeds 40 ohm.
 
+    **Normalisation**
+
+    The scalar is referred to the *total* strip current, so the geometry
+    weight that turns it into a per-unit-length resistance is $1/(2W)$: at
+    dc the entry returns $2/(\sigma t)$ and $2/(\sigma t)\cdot 1/(2W)$ is
+    the true $1/(\sigma W t)$. That is not the weight
+    :class:`~pmrf.models.components.lines.current_distribution.WheelerCurrentDistribution`
+    supplies -- for a 1.55 mm trace Wheeler's weight is
+    $963.7\,\mathrm{m^{-1}}$ against $1/(2W)=322.6\,\mathrm{m^{-1}}$, a
+    factor of 2.99 -- because Wheeler's weight also covers the ground plane
+    and the edge crowding that this one-dimensional strip result does not
+    contain. Charged with Wheeler's weight the entry therefore gives
+    0.925 ohm/m at dc for 35 um copper on that trace where the true value is
+    0.3097 ohm/m. Rescaling cannot fix both ends at once, which is why
+    :class:`RootSumSquareSlabShape` and not this entry is the planar
+    default; see the normalisation note on
+    :class:`AbstractConductorShape`. Use this entry with a weight it is
+    normalised against.
+
     References
     ----------
     Holloway, C. L., & Kuester, E. F. (1994). Edge shape effects and
@@ -135,15 +196,12 @@ class HollowayKuesterSlabShape(AbstractConductorShape):
     Electromagnetic Analysis. IEEE Transactions on Microwave Theory and
     Techniques, 51(3), 915-921. Eq. (4).
     """
-    #: Strip thickness in metres
-    t: jnp.ndarray
-
-    def impedance(self, w, conductor: ConductorProperties) -> jnp.ndarray:
-        gamma_t_over_two = conductor.gamma(w) * self.t / 2
-        evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
+    def impedance(self, omega, conductor: ConductorProperties, *, t, **geometry) -> jnp.ndarray:
+        gamma_t_over_two = conductor.gamma(omega) * t / 2
+        evaluable = (omega > 0) & jnp.isfinite(conductor.sigma)
         safe_argument = jnp.where(evaluable, gamma_t_over_two, 1.0)
         zs = conductor.zs / jnp.tanh(safe_argument)
-        dc = 2 / (conductor.sigma * self.t)
+        dc = 2 / (conductor.sigma * t)
         return jnp.where(evaluable, zs, dc)
 
 
@@ -153,41 +211,80 @@ class RootSumSquareSlabShape(AbstractConductorShape):
 
     **Mathematical Formulation**
 
-    $$Z_s=\sqrt{R_{dc,sq}^2+\Re(\zeta_c)^2}+j\Im(\zeta_c).$$
+    $$Z_s=\sqrt{R_{dc,sq}^2+\Re(\zeta_c)^2}+j\Im(\zeta_c),\qquad
+    R_{dc,sq}=\frac{1}{\sigma W t\,k},$$
 
-    This is a ParamRF convention and has no source paper.  It preserves the
-    dc and semi-infinite resistance asymptotes, remains smooth and monotone,
-    and deliberately leaves the half-space reactance unchanged.  Against the
-    exact slab over 10--500 MHz its transition-shape residual after the best
-    global scale is 11% for a 1.55 mm by 35 um trace, 14% for 0.45 mm by
-    35 um, and 15% for a 0.35 mm by 35 um, 96-ohm trace.  It is retained for
-    compatibility with the modelling convention used by industry tools, not
-    as the preferred finite-thickness physics.
+    where $W$ is the strip width, $t$ its thickness and $k$ the caller's
+    inverse-metre geometry weight. The entry computes its own dc floor from
+    those dimensions: charged with $k$ the first term becomes exactly the
+    strip's true dc resistance $1/(\sigma W t)$, and the second becomes the
+    semi-infinite result $k\,\Re(\zeta_c)$. This is a ParamRF convention and
+    has no source paper.
+
+    **Why it is the planar default**
+
+    Under a frequency-independent geometry weight this is the *only* entry
+    that is right at both ends. :class:`HollowayKuesterSlabShape` is exact
+    but is normalised to the total strip current, which fixes its weight at
+    $1/(2W)$ -- a factor of 2.99 away from Wheeler's for a 1.55 mm trace --
+    so it cannot satisfy the dc asymptote under the weight actually in use;
+    see the normalisation note on :class:`AbstractConductorShape`. Reaching
+    into the caller's normalisation through ``weight`` is the price of
+    satisfying both asymptotes at once, and is why the industry tools
+    converged on the same blend.
+
+    **Validity**
+
+    Against the exact slab over 10--500 MHz its transition-shape residual
+    after the best global scale is 11% for a 1.55 mm by 35 um trace, 14% for
+    0.45 mm by 35 um, and 15% for a 0.35 mm by 35 um, 96-ohm trace.
+
+    The blend is resistance-only: it keeps the half-space reactance
+    $\Im(\zeta_c)$, which grows as $\sqrt{\omega}$, where the true finite
+    slab's internal inductance saturates at $\omega\mu t/6$. Below
+    $t\approx\delta$ it is therefore not merely approximate in the
+    transition but qualitatively wrong on internal inductance. Measured
+    against :class:`HollowayKuesterSlabShape` for 35 um copper:
+
+    ==================  ======  ======  ======  ======  ======
+    quantity            100kHz    1MHz    5MHz   10MHz   50MHz
+    ==================  ======  ======  ======  ======  ======
+    $t/\delta$            0.17    0.54    1.20    1.70    3.79
+    blend $X$/exact $X$  17.7x    5.6x    2.5x    1.8x   1.01x
+    ==================  ======  ======  ======  ======  ======
+
+    The honest fix is separate strip and ground-plane weights, which
+    Holloway--Kuester supply and ParamRF does not implement.
 
     References
     ----------
     ParamRF convention; no source paper.
-    """
-    #: Geometry factor which gives DC sheet resistance when divided by sigma
-    dc_shape_factor: jnp.ndarray
 
-    def impedance(self, w, conductor: ConductorProperties) -> jnp.ndarray:
-        r_dc_sq = self.dc_shape_factor / conductor.sigma
+    Holloway, C. L., & Kuester, E. F. (1994). Edge shape effects and
+    quasi-closed form expressions for the conductor loss of microstrip
+    lines. Radio Science, 29(3), 539-559.
+    """
+    def impedance(self, omega, conductor: ConductorProperties, *, w, t, weight, **geometry) -> jnp.ndarray:
+        # The dc floor is a per-unit-length quantity, 1/(sigma*W*t), while
+        # this layer returns ohm per square: dividing by the caller's weight
+        # places that floor in the caller's normalisation, so that
+        # multiplying by the weight restores it exactly.
+        r_dc_sq = 1 / (conductor.sigma * w * t * weight)
         resistance = jnp.sqrt(r_dc_sq**2 + jnp.real(conductor.zs) ** 2)
         return resistance + 1j * jnp.imag(conductor.zs)
 
 
-def _tesche_circuit_impedance(zeta_c, r_dc_sq, inverse_l_int_sq, w):
+def _tesche_circuit_impedance(zeta_c, r_dc_sq, inverse_l_int_sq, omega):
     """Blend Tesche's dc and high-frequency limits through his equivalent circuit.
 
     The internal inductance arrives inverted so that an infinite one -- an
     infinitely thick tube wall -- enters as a plain zero. Complex arithmetic
-    on an infinity does not survive: ``1j*w*inf`` is ``nan + infj``, and
+    on an infinity does not survive: ``1j*omega*inf`` is ``nan + infj``, and
     dividing a complex number by ``inf + 0j`` is nan under XLA's division.
     """
-    safe_w = jnp.where(w > 0, w, 1.0)
-    z = r_dc_sq + zeta_c / (1 + zeta_c * inverse_l_int_sq / (1j * safe_w))
-    return jnp.where(w > 0, z, r_dc_sq)
+    safe_omega = jnp.where(omega > 0, omega, 1.0)
+    z = r_dc_sq + zeta_c / (1 + zeta_c * inverse_l_int_sq / (1j * safe_omega))
+    return jnp.where(omega > 0, z, r_dc_sq)
 
 
 class TescheRodShape(AbstractConductorShape):
@@ -228,10 +325,10 @@ class TescheRodShape(AbstractConductorShape):
     Coaxial Cable Filled With a Nondispersive Dielectric. IEEE Transactions
     on Electromagnetic Compatibility, 49(1), 12-17.
     """
-    def impedance(self, w, conductor: ConductorProperties, *, a) -> jnp.ndarray:
+    def impedance(self, omega, conductor: ConductorProperties, *, a, **geometry) -> jnp.ndarray:
         r_dc_sq = 2 / (a * conductor.sigma)
         inverse_l_int_sq = 4 / (mu_0 * conductor.mu_r * a)
-        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, inverse_l_int_sq, w)
+        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, inverse_l_int_sq, omega)
 
 
 class TescheTubeShape(AbstractConductorShape):
@@ -268,7 +365,7 @@ class TescheTubeShape(AbstractConductorShape):
     Coaxial Cable Filled With a Nondispersive Dielectric. IEEE Transactions
     on Electromagnetic Compatibility, 49(1), 12-17.
     """
-    def impedance(self, w, conductor: ConductorProperties, *, a, t=jnp.inf) -> jnp.ndarray:
+    def impedance(self, omega, conductor: ConductorProperties, *, a, t=jnp.inf, **geometry) -> jnp.ndarray:
         # An infinite wall is taken analytically rather than arithmetically:
         # both the dc resistance and the inverse internal inductance are zero
         # there, and evaluating the expressions at t = inf would leave an
@@ -281,7 +378,7 @@ class TescheTubeShape(AbstractConductorShape):
             jnp.log1p(safe_t / a) / (1 - q) ** 2 + (q - 3) / (4 * (1 - q))
         )
         inverse_l_int_sq = jnp.where(finite_wall, 1 / l_int_sq, 0.0)
-        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, inverse_l_int_sq, w)
+        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, inverse_l_int_sq, omega)
 
 
 class SchelkunoffRodShape(AbstractConductorShape):
@@ -320,7 +417,7 @@ class SchelkunoffRodShape(AbstractConductorShape):
     Transmission Lines and Cylindrical Shields. Bell System Technical
     Journal, 13(4), 532-579. Eq. (65).
     """
-    def impedance(self, w, conductor: ConductorProperties, *, a) -> jnp.ndarray:
+    def impedance(self, omega, conductor: ConductorProperties, *, a, **geometry) -> jnp.ndarray:
         # gamma vanishes at dc, where the ratio has a pole that exactly
         # cancels zeta_c's zero. Take that limit analytically and keep the
         # argument away from the pole so the gradient stays finite. A
@@ -330,12 +427,12 @@ class SchelkunoffRodShape(AbstractConductorShape):
         # the narrower `w > 0`: an infinite sigma needs a safe Bessel
         # argument, but its zero zeta_c already gives the right answer, and
         # 2/(a*sigma) is likewise zero there.
-        gamma_a = conductor.gamma(w) * a
-        evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
+        gamma_a = conductor.gamma(omega) * a
+        evaluable = (omega > 0) & jnp.isfinite(conductor.sigma)
         safe_gamma_a = jnp.where(evaluable, gamma_a, 1.0)
         zs = conductor.zs * i0_over_i1(safe_gamma_a)
         r_dc_sq = 2 / (a * conductor.sigma)
-        return jnp.where(w > 0, zs, r_dc_sq)
+        return jnp.where(omega > 0, zs, r_dc_sq)
 
 
 class SchelkunoffTubeShape(AbstractConductorShape):
@@ -400,15 +497,15 @@ class SchelkunoffTubeShape(AbstractConductorShape):
     Transmission Lines and Cylindrical Shields. Bell System Technical
     Journal, 13(4), 532-579. Eq. (74).
     """
-    def impedance(self, w, conductor: ConductorProperties, *, a, t=jnp.inf) -> jnp.ndarray:
+    def impedance(self, omega, conductor: ConductorProperties, *, a, t=jnp.inf, **geometry) -> jnp.ndarray:
         # Same guards as the solid rod: gamma vanishes at dc and diverges for
         # a perfect conductor, so both branches are evaluated on arguments
         # the other regime cannot poison. An infinite wall is the third
         # unevaluable argument -- the Bessel functions at gamma*b are then
         # 0 and inf, whose product is NaN -- so it too gets a safe argument
         # and an analytic value, here rho = 0.
-        gamma = conductor.gamma(w)
-        evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
+        gamma = conductor.gamma(omega)
+        evaluable = (omega > 0) & jnp.isfinite(conductor.sigma)
         safe_gamma = jnp.where(evaluable, gamma, 1.0)
         finite_wall = jnp.isfinite(t)
         safe_t = jnp.where(finite_wall, t, a)

--- a/pmrf/materials/conductor_shape.py
+++ b/pmrf/materials/conductor_shape.py
@@ -43,9 +43,17 @@ class AbstractConductorShape(eqx.Module):
         w : ArrayLike
             Angular frequency in rad/s.
         conductor : ConductorProperties
-            The metal's evaluated properties. ``conductor.zs`` is its
-            intrinsic surface impedance $\zeta_c=\sqrt{j\omega\mu/\sigma}$,
-            not yet weighted by this shape's factor.
+            The metal's evaluated properties. ``conductor.zs`` is the
+            surface prefactor -- for a smooth bulk metal the intrinsic
+            surface impedance $\zeta_c=\sqrt{j\omega\mu/\sigma}$, but a
+            surface treatment such as roughness scales it -- and
+            ``conductor.gamma(w)`` is the diffusion constant
+            $\gamma=\sqrt{j\omega\mu\sigma}$ inside the bulk, which supplies
+            the dimensionless $\gamma a$ and $\gamma t$ arguments. The two
+            are independent inputs: never recover one from the other via
+            $\gamma=\sigma\zeta_c$, an identity that holds only for a smooth
+            bulk conductor. ``zs`` is not yet weighted by this shape's
+            factor.
         **geometry
             Shape-specific cross-section dimensions, in meters.
 
@@ -98,7 +106,7 @@ class HollowayKuesterSlabShape(AbstractConductorShape):
     $Z_m=\zeta_c\operatorname{csch}(\gamma_c t)$.  Their eq. (100) shows
     that the total current therefore sees
     $$Z_s+Z_m=\zeta_c\coth(\gamma_c t/2),\qquad
-    \gamma_c=\sigma\zeta_c.$$
+    \gamma_c=\sqrt{j\omega\mu\sigma}.$$
 
     The half-thickness argument is essential: the scalar represents total
     current, rather than the self impedance of either face.  Its limits are
@@ -124,7 +132,7 @@ class HollowayKuesterSlabShape(AbstractConductorShape):
     t: jnp.ndarray
 
     def impedance(self, w, conductor: ConductorProperties) -> jnp.ndarray:
-        gamma_t_over_two = conductor.sigma * conductor.zs * self.t / 2
+        gamma_t_over_two = conductor.gamma(w) * self.t / 2
         evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
         safe_argument = jnp.where(evaluable, gamma_t_over_two, 1.0)
         zs = conductor.zs / jnp.tanh(safe_argument)
@@ -265,9 +273,9 @@ class SchelkunoffRodShape(AbstractConductorShape):
     per unit length of a solid cylinder of radius $a$, is
     $$Z = \frac{\gamma}{2\pi a\sigma}\,\frac{I_0(\gamma a)}{I_1(\gamma a)},
     \qquad \gamma=\sqrt{j\omega\mu\sigma}.$$
-    Since $\zeta_c=\sqrt{j\omega\mu/\sigma}=\gamma/\sigma$, the shape
-    factor this layer returns -- with the caller supplying its own
-    $1/2\pi a$ geometry weight -- is simply the Bessel ratio:
+    For a smooth bulk metal $\zeta_c=\sqrt{j\omega\mu/\sigma}=\gamma/\sigma$,
+    so the shape factor this layer returns -- with the caller supplying its
+    own $1/2\pi a$ geometry weight -- is simply the Bessel ratio:
     $$Z_s = \zeta_c\,\frac{I_0(\gamma a)}{I_1(\gamma a)}.$$
 
     Both limits follow with no special case. As $\gamma a\to0$,
@@ -291,16 +299,16 @@ class SchelkunoffRodShape(AbstractConductorShape):
     Journal, 13(4), 532-579. Eq. (65).
     """
     def impedance(self, w, conductor: ConductorProperties, *, a) -> jnp.ndarray:
-        # gamma = sigma * zeta_c vanishes at dc, where the ratio has a pole
-        # that exactly cancels zeta_c's zero. Take that limit analytically
-        # and keep the argument away from the pole so the gradient stays
-        # finite. A perfect conductor is the other unevaluable argument:
-        # gamma is infinite there, but zeta_c is zero, so the shape factor
-        # never has to be evaluated at all -- which is why the final guard
-        # below is the narrower `w > 0`: an infinite sigma needs a safe
-        # Bessel argument, but its zero zeta_c already gives the right
-        # answer, and 2/(a*sigma) is likewise zero there.
-        gamma_a = conductor.sigma * conductor.zs * a
+        # gamma vanishes at dc, where the ratio has a pole that exactly
+        # cancels zeta_c's zero. Take that limit analytically and keep the
+        # argument away from the pole so the gradient stays finite. A
+        # perfect conductor is the other unevaluable argument: gamma is
+        # infinite there, but zeta_c is zero, so the shape factor never has
+        # to be evaluated at all -- which is why the final guard below is
+        # the narrower `w > 0`: an infinite sigma needs a safe Bessel
+        # argument, but its zero zeta_c already gives the right answer, and
+        # 2/(a*sigma) is likewise zero there.
+        gamma_a = conductor.gamma(w) * a
         evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
         safe_gamma_a = jnp.where(evaluable, gamma_a, 1.0)
         zs = conductor.zs * i0_over_i1(safe_gamma_a)
@@ -329,7 +337,7 @@ class SchelkunoffTubeShape(AbstractConductorShape):
     13(4), 532-579. Eq. (74).
     """
     def impedance(self, w, conductor: ConductorProperties, *, a, t) -> jnp.ndarray:
-        gamma = conductor.sigma * conductor.zs
+        gamma = conductor.gamma(w)
         evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
         safe_gamma = jnp.where(evaluable, gamma, 1.0)
         xa = safe_gamma * a
@@ -352,7 +360,7 @@ class SchelkunoffCothTubeShape(AbstractConductorShape):
     $$Z_s = \zeta_c\coth(\gamma t)\frac{K_0(\gamma a)}{K_1(\gamma a)}.$$
     """
     def impedance(self, w, conductor: ConductorProperties, *, a, t) -> jnp.ndarray:
-        gamma = conductor.sigma * conductor.zs
+        gamma = conductor.gamma(w)
         evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
         safe_gamma = jnp.where(evaluable, gamma, 1.0)
         zeta = conductor.zs / jnp.tanh(safe_gamma * t)
@@ -377,7 +385,7 @@ class SchelkunoffInfiniteTubeShape(AbstractConductorShape):
     13(4), 532-579. Eq. (74), infinite-wall limit.
     """
     def impedance(self, w, conductor: ConductorProperties, *, a) -> jnp.ndarray:
-        gamma = conductor.sigma * conductor.zs
+        gamma = conductor.gamma(w)
         evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
         safe_gamma = jnp.where(evaluable, gamma, 1.0)
         z = conductor.zs * k0_over_k1(safe_gamma * a)

--- a/pmrf/materials/conductor_shape.py
+++ b/pmrf/materials/conductor_shape.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 from scipy.constants import mu_0
 
 from pmrf.materials.properties import ConductorProperties
-from pmrf.math.bessel import i0_over_i1, k0_over_k1
+from pmrf.math.bessel import i0_over_i1, i1e, k0_over_k1, k1e
 
 
 class AbstractConductorShape(eqx.Module):
@@ -55,7 +55,11 @@ class AbstractConductorShape(eqx.Module):
             bulk conductor. ``zs`` is not yet weighted by this shape's
             factor.
         **geometry
-            Shape-specific cross-section dimensions, in meters.
+            Shape-specific cross-section dimensions, in meters. A shape
+            accepts and ignores dimensions it has none of -- a half-space
+            takes a radius and a wall thickness and uses neither -- so a
+            caller choosing between shapes never has to know which
+            arguments a particular one reads.
 
         Returns
         -------
@@ -91,7 +95,10 @@ class HalfSpaceShape(AbstractConductorShape):
     Investigations of Radiowave Propagation, Part II, 5-12. Academy of
     Sciences, USSR.
     """
-    def impedance(self, w, conductor: ConductorProperties) -> jnp.ndarray:
+    def impedance(self, w, conductor: ConductorProperties, **geometry) -> jnp.ndarray:
+        # Cross-section dimensions are accepted and ignored: a half-space has
+        # none, and a caller choosing between shapes should not have to know
+        # which of them take a radius or a wall thickness.
         return conductor.zs
 
 
@@ -170,10 +177,16 @@ class RootSumSquareSlabShape(AbstractConductorShape):
         return resistance + 1j * jnp.imag(conductor.zs)
 
 
-def _tesche_circuit_impedance(zeta_c, r_dc_sq, l_int_sq, w):
-    """Blend Tesche's dc and high-frequency limits through his equivalent circuit."""
+def _tesche_circuit_impedance(zeta_c, r_dc_sq, inverse_l_int_sq, w):
+    """Blend Tesche's dc and high-frequency limits through his equivalent circuit.
+
+    The internal inductance arrives inverted so that an infinite one -- an
+    infinitely thick tube wall -- enters as a plain zero. Complex arithmetic
+    on an infinity does not survive: ``1j*w*inf`` is ``nan + infj``, and
+    dividing a complex number by ``inf + 0j`` is nan under XLA's division.
+    """
     safe_w = jnp.where(w > 0, w, 1.0)
-    z = r_dc_sq + zeta_c / (1 + zeta_c / (1j * safe_w * l_int_sq))
+    z = r_dc_sq + zeta_c / (1 + zeta_c * inverse_l_int_sq / (1j * safe_w))
     return jnp.where(w > 0, z, r_dc_sq)
 
 
@@ -217,8 +230,8 @@ class TescheRodShape(AbstractConductorShape):
     """
     def impedance(self, w, conductor: ConductorProperties, *, a) -> jnp.ndarray:
         r_dc_sq = 2 / (a * conductor.sigma)
-        l_int_sq = mu_0 * conductor.mu_r * a / 4
-        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, l_int_sq, w)
+        inverse_l_int_sq = 4 / (mu_0 * conductor.mu_r * a)
+        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, inverse_l_int_sq, w)
 
 
 class TescheTubeShape(AbstractConductorShape):
@@ -242,10 +255,12 @@ class TescheTubeShape(AbstractConductorShape):
 
     Same circuit approximation as the solid rod, so it shares the same
     defect: its strong-skin limit is $\zeta_c + R_{dc,sq}$, not $\zeta_c$
-    exactly. In the infinite-wall limit ($t\to\infty$), $R_{dc,sq}\to0$ and
-    $L_{int,sq}\to\infty$, and this reduces to :class:`HalfSpaceShape` --
-    how :class:`~pmrf.models.components.lines.formulations.TescheCoaxialFormulation`
-    treats an outer shield whose wall thickness is not modelled.
+    exactly. An infinite $t$ is the default, and is taken analytically
+    rather than arithmetically: $R_{dc,sq}\to0$ and $L_{int,sq}\to\infty$,
+    so the shape reduces exactly to :class:`HalfSpaceShape`. That is how
+    :class:`~pmrf.models.components.lines.formulations.TescheCoaxialFormulation`
+    describes an outer shield whose wall thickness is not modelled -- it
+    passes an infinite $t$ rather than swapping the shape.
 
     References
     ----------
@@ -253,13 +268,20 @@ class TescheTubeShape(AbstractConductorShape):
     Coaxial Cable Filled With a Nondispersive Dielectric. IEEE Transactions
     on Electromagnetic Compatibility, 49(1), 12-17.
     """
-    def impedance(self, w, conductor: ConductorProperties, *, a, t) -> jnp.ndarray:
-        q = (a / (a + t)) ** 2
-        r_dc_sq = 1 / (t * conductor.sigma)
+    def impedance(self, w, conductor: ConductorProperties, *, a, t=jnp.inf) -> jnp.ndarray:
+        # An infinite wall is taken analytically rather than arithmetically:
+        # both the dc resistance and the inverse internal inductance are zero
+        # there, and evaluating the expressions at t = inf would leave an
+        # inf/inf behind instead.
+        finite_wall = jnp.isfinite(t)
+        safe_t = jnp.where(finite_wall, t, a)
+        q = (a / (a + safe_t)) ** 2
+        r_dc_sq = jnp.where(finite_wall, 1 / (safe_t * conductor.sigma), 0.0)
         l_int_sq = mu_0 * conductor.mu_r * a * (
-            jnp.log1p(t / a) / (1 - q) ** 2 + (q - 3) / (4 * (1 - q))
+            jnp.log1p(safe_t / a) / (1 - q) ** 2 + (q - 3) / (4 * (1 - q))
         )
-        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, l_int_sq, w)
+        inverse_l_int_sq = jnp.where(finite_wall, 1 / l_int_sq, 0.0)
+        return _tesche_circuit_impedance(conductor.zs, r_dc_sq, inverse_l_int_sq, w)
 
 
 class SchelkunoffRodShape(AbstractConductorShape):
@@ -317,76 +339,89 @@ class SchelkunoffRodShape(AbstractConductorShape):
 
 
 class SchelkunoffTubeShape(AbstractConductorShape):
-    r"""Finite cylindrical tube using Schelkunoff's tube impedance.
+    r"""
+    Cylindrical tube of finite wall thickness, exact.
 
     **Mathematical Formulation**
 
-    For inner radius $a$ and outer radius $b=a+t$, Schelkunoff's eq. (74) is
-    evaluated in the numerically stable form
-    $$Z_s = \zeta_c\frac{I_0(\gamma b)K_1(\gamma a)+K_0(\gamma b)I_1(\gamma a)}
-    {I_1(\gamma b)K_1(\gamma a)-K_1(\gamma b)I_1(\gamma a)}.$$
+    For inner radius $a$, outer radius $b=a+t$ and current returning on the
+    **inner** surface, Schelkunoff's eq. (74) gives the internal impedance
+    referred to that surface. Written as a shape factor -- the caller
+    supplies the $1/2\pi a$ geometry weight -- it is
+    $$Z_s = \zeta_c\,
+    \frac{I_0(\gamma a)K_1(\gamma b)+K_0(\gamma a)I_1(\gamma b)}
+    {I_1(\gamma b)K_1(\gamma a)-I_1(\gamma a)K_1(\gamma b)},
+    \qquad\gamma=\sqrt{j\omega\mu\sigma}.$$
 
-    The implementation uses an equivalent exponentially scaled expression.
-    The cylindrical curvature ratio is evaluated from its convergent series
-    in weak skin effect and its asymptotic expansion in strong skin effect.
+    Dividing through by $I_1(\gamma b)K_1(\gamma a)$ turns this into three
+    bounded pieces,
+    $$Z_s = \zeta_c\,\frac{K_0(\gamma a)/K_1(\gamma a)
+    + \big[I_0(\gamma a)/I_1(\gamma a)\big]\,\rho}{1-\rho},
+    \qquad
+    \rho = \frac{I_1(\gamma a)K_1(\gamma b)}{I_1(\gamma b)K_1(\gamma a)},$$
+    which is what is evaluated. The two ratios are
+    :func:`~pmrf.math.bessel.i0_over_i1` and
+    :func:`~pmrf.math.bessel.k0_over_k1`; the surface-coupling term $\rho$ is
+    assembled from the exponentially scaled
+    :func:`~pmrf.math.bessel.i1e` and :func:`~pmrf.math.bessel.k1e`, so that
+    the only exponential left is $e^{-2\gamma t}$, which never exceeds unity.
+    No Bessel function is ever evaluated unscaled, and nothing overflows for
+    a thick wall.
+
+    Both limits fall out with no special case. In strong skin effect
+    $\rho\to e^{-2\gamma t}$ and the shape becomes
+    $\zeta_c\coth(\gamma t)$ with the cylindrical curvature corrections
+    carried by the two ratios. As $\gamma\to0$, $\rho\to a^2/b^2$ and
+    $I_0/I_1\to2/\gamma a$, leaving the exact dc sheet resistance
+    $$Z_s \to \frac{2a}{\sigma(b^2-a^2)} = \frac{1}{\sigma t}
+    \cdot\frac{2a}{a+b},$$
+    which is $2\pi a$ times $1/\sigma\pi(b^2-a^2)$, the tube's dc resistance
+    per unit length, and reduces to $1/\sigma t$ for a thin wall. That is the
+    value the $\omega=0$ branch below returns, so the dc value and the
+    low-frequency limit agree exactly rather than differing by a factor of
+    two.
+
+    An infinite ``t`` is accepted and gives the infinite-wall limit
+    $\zeta_c K_0(\gamma a)/K_1(\gamma a)$, which is how a coaxial shield
+    whose wall is not modelled is described.
+
+    **Validity**
+
+    Exact for a homogeneous, isotropic tube carrying axially symmetric
+    current returning on its inner surface, at every frequency. The
+    remaining error is the numerics of the Bessel evaluations, below 1e-7
+    relative against :func:`scipy.special` over the weak-skin, transition
+    and strong-skin regimes; see ``tests/test_materials/
+    test_conductor_shape.py``.
 
     References
     ----------
     Schelkunoff, S. A. (1934). The Electromagnetic Theory of Coaxial
-    Transmission Lines and Cylindrical Shields. Bell System Technical Journal,
-    13(4), 532-579. Eq. (74).
+    Transmission Lines and Cylindrical Shields. Bell System Technical
+    Journal, 13(4), 532-579. Eq. (74).
     """
-    def impedance(self, w, conductor: ConductorProperties, *, a, t) -> jnp.ndarray:
+    def impedance(self, w, conductor: ConductorProperties, *, a, t=jnp.inf) -> jnp.ndarray:
+        # Same guards as the solid rod: gamma vanishes at dc and diverges for
+        # a perfect conductor, so both branches are evaluated on arguments
+        # the other regime cannot poison. An infinite wall is the third
+        # unevaluable argument -- the Bessel functions at gamma*b are then
+        # 0 and inf, whose product is NaN -- so it too gets a safe argument
+        # and an analytic value, here rho = 0.
         gamma = conductor.gamma(w)
         evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
         safe_gamma = jnp.where(evaluable, gamma, 1.0)
+        finite_wall = jnp.isfinite(t)
+        safe_t = jnp.where(finite_wall, t, a)
+
         xa = safe_gamma * a
-        xb = safe_gamma * (a + t)
-        # Eq. (74) in the strong-skin range, retaining the exponentially small
-        # coupling between the two cylindrical surfaces.
-        curvature = k0_over_k1(xa)
-        coupling = jnp.exp(-2 * (xb - xa))
-        z = conductor.zs * (curvature + coupling) / (1 - coupling)
-        return jnp.where(evaluable, z, 1 / (t * conductor.sigma))
+        xb = safe_gamma * (a + safe_t)
+        rho = (i1e(xa) * k1e(xb)) / (i1e(xb) * k1e(xa)) * jnp.exp(-2 * safe_gamma * safe_t)
+        rho = jnp.where(finite_wall, rho, 0.0)
 
-
-class SchelkunoffCothTubeShape(AbstractConductorShape):
-    r"""Cheap finite-wall shield approximation.
-
-    **Mathematical Formulation**
-
-    The planar finite-slab impedance is charged over the circumference and
-    corrected by the infinite-wall cylindrical curvature:
-    $$Z_s = \zeta_c\coth(\gamma t)\frac{K_0(\gamma a)}{K_1(\gamma a)}.$$
-    """
-    def impedance(self, w, conductor: ConductorProperties, *, a, t) -> jnp.ndarray:
-        gamma = conductor.gamma(w)
-        evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
-        safe_gamma = jnp.where(evaluable, gamma, 1.0)
-        zeta = conductor.zs / jnp.tanh(safe_gamma * t)
-        zeta = zeta * k0_over_k1(safe_gamma * a)
-        return jnp.where(evaluable, zeta, 1 / (t * conductor.sigma))
-
-
-class SchelkunoffInfiniteTubeShape(AbstractConductorShape):
-    r"""Infinite-wall limit of the Schelkunoff cylindrical shield.
-
-    **Mathematical Formulation**
-
-    $$Z_s = \zeta_c\frac{K_0(\gamma a)}{K_1(\gamma a)}$$
-
-    The ratio is evaluated from its convergent series in weak skin effect and
-    its asymptotic expansion in strong skin effect.
-
-    References
-    ----------
-    Schelkunoff, S. A. (1934). The Electromagnetic Theory of Coaxial
-    Transmission Lines and Cylindrical Shields. Bell System Technical Journal,
-    13(4), 532-579. Eq. (74), infinite-wall limit.
-    """
-    def impedance(self, w, conductor: ConductorProperties, *, a) -> jnp.ndarray:
-        gamma = conductor.gamma(w)
-        evaluable = (w > 0) & jnp.isfinite(conductor.sigma)
-        safe_gamma = jnp.where(evaluable, gamma, 1.0)
-        z = conductor.zs * k0_over_k1(safe_gamma * a)
-        return jnp.where(evaluable, z, 0.0)
+        z = conductor.zs * (k0_over_k1(xa) + i0_over_i1(xa) * rho) / (1 - rho)
+        # sigma divides last so that a perfect conductor sends the whole
+        # quotient to zero rather than leaving inf/inf in the wall gradient.
+        r_dc_sq = jnp.where(
+            finite_wall, (2 * a / (safe_t * (safe_t + 2 * a))) / conductor.sigma, 0.0
+        )
+        return jnp.where(evaluable, z, r_dc_sq)

--- a/pmrf/materials/properties.py
+++ b/pmrf/materials/properties.py
@@ -1,7 +1,8 @@
-"""Frequency-evaluated, geometry-free material properties."""
+r"""Frequency-evaluated, geometry-free material properties."""
 import equinox as eqx
 
 import jax.numpy as jnp
+from scipy.constants import mu_0
 
 
 class DielectricProperties(eqx.Module):
@@ -23,7 +24,11 @@ class DielectricProperties(eqx.Module):
 
 
 class ConductorProperties(eqx.Module):
-    """Evaluated conductor properties.
+    r"""Evaluated conductor properties.
+
+    ``zs`` and :meth:`gamma` are independent: ``zs`` is the surface
+    prefactor, which a surface treatment such as roughness may scale, while
+    :meth:`gamma` describes diffusion into the unmodified bulk.
 
     Parameters
     ----------
@@ -38,3 +43,52 @@ class ConductorProperties(eqx.Module):
     zs: jnp.ndarray
     sigma: jnp.ndarray
     mu_r: jnp.ndarray
+
+    def gamma(self, w) -> jnp.ndarray:
+        r"""
+        Return the propagation constant inside the metal, in 1/m.
+
+        **Mathematical Formulation**
+
+        $$\gamma = \sqrt{j\omega\mu\sigma} = \frac{1+j}{\delta},
+        \qquad \delta = \sqrt{\frac{2}{\omega\mu\sigma}},$$
+
+        with $\mu=\mu_0\mu_r$. This is the inverse complex skin depth: it
+        governs how fast the field diffuses into the bulk, and it is what
+        makes $\gamma a$ and $\gamma t$ the dimensionless "how many skin
+        depths across is this cross-section" arguments of the Bessel and
+        $\coth$ expressions of
+        :mod:`~pmrf.materials.conductor_shape`. Despite the name it is not
+        the propagation constant of the line.
+
+        It is deliberately computed from $\sigma$ and $\mu_r$ rather than
+        recovered from ``zs`` as $\sigma\zeta_c$. That identity holds only
+        for a smooth bulk metal: any surface treatment which scales ``zs``
+        -- roughness today, cladding or plating tomorrow -- would otherwise
+        inflate the diffusion constant, which surface texture does not
+        change.
+
+        The value is zero at dc, where the $\sqrt{\cdot}$ branch point is
+        guarded so the gradient stays finite, and infinite for a perfect
+        conductor. Callers are responsible for their own dc and
+        perfect-conductor branches.
+
+        Parameters
+        ----------
+        w : ArrayLike
+            Angular frequency in rad/s.
+
+        Returns
+        -------
+        jnp.ndarray
+            Propagation constant inside the metal, in 1/m.
+
+        References
+        ----------
+        Pozar, D. M. (2011). Microwave Engineering (4th ed.), Section 1.7.
+        Wiley.
+        """
+        w = jnp.asarray(w)
+        safe_w = jnp.where(w > 0, w, 1.0)
+        k = jnp.sqrt(safe_w * mu_0 * self.mu_r * self.sigma / 2)
+        return jnp.where(w > 0, k * (1 + 1j), 0.0)

--- a/pmrf/materials/substrate.py
+++ b/pmrf/materials/substrate.py
@@ -44,8 +44,12 @@ class Substrate(Module):
         The metallization. A scalar conductivity in S/m is coerced into a
         :class:`~pmrf.materials.BulkConductor`.
     t : Param | None, default=None
-        Thickness of the metallization in meters, or ``None`` for a
-        zero-thickness idealisation.
+        Thickness of the metallization in meters, or ``None`` when it is
+        unspecified. Unspecified is not the same input as zero: it asserts
+        skin effect in operation at every frequency, so the conductor loss
+        gets no dc resistance floor. A positive value gets the floor
+        $R_{dc}=1/(\sigma W t)$, and refines the geometry in those
+        quasi-static formulations that are thickness-aware.
     """
     #: Height of the dielectric sheet
     h: Param = param(default=1.6e-3, constraint=Positive())

--- a/pmrf/math/bessel.py
+++ b/pmrf/math/bessel.py
@@ -4,10 +4,11 @@ Modified Bessel functions for complex arguments.
 JAX ships :func:`jax.scipy.special.i0e` and :func:`~jax.scipy.special.i1e`
 for real arguments only, but cylindrical-conductor physics needs $I_0$ and
 $I_1$ at the complex propagation constant $\gamma a=\sqrt{j\omega\mu\sigma}\,a$.
-What that physics actually needs is never $I_0$ or $I_1$ alone but their
-ratio, which is bounded everywhere off the imaginary axis, so this module
-evaluates the ratio directly rather than two exponentially large numbers
-that are then divided.
+What that physics actually needs is never a Bessel function alone: it is
+either a ratio such as $I_0/I_1$, bounded everywhere off the imaginary axis,
+or an exponentially scaled function such as $I_1(x)e^{-x}$. Both are
+evaluated directly here, so no exponentially large number is ever formed
+only to be divided away.
 """
 import jax.numpy as jnp
 
@@ -40,25 +41,54 @@ for _k in range(1, _SERIES_TERMS):
 _HARMONIC_NUMBERS = tuple(_HARMONIC_NUMBERS)
 
 
-def _i_ratio_series(x):
-    """Evaluate $I_0(x)/I_1(x)$ from the ascending power series."""
+def _poly_in_inverse(x, coefficients):
+    r"""Evaluate $\sum_k c_k x^{-k}$ by Horner's rule in $1/x$."""
+    inv = 1 / x
+    out = jnp.zeros_like(x)
+    for coefficient in reversed(coefficients):
+        out = out * inv + coefficient
+    return out
+
+
+def _i_series_terms(x):
+    r"""Return the ascending-series terms of $I_0$ and $I_1$, and their sums.
+
+    Both series share the term $(x/2)^{2k}/(k!)^2$, accumulated as a running
+    product so no factorial ever overflows; $I_1$ weights it by
+    $(x/2)/(k+1)$. The terms themselves are returned as well because the
+    $K$ series below weight the same ones by the harmonic numbers.
+    """
     k = jnp.arange(_SERIES_TERMS)
     half = x[..., None] / 2
-    # (x/2)^{2k}/(k!)^2 as a running product, so no factorial ever overflows.
-    step = jnp.where(k == 0, 1.0, (half ** 2) / jnp.where(k == 0, 1.0, k) ** 2)
+    step = jnp.where(k == 0, 1.0, (half**2) / jnp.where(k == 0, 1.0, k) ** 2)
     terms = jnp.cumprod(step, axis=-1)
     i0 = jnp.sum(terms, axis=-1)
     i1 = jnp.sum(terms * half / (k + 1), axis=-1)
+    return terms, i0, i1
+
+
+def _k_series(x, terms, i0, i1):
+    r"""Return $K_0(x)$ and $K_1(x)$ from their convergent logarithmic series."""
+    k = jnp.arange(_SERIES_TERMS)
+    harmonic = jnp.asarray(_HARMONIC_NUMBERS)
+    log_term = jnp.log(x / 2) + jnp.euler_gamma
+    k0 = -log_term * i0 + jnp.sum(terms * harmonic, axis=-1)
+    k1 = (
+        i0 / x + log_term * i1
+        - jnp.sum(terms * (2 * k) * harmonic / x[..., None], axis=-1)
+    )
+    return k0, k1
+
+
+def _i_ratio_series(x):
+    """Evaluate $I_0(x)/I_1(x)$ from the ascending power series."""
+    _, i0, i1 = _i_series_terms(x)
     return i0 / i1
 
 
 def _i_ratio_asymptotic(x):
     """Evaluate $I_0(x)/I_1(x)$ from the large-argument expansion."""
-    inv = 1 / x
-    out = jnp.zeros_like(x)
-    for c in reversed(_ASYMPTOTIC_COEFFS):
-        out = out * inv + c
-    return out
+    return _poly_in_inverse(x, _ASYMPTOTIC_COEFFS)
 
 
 def i0_over_i1(x: jnp.ndarray) -> jnp.ndarray:
@@ -113,30 +143,13 @@ def i0_over_i1(x: jnp.ndarray) -> jnp.ndarray:
 
 def _k_ratio_series(x):
     r"""Evaluate $K_0(x)/K_1(x)$ from the convergent logarithmic series."""
-    k = jnp.arange(_SERIES_TERMS)
-    half = x[..., None] / 2
-    step = jnp.where(k == 0, 1.0, half**2 / jnp.where(k == 0, 1.0, k) ** 2)
-    terms = jnp.cumprod(step, axis=-1)
-    harmonic = jnp.asarray(_HARMONIC_NUMBERS)
-
-    i0 = jnp.sum(terms, axis=-1)
-    i1 = jnp.sum(terms * half / (k + 1), axis=-1)
-    log_term = jnp.log(x / 2) + jnp.euler_gamma
-    k0 = -log_term * i0 + jnp.sum(terms * harmonic, axis=-1)
-    k1 = (
-        i0 / x + log_term * i1
-        - jnp.sum(terms * (2 * k) * harmonic / x[..., None], axis=-1)
-    )
+    k0, k1 = _k_series(x, *_i_series_terms(x))
     return k0 / k1
 
 
 def _k_ratio_asymptotic(x):
     """Evaluate $K_0(x)/K_1(x)$ from its large-argument expansion."""
-    inv = 1 / x
-    out = jnp.zeros_like(x)
-    for coefficient in reversed(_K_RATIO_ASYMPTOTIC_COEFFS):
-        out = out * inv + coefficient
-    return out
+    return _poly_in_inverse(x, _K_RATIO_ASYMPTOTIC_COEFFS)
 
 
 def k0_over_k1(x: jnp.ndarray) -> jnp.ndarray:
@@ -169,3 +182,138 @@ def k0_over_k1(x: jnp.ndarray) -> jnp.ndarray:
         _k_ratio_series(x_series),
         _k_ratio_asymptotic(x_asymptotic),
     )
+
+
+#: Coefficients $(-1)^k a_k(1)$ of $x^{-k}$ in the large-argument expansion of
+#: $\sqrt{2\pi x}\,I_1(x)e^{-x}$, from the standard series
+#: $I_\nu(z)\sim e^z(2\pi z)^{-1/2}\sum_k(-1)^k a_k(\nu)z^{-k}$ with
+#: $a_k(\nu)=\prod_{m=1}^{k}(4\nu^2-(2m-1)^2)/(k!\,8^k)$ at $\nu=1$.
+_I1E_ASYMPTOTIC_COEFFS = (
+    1.0, -3 / 8, -15 / 128, -105 / 1024, -4725 / 32768, -72765 / 262144,
+)
+
+#: Coefficients $a_k(1)$ of $x^{-k}$ in the large-argument expansion of
+#: $\sqrt{2x/\pi}\,K_1(x)e^{x}$, the same $a_k(1)$ as above without the
+#: alternating $(-1)^k$, from
+#: $K_\nu(z)\sim e^{-z}(\pi/2z)^{1/2}\sum_k a_k(\nu)z^{-k}$. Ten terms are
+#: carried rather than six because the logarithmic series it hands over to
+#: loses digits to cancellation, so the seam has to sit further out.
+_K1E_ASYMPTOTIC_COEFFS = (
+    1.0, 3 / 8, -15 / 128, 105 / 1024, -4725 / 32768,
+    72765 / 262144, -2837835 / 4194304, 66891825 / 33554432,
+    -14783093325 / 2147483648, 468131288625 / 17179869184,
+)
+
+#: $|x|$ below which $K_1(x)e^{x}$ is evaluated from its logarithmic series.
+#: At the seam on the $45^\circ$ ray the series is 3.5e-8 accurate and the
+#: ten-term expansion 1.3e-9; moving it either way makes one of the two
+#: worse.
+K1E_SERIES_CUTOFF = 12.0
+
+
+def _i1_series(x):
+    r"""Evaluate $I_1(x)$ from the ascending power series."""
+    return _i_series_terms(x)[2]
+
+
+def _k1_series(x):
+    r"""Evaluate $K_1(x)$ from its convergent logarithmic series."""
+    return _k_series(x, *_i_series_terms(x))[1]
+
+
+def i1e(x: jnp.ndarray) -> jnp.ndarray:
+    r"""
+    Exponentially scaled $I_1(x)e^{-x}$, for complex $x$.
+
+    **Mathematical Formulation**
+
+    Below $|x|=20$ the ascending series
+    $I_1(x)=\sum_{k\ge0}(x/2)^{2k+1}/(k!\,(k+1)!)$ is summed to 40 terms and
+    multiplied by $e^{-x}$; above it the large-argument expansion
+    $$I_1(x)e^{-x}\sim\frac{1}{\sqrt{2\pi x}}
+    \left(1-\frac{3}{8x}-\frac{15}{128x^2}-\frac{105}{1024x^3}
+    -\frac{4725}{32768x^4}-\frac{72765}{262144x^5}\right)$$
+    is used instead. Scaling is what keeps a thick-wall tube evaluable:
+    $I_1$ itself overflows well before the physics does.
+
+    **Validity**
+
+    Measured against :func:`scipy.special.ive` over $|x|\in[10^{-3},10^4]$
+    on the $45^\circ$ ray of a good conductor, worst relative error 1.2e-8
+    at the switch point. Like :func:`i0_over_i1`, the large-argument branch is
+    an asymptotic series about the positive real axis and degrades as
+    $\arg x\to90^\circ$.
+
+    Parameters
+    ----------
+    x : jnp.ndarray
+        Argument, real or complex.
+
+    Returns
+    -------
+    jnp.ndarray
+        $I_1(x)e^{-x}$.
+
+    References
+    ----------
+    Olver, F. W. J., et al. (eds.). NIST Digital Library of Mathematical
+    Functions, 10.25.2, 10.40.1.
+    """
+    x = jnp.asarray(x)
+    small = jnp.abs(x) < I0_OVER_I1_SERIES_CUTOFF
+    x_series = jnp.where(small, x, I0_OVER_I1_SERIES_CUTOFF)
+    x_asymptotic = jnp.where(small, I0_OVER_I1_SERIES_CUTOFF, x)
+    series = _i1_series(x_series) * jnp.exp(-x_series)
+    asymptotic = _poly_in_inverse(x_asymptotic, _I1E_ASYMPTOTIC_COEFFS) / jnp.sqrt(
+        2 * jnp.pi * x_asymptotic
+    )
+    return jnp.where(small, series, asymptotic)
+
+
+def k1e(x: jnp.ndarray) -> jnp.ndarray:
+    r"""
+    Exponentially scaled $K_1(x)e^{x}$, for complex $x$.
+
+    **Mathematical Formulation**
+
+    Below $|x|=12$, $K_1$ is evaluated from the logarithmic series used by
+    :func:`k0_over_k1` and multiplied by $e^{x}$; above it the ten-term
+    large-argument expansion
+    $$K_1(x)e^{x}\sim\sqrt{\frac{\pi}{2x}}
+    \left(1+\frac{3}{8x}-\frac{15}{128x^2}+\frac{105}{1024x^3}
+    -\frac{4725}{32768x^4}+\ldots\right)$$
+    is used instead.
+
+    **Validity**
+
+    Measured against :func:`scipy.special.kve` over $|x|\in[10^{-3},10^4]$
+    worst relative error 8e-8 on the $45^\circ$ ray of a good conductor, at
+    the switch point, rising to 2.5e-7 at $30^\circ$ where the logarithmic
+    series suffers more cancellation. Like every asymptotic branch in this module it degrades as
+    $\arg x\to90^\circ$. $x=0$ is a genuine pole and is the caller's to
+    handle.
+
+    Parameters
+    ----------
+    x : jnp.ndarray
+        Argument, real or complex.
+
+    Returns
+    -------
+    jnp.ndarray
+        $K_1(x)e^{x}$.
+
+    References
+    ----------
+    Olver, F. W. J., et al. (eds.). NIST Digital Library of Mathematical
+    Functions, 10.31.1, 10.40.2.
+    """
+    x = jnp.asarray(x)
+    small = jnp.abs(x) < K1E_SERIES_CUTOFF
+    x_series = jnp.where(small, x, K1E_SERIES_CUTOFF)
+    x_asymptotic = jnp.where(small, K1E_SERIES_CUTOFF, x)
+    series = _k1_series(x_series) * jnp.exp(x_series)
+    asymptotic = _poly_in_inverse(x_asymptotic, _K1E_ASYMPTOTIC_COEFFS) * jnp.sqrt(
+        jnp.pi / (2 * x_asymptotic)
+    )
+    return jnp.where(small, series, asymptotic)

--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -101,6 +101,12 @@ from pmrf.models.components.lines.formulations import (
     PlanarQuasiStaticResult as PlanarQuasiStaticResult,
 )
 
+from pmrf.models.components.lines.cross_section import (
+    AbstractPlanarCrossSection as AbstractPlanarCrossSection,
+    MicrostripCrossSection as MicrostripCrossSection,
+    StriplineCrossSection as StriplineCrossSection,
+)
+
 from pmrf.models.components.lines.current_distribution import (
     AbstractCurrentDistribution as AbstractCurrentDistribution,
     WheelerCurrentDistribution as WheelerCurrentDistribution,

--- a/pmrf/models/components/lines/__init__.py
+++ b/pmrf/models/components/lines/__init__.py
@@ -3,6 +3,12 @@ Transmission lines, include phase, physical, coaxial, microstrip, or arbitrarily
 """
 __sphinx_group__ = True
 
+from pmrf.models.components.lines.cross_section import (
+    AbstractPlanarCrossSection as AbstractPlanarCrossSection,
+    MicrostripCrossSection as MicrostripCrossSection,
+    StriplineCrossSection as StriplineCrossSection,
+)
+
 from pmrf.models.components.lines.current_distribution import (
     AbstractCurrentDistribution as AbstractCurrentDistribution,
     WheelerCurrentDistribution as WheelerCurrentDistribution,

--- a/pmrf/models/components/lines/cross_section.py
+++ b/pmrf/models/components/lines/cross_section.py
@@ -1,0 +1,94 @@
+"""Typed cross-section records for planar transmission lines.
+
+A cross-section record is the geometry a line hands to a current-distribution
+strategy: one frozen record per planar family, because no stable set of
+cross-section quantities exists *across* families -- coplanar waveguide brings
+a gap width, suspended substrate an air gap, offset stripline an offset --
+while each family's own set is stable.
+
+The record carries dimensions only. Quantities that are solved rather than
+given -- the characteristic impedance, the effective permittivity -- reach a
+strategy through the quasi-static result instead, so a strategy that consumes
+solved intermediates needs no new record field.
+"""
+import equinox as eqx
+import jax.numpy as jnp
+
+
+class AbstractPlanarCrossSection(eqx.Module):
+    """Frozen cross-section geometry of one planar line family.
+
+    Subclasses are per-family: pairing a strategy written for one family with
+    another family's record is a type error at the current-distribution
+    boundary rather than a missing-argument error deep in a call.
+    """
+
+    def dimensions(self) -> dict:
+        """Return the dimensions a conductor shape may be solved with.
+
+        Conductor shapes are shared across families and name their own
+        geometry, so the record translates itself into that vocabulary once,
+        here, rather than at each call site.
+        """
+        raise NotImplementedError
+
+
+class MicrostripCrossSection(AbstractPlanarCrossSection):
+    """Cross-section of a strip on a grounded dielectric sheet.
+
+    Parameters
+    ----------
+    w : ArrayLike
+        Width of the strip in meters.
+    h : ArrayLike
+        Substrate height in meters. Edge-shape and ground-plane-share loss
+        models need it even though the classical incremental-inductance rule
+        does not.
+    t : ArrayLike | None, default=None
+        Strip thickness in meters, or ``None`` when it is unspecified.
+    """
+
+    #: Width of the strip in meters
+    w: jnp.ndarray
+
+    #: Substrate height in meters
+    h: jnp.ndarray
+
+    #: Strip thickness in meters, or ``None`` when unspecified
+    t: jnp.ndarray | None = None
+
+    def dimensions(self) -> dict:
+        return {"w": self.w, "t": self.t}
+
+
+class StriplineCrossSection(AbstractPlanarCrossSection):
+    """Cross-section of a centre strip between two ground planes.
+
+    Parameters
+    ----------
+    w : ArrayLike
+        Width of the centre strip in meters.
+    b : ArrayLike
+        Separation of the ground planes in meters.
+    t : ArrayLike | None, default=None
+        Strip thickness in meters, or ``None`` when it is unspecified.
+    ep_r : jnp.ndarray | None, default=None
+        Complex relative permittivity of the homogeneous filling. It is a
+        material property rather than a dimension, but Cohn's attenuation
+        branches select on it, so the stripline record carries it.
+    """
+
+    #: Width of the centre strip in meters
+    w: jnp.ndarray
+
+    #: Separation of the ground planes in meters
+    b: jnp.ndarray
+
+    #: Strip thickness in meters, or ``None`` when unspecified
+    t: jnp.ndarray | None = None
+
+    #: Complex relative permittivity of the filling
+    ep_r: jnp.ndarray | None = None
+
+    def dimensions(self) -> dict:
+        return {"w": self.w, "t": self.t}

--- a/pmrf/models/components/lines/current_distribution.py
+++ b/pmrf/models/components/lines/current_distribution.py
@@ -6,7 +6,11 @@ import jax.numpy as jnp
 from scipy.constants import epsilon_0, mu_0
 
 from pmrf.frequency import Frequency
-from pmrf.materials.conductor_shape import HalfSpaceShape, RootSumSquareSlabShape
+from pmrf.materials.conductor_shape import (
+    AbstractConductorShape,
+    HalfSpaceShape,
+    RootSumSquareSlabShape,
+)
 
 
 class AbstractCurrentDistribution(eqx.Module):
@@ -16,7 +20,10 @@ class AbstractCurrentDistribution(eqx.Module):
     material's surface impedance and the weight, in inverse metres, charges
     that impedance into the line's series impedance.  Weights are evaluated
     at the requested frequency because current crowding may be frequency
-    dependent.
+    dependent.  A strategy chooses shapes and weights only: the
+    cross-section dimensions a shape needs reach it from the line at call
+    time, so no strategy ever hands a shape a number derived from its own
+    weight.
     """
 
     @abstractmethod
@@ -35,19 +42,33 @@ class WheelerCurrentDistribution(AbstractCurrentDistribution):
     The trace is represented by a half-space surface and the returned weight
     is Wheeler's geometry factor in inverse metres.
 
+    A trace of unspecified thickness is a half-space; a trace of stated
+    thickness is charged through :attr:`slab_shape`.
+
     References
     ----------
     Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
     IRE, 30(9), 412-424.
     """
 
-    def distribute(self, freq: Frequency, *, zc, w, t=None):
+    #: The finite-thickness cross-section entry used when a thickness is
+    #: stated.  The default,
+    #: :class:`~pmrf.materials.conductor_shape.RootSumSquareSlabShape`, is
+    #: the only entry that is right at both asymptotes under this
+    #: distribution's frequency-independent weight;
+    #: :class:`~pmrf.materials.conductor_shape.HollowayKuesterSlabShape` is
+    #: the exact strip-diffusion result but is normalised to the total strip
+    #: current and so wants a weight of $1/(2W)$ rather than Wheeler's.
+    #: Neither is the better entry in general -- see the normalisation note
+    #: on :class:`~pmrf.materials.conductor_shape.AbstractConductorShape`.
+    slab_shape: AbstractConductorShape = eqx.field(
+        default_factory=RootSumSquareSlabShape
+    )
+
+    def distribute(self, freq: Frequency, *, zc, w, t=None, **geometry):
         z0 = jnp.sqrt(mu_0 / epsilon_0)
         weight = 2 / w * jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
-        shape = (
-            HalfSpaceShape() if t is None else
-            RootSumSquareSlabShape(dc_shape_factor=1 / (w * t * weight))
-        )
+        shape = HalfSpaceShape() if t is None else self.slab_shape
         return ((shape, weight),)
 
 
@@ -66,7 +87,7 @@ class CohnCurrentDistribution(AbstractCurrentDistribution):
     on Microwave Theory and Techniques, 3(2), 119-126.
     """
 
-    def distribute(self, freq: Frequency, *, zc, w, b, t, ep_r):
+    def distribute(self, freq: Frequency, *, zc, w, b, t, ep_r, **geometry):
         if t is None:
             weight = jnp.asarray(0.0)
         else:

--- a/pmrf/models/components/lines/current_distribution.py
+++ b/pmrf/models/components/lines/current_distribution.py
@@ -98,6 +98,13 @@ class AbstractCurrentDistribution(eqx.Module, Generic[CrossSectionT]):
 class WheelerCurrentDistribution(AbstractCurrentDistribution[MicrostripCrossSection]):
     r"""Wheeler's incremental-inductance current distribution.
 
+    This is Wheeler's 1942 skin-effect rule, and it is the default
+    ``current_distribution`` of every microstrip. It is a different paper
+    from :class:`~pmrf.models.components.lines.formulations.WheelerMicrostripFormulation`
+    (Wheeler 1977), which is the quasi-static impedance approximation and is
+    *not* the default formulation -- Hammerstad--Jensen is. The two share only
+    an author.
+
     **Mathematical Formulation**
 
     $$k_c = \frac{2}{W}\exp\left[-1.2\left(\frac{\Re(Z_c)}{Z_0}\right)^{0.7}\right]$$

--- a/pmrf/models/components/lines/current_distribution.py
+++ b/pmrf/models/components/lines/current_distribution.py
@@ -1,5 +1,6 @@
 """Current-distribution strategies for conductor loss in planar lines."""
 from abc import abstractmethod
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -11,9 +12,19 @@ from pmrf.materials.conductor_shape import (
     HalfSpaceShape,
     RootSumSquareSlabShape,
 )
+from pmrf.models.components.lines.cross_section import (
+    AbstractPlanarCrossSection,
+    MicrostripCrossSection,
+    StriplineCrossSection,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle broken at runtime
+    from pmrf.models.components.lines.formulations import PlanarQuasiStaticResult
+
+CrossSectionT = TypeVar("CrossSectionT", bound=AbstractPlanarCrossSection)
 
 
-class AbstractCurrentDistribution(eqx.Module):
+class AbstractCurrentDistribution(eqx.Module, Generic[CrossSectionT]):
     r"""Surface-current distribution for a transmission-line cross-section.
 
     A strategy returns ``(shape, weight)`` pairs.  The shape supplies the
@@ -21,23 +32,82 @@ class AbstractCurrentDistribution(eqx.Module):
     that impedance into the line's series impedance.  Weights are evaluated
     at the requested frequency because current crowding may be frequency
     dependent.  A strategy chooses shapes and weights only: the
-    cross-section dimensions a shape needs reach it from the line at call
+    cross-section dimensions a shape needs reach it from the record at call
     time, so no strategy ever hands a shape a number derived from its own
     weight.
+
+    A strategy is written for one planar family and declares it in
+    :attr:`cross_section_type`.  It receives that family's frozen
+    cross-section record together with the solved quasi-static state, so a
+    model that consumes solved intermediates rather than dimensions needs no
+    new record field.  :meth:`distribute` checks the record against the
+    declared type, which is where a wrong-family pairing fails.
     """
 
+    #: The cross-section record family this strategy is written for.
+    cross_section_type: ClassVar[type] = AbstractPlanarCrossSection
+
+    def distribute(
+        self,
+        freq: Frequency,
+        cross_section: CrossSectionT,
+        quasi_static: "PlanarQuasiStaticResult",
+    ):
+        r"""Return the conductor-shape and geometry-weight pairs.
+
+        Parameters
+        ----------
+        freq : Frequency
+            The frequency axis.
+        cross_section : AbstractPlanarCrossSection
+            The line's frozen cross-section record. It must be an instance of
+            this strategy's :attr:`cross_section_type`.
+        quasi_static : PlanarQuasiStaticResult
+            The solved quasi-static state of the line, as the conversion to
+            immittance has it.
+
+        Returns
+        -------
+        tuple
+            ``(shape, weight)`` pairs.
+
+        Raises
+        ------
+        TypeError
+            If the cross-section record belongs to another line family.
+        """
+        if not isinstance(cross_section, self.cross_section_type):
+            raise TypeError(
+                f"{type(self).__name__} is a "
+                f"{self.cross_section_type.__name__} strategy, but it was "
+                f"given a {type(cross_section).__name__}"
+            )
+        return self._distribute(freq, cross_section, quasi_static)
+
     @abstractmethod
-    def distribute(self, freq: Frequency, *, zc, **geometry):
-        r"""Return the conductor-shape and geometry-weight pairs."""
+    def _distribute(
+        self,
+        freq: Frequency,
+        cross_section: CrossSectionT,
+        quasi_static: "PlanarQuasiStaticResult",
+    ):
+        r"""Return the pairs for an already type-checked cross-section."""
         raise NotImplementedError
 
 
-class WheelerCurrentDistribution(AbstractCurrentDistribution):
+class WheelerCurrentDistribution(AbstractCurrentDistribution[MicrostripCrossSection]):
     r"""Wheeler's incremental-inductance current distribution.
 
     **Mathematical Formulation**
 
     $$k_c = \frac{2}{W}\exp\left[-1.2\left(\frac{\Re(Z_c)}{Z_0}\right)^{0.7}\right]$$
+
+    The weight charges the sheet impedance over the physical trace width $W$,
+    not a dispersion-widened one: the rule sums over every receded conductor
+    surface, and those terms do not vanish as $t\to0$.  $Z_c$ is the
+    characteristic impedance of the solved state it is given, so on a
+    dispersive line it is the dispersed one; only its real part enters, since
+    the exponent is a lossless current-crowding correction.
 
     The trace is represented by a half-space surface and the returned weight
     is Wheeler's geometry factor in inverse metres.
@@ -50,6 +120,8 @@ class WheelerCurrentDistribution(AbstractCurrentDistribution):
     Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
     IRE, 30(9), 412-424.
     """
+
+    cross_section_type: ClassVar[type] = MicrostripCrossSection
 
     #: The finite-thickness cross-section entry used when a thickness is
     #: stated.  The default,
@@ -65,21 +137,24 @@ class WheelerCurrentDistribution(AbstractCurrentDistribution):
         default_factory=RootSumSquareSlabShape
     )
 
-    def distribute(self, freq: Frequency, *, zc, w, t=None, **geometry):
+    def _distribute(self, freq, cross_section, quasi_static):
         z0 = jnp.sqrt(mu_0 / epsilon_0)
-        weight = 2 / w * jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
-        shape = HalfSpaceShape() if t is None else self.slab_shape
+        zc = quasi_static.zc
+        weight = 2 / cross_section.w * jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
+        shape = HalfSpaceShape() if cross_section.t is None else self.slab_shape
         return ((shape, weight),)
 
 
-class CohnCurrentDistribution(AbstractCurrentDistribution):
+class CohnCurrentDistribution(AbstractCurrentDistribution[StriplineCrossSection]):
     r"""Cohn's stripline current distribution.
 
     **Mathematical Formulation**
 
-    The returned weight is $k_c=2\alpha_c/R_s$, using Cohn's two attenuation
-    branches and the stripline geometry.  A zero-thickness strip has no finite
-    conductor-loss weight in this model.
+    The returned weight is $k_c=2(\alpha_c/R_s)Z_c$: Cohn gives the
+    attenuation per unit length, and the immittance the weight is charged
+    into is a series impedance, so the low-loss inversion of
+    $\alpha_c=\Re(Z_s k_c)/(2\Re(Z_c))$ puts the $Z_c$ back.  A zero-thickness
+    strip has no finite conductor-loss weight in this model.
 
     References
     ----------
@@ -87,12 +162,15 @@ class CohnCurrentDistribution(AbstractCurrentDistribution):
     on Microwave Theory and Techniques, 3(2), 119-126.
     """
 
-    def distribute(self, freq: Frequency, *, zc, w, b, t, ep_r, **geometry):
+    cross_section_type: ClassVar[type] = StriplineCrossSection
+
+    def _distribute(self, freq, cross_section, quasi_static):
+        w, b, t = cross_section.w, cross_section.b, cross_section.t
         if t is None:
             weight = jnp.asarray(0.0)
         else:
-            ep_r = jnp.real(ep_r)
-            zc_real = jnp.real(zc)
+            ep_r = jnp.real(cross_section.ep_r)
+            zc_real = jnp.real(quasi_static.zc)
             a = 1 + 2 * w / (b - t) + (b + t) / (jnp.pi * (b - t)) * jnp.log((2 * b - t) / t)
             alpha_low = 2.7e-3 * ep_r * zc_real / (30 * jnp.pi * (b - t)) * a
             beta = 1 + b / (0.5 * w + 0.7 * t) * (

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -365,7 +365,11 @@ class AbstractMicrostripFormulation(eqx.Module):
         h : ArrayLike
             Height of the dielectric substrate in meters.
         t : ArrayLike | None
-            Thickness of the trace in meters, or None for a zero-thickness trace.
+            Thickness of the trace in meters, or ``None`` when it is
+            unspecified. A formulation derived for a zero-thickness strip
+            accepts it and ignores it rather than rejecting it; thickness
+            reaches conductor loss through the line's cross-section either
+            way.
         ep_r : jnp.ndarray
             Complex relative permittivity of the substrate, shape ``(npoints,)``.
 
@@ -380,6 +384,13 @@ class AbstractMicrostripFormulation(eqx.Module):
 class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
     r"""
     Microstrip line formulation using the standard Wheeler approximations.
+
+    This is Wheeler's 1977 quasi-static impedance approximation. It is not
+    the ParamRF default -- :class:`HammerstadJensenMicrostripFormulation` is.
+    It is a different paper from
+    :class:`~pmrf.models.components.lines.current_distribution.WheelerCurrentDistribution`
+    (Wheeler 1942), the skin-effect conductor-loss rule, which *is* the default
+    current distribution and is unaffected by the choice of formulation.
 
     **Mathematical Formulation**
 
@@ -401,8 +412,13 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
 
     **Validity**
 
-    Derived for a zero-thickness strip on an isotropic, non-magnetic substrate,
-    which is why finite thickness is rejected rather than ignored. It is a
+    Derived for a zero-thickness strip on an isotropic, non-magnetic substrate.
+    A finite thickness is accepted and ignored: it does not enter this
+    formulation's $\varepsilon_e$ or $Z_c$, and the line applies it to
+    conductor loss instead, through the cross-section it hands its
+    current distribution. Use
+    :class:`HammerstadJensenMicrostripFormulation` -- the ParamRF default --
+    when the thickness should also widen the strip electrically. It is a
     quasi-static result and carries no modal dispersion, so it describes the
     line only well below the frequency at which $\varepsilon_e$ begins to rise
     towards $\varepsilon_r$; pair it with an
@@ -416,9 +432,10 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
     IEEE Transactions on Microwave Theory and Techniques.
     """
     def quasi_static(self, *, w, h, t, ep_r) -> PlanarQuasiStaticResult:
-        if t is not None:
-            raise ValueError("Wheeler microstrip approximation does not support finite thickness")
-
+        # t is accepted and ignored: the 1977 result is derived for a
+        # zero-thickness strip, so thickness enters neither ep_eff nor zc. It
+        # still reaches the current distribution through the line's
+        # cross-section, where it refines conductor loss.
         W, H = w, h
         u = W / H
 

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -1,7 +1,9 @@
 """
 Closed-form physics for transmission lines (coaxial, microstrip, stripline).
 
-Three distinct strategy roles appear on a line model, each with its own field:
+Five distinct strategy roles appear across the line models, each with its own
+field. The vocabulary is defined once in ``CONTEXT.md`` at the repo root; the
+architectural decisions behind it are in ``docs/adr/``.
 
 - A **Formulation** (`formulation`) produces the complete electrical state a
   model needs to reach S-parameters: either a per-unit-length immittance
@@ -12,6 +14,16 @@ Three distinct strategy roles appear on a line model, each with its own field:
   exists where the cross-section is inhomogeneous and the mode is therefore not
   strictly TEM -- microstrip has one, homogeneously filled coaxial and stripline
   do not.
+- A **ConductorShape**
+  (:mod:`pmrf.materials.conductor_shape`) gives the surface impedance per
+  square of one conductor cross-section: pure numerics over an evaluated
+  material and a set of named dimensions, with the inverse-metre geometry
+  weight left to the caller.
+- A **CurrentDistribution** (`current_distribution`, in
+  :mod:`pmrf.models.components.lines.current_distribution`) says how a line's
+  surface current divides across its conductors, pairing shapes with those
+  geometry weights. Planar lines carry one; a coaxial line does not, because
+  its weights are exact constants rather than a fitted rule.
 - A **Roughness** (`roughness`, in :mod:`pmrf.materials.conductor`) modifies
   conductor behaviour rather than line state: it scales a surface impedance,
   and so belongs to the conductor material, not to the geometry.

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -35,6 +35,7 @@ from pmrf.materials.conductor_shape import (
     TescheRodShape,
     TescheTubeShape,
 )
+from pmrf.models.components.lines.cross_section import AbstractPlanarCrossSection
 from pmrf.models.components.lines.current_distribution import (
     AbstractCurrentDistribution,
     CohnCurrentDistribution,
@@ -63,9 +64,6 @@ class PlanarQuasiStaticResult(eqx.Module):
         Quasi-static characteristic impedance in ohms, $Z_a/\sqrt{\varepsilon_e}$.
     w_eff : jnp.ndarray
         Electromagnetic effective conductor width in meters.
-    conductor_loss_factor : jnp.ndarray | None
-        Legacy scalar geometry factor retained for direct callers. Line models
-        use a current-distribution strategy instead.
     shunt_conductance_factor : jnp.ndarray
         Geometry factor multiplying static conductivity, in meters.
     """
@@ -81,14 +79,11 @@ class PlanarQuasiStaticResult(eqx.Module):
     #: Geometry factor multiplying static conductivity
     shunt_conductance_factor: jnp.ndarray
 
-    #: Legacy geometry factor for callers predating current distributions
-    conductor_loss_factor: jnp.ndarray | None = None
-
     def to_immittance(
         self, freq: Frequency, dielectric: DielectricProperties,
         conductor: ConductorProperties,
-        current_distribution: AbstractCurrentDistribution | None = None,
-        **geometry,
+        current_distribution: AbstractCurrentDistribution,
+        cross_section: AbstractPlanarCrossSection,
     ) -> ImmittanceResult:
         r"""
         Converts the quasi-static solution into a per-unit-length immittance.
@@ -111,8 +106,15 @@ class PlanarQuasiStaticResult(eqx.Module):
         ----------
         freq : Frequency
             The frequency axis.
-        zs : jnp.ndarray
-            Complex surface impedance of the conductor in ohm per square.
+        dielectric : DielectricProperties
+            Evaluated relative permittivity and permeability.
+        conductor : ConductorProperties
+            Evaluated conductor properties.
+        current_distribution : AbstractCurrentDistribution
+            The strategy that charges surface impedance into $Z$. It must be
+            written for the family ``cross_section`` belongs to.
+        cross_section : AbstractPlanarCrossSection
+            The line's frozen cross-section record.
 
         Returns
         -------
@@ -128,22 +130,18 @@ class PlanarQuasiStaticResult(eqx.Module):
         sqrt_ep_eff_over_mu = jnp.sqrt(self.ep_eff / dielectric.mu_r)
 
         Z = 1j * omega * self.zc * sqrt_ep_eff_mu / c
-        if current_distribution is None:
-            if self.conductor_loss_factor is None:
-                raise ValueError("current_distribution is required")
-            Z_cond = conductor.zs * self.conductor_loss_factor
-        else:
-            # Cross-section dimensions reach the shape from the line's own
-            # geometry, and the weight the shape is about to be multiplied
-            # by travels with them: an entry whose dc floor is fixed in
-            # per-unit-length terms needs it to express that floor in this
-            # caller's normalisation. Every other entry ignores it.
-            Z_cond = sum(
-                shape.impedance(omega, conductor, weight=weight, **geometry) * weight
-                for shape, weight in current_distribution.distribute(
-                    freq, zc=self.zc, **geometry
-                )
+        # Cross-section dimensions reach the shape from the typed record, and
+        # the weight the shape is about to be multiplied by travels with
+        # them: an entry whose dc floor is fixed in per-unit-length terms
+        # needs it to express that floor in this caller's normalisation.
+        # Every other entry ignores it.
+        dimensions = cross_section.dimensions()
+        Z_cond = sum(
+            shape.impedance(omega, conductor, weight=weight, **dimensions) * weight
+            for shape, weight in current_distribution.distribute(
+                freq, cross_section, self
             )
+        )
         Z = Z + Z_cond
         Y = 1j * omega * sqrt_ep_eff_over_mu / (self.zc * c)
         Y = Y + dielectric.sigma * self.shunt_conductance_factor
@@ -362,8 +360,6 @@ class AbstractMicrostripFormulation(eqx.Module):
 
         Parameters
         ----------
-        freq : Frequency
-            The frequency axis.
         w : ArrayLike
             Width of the microstrip trace in meters.
         h : ArrayLike
@@ -372,9 +368,6 @@ class AbstractMicrostripFormulation(eqx.Module):
             Thickness of the trace in meters, or None for a zero-thickness trace.
         ep_r : jnp.ndarray
             Complex relative permittivity of the substrate, shape ``(npoints,)``.
-        zs : jnp.ndarray
-            Complex surface impedance of the conductor in ohm per square,
-            shape ``(npoints,)``.
 
         Returns
         -------
@@ -401,11 +394,10 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
     $\varepsilon_r$ is complex, and $\varepsilon_e$ is linear in it, so the
     dielectric loss carries through the same filling factor as the real part and
     needs no separate loss-tangent term. The effective width is $W$: the
-    approximation is derived for a zero-thickness strip, so `zs` does not enter
-    here. Conductor loss is charged separately, through
-    `conductor_loss_factor`, by Wheeler's own incremental-inductance rule
-    (see :func:`_wheeler_conductor_loss_factor`), applied over the physical
-    width $W$ rather than a thickness-widened one.
+    approximation is derived for a zero-thickness strip, so conductor properties
+    do not enter here. Conductor loss is not produced by this formulation at
+    all: the line charges it through its
+    :class:`~pmrf.models.components.lines.current_distribution.AbstractCurrentDistribution`.
 
     **Validity**
 
@@ -448,10 +440,7 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
         zc = Za / jnp.sqrt(ep_eff)
         w_eff = W * jnp.ones_like(ep_r)
         conductance_factor = _microstrip_conductance_factor(ep_r, ep_eff, zc)
-        return PlanarQuasiStaticResult(
-            ep_eff, zc, w_eff, conductance_factor,
-            _wheeler_conductor_loss_factor(W, zc),
-        )
+        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, conductance_factor)
 
 
 class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
@@ -486,11 +475,9 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
     \qquad W_{eff}=u_rH,$$
     where $e$ denotes the bracketed permittivity expression before its
     thickness correction. $W_{eff}$ is the electromagnetic fringing width and
-    feeds the dispersion formulation; conductor loss is charged separately,
-    through `conductor_loss_factor`, by Wheeler's incremental-inductance rule
-    (see :func:`_wheeler_conductor_loss_factor`) over the physical width $W$,
-    which is the correct one for that rule regardless of which formulation
-    supplied the quasi-static solution.
+    feeds the dispersion formulation; conductor loss is not produced here at all,
+    but charged separately by the line's
+    :class:`~pmrf.models.components.lines.current_distribution.AbstractCurrentDistribution`.
 
     The fractional power in $b$ is evaluated through the principal logarithm.
     The dielectric constraint $\Re(\varepsilon_r)>1$ keeps its argument away
@@ -546,10 +533,7 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
         ep_eff = e * (z1 / zr) ** 2
         w_eff = ur * h
         conductance_factor = _microstrip_conductance_factor(ep_r, ep_eff, zc)
-        return PlanarQuasiStaticResult(
-            ep_eff, zc, w_eff, conductance_factor,
-            _wheeler_conductor_loss_factor(w, zc),
-        )
+        return PlanarQuasiStaticResult(ep_eff, zc, w_eff, conductance_factor)
 
     @staticmethod
     def _homogeneous_impedance(u):
@@ -749,8 +733,6 @@ class AbstractStriplineFormulation(eqx.Module):
 
         Parameters
         ----------
-        freq : Frequency
-            The frequency axis.
         w : ArrayLike
             Width of the centre strip in meters.
         b : ArrayLike
@@ -759,9 +741,6 @@ class AbstractStriplineFormulation(eqx.Module):
             Thickness of the strip in meters, or None for a zero-thickness strip.
         ep_r : jnp.ndarray
             Complex relative permittivity of the filling, shape ``(npoints,)``.
-        zs : jnp.ndarray
-            Complex surface impedance of the conductor in ohm per square,
-            shape ``(npoints,)``.
 
         Returns
         -------
@@ -786,29 +765,12 @@ class CohnStriplineFormulation(AbstractStriplineFormulation):
     the characteristic impedance of the zero-thickness strip is
     $$Z_c = \frac{30\pi}{\sqrt{\varepsilon_r}}\frac{b}{W_e + 0.441b}.$$
 
-    Conductor loss follows Cohn's incremental-inductance result, which unlike
-    the impedance does depend on the strip thickness $T$:
-    $$\frac{\alpha_c}{R_s} = \begin{cases}
-    \dfrac{2.7\times10^{-3}\,\varepsilon_r Z_c}{30\pi(b-T)}A,
-        & \sqrt{\varepsilon_r}Z_c < 120,\\[2ex]
-    \dfrac{0.16}{Z_c b}B, & \sqrt{\varepsilon_r}Z_c \geq 120,
-    \end{cases}$$
-    $$A = 1 + \frac{2W}{b-T}
-    + \frac{1}{\pi}\frac{b+T}{b-T}\ln\frac{2b-T}{T}$$
-    $$B = 1 + \frac{b}{0.5W + 0.7T}
-    \left(0.5 + \frac{0.7T}{W} + \frac{1}{2\pi}\ln\frac{4\pi W}{T}\right).$$
-
-    That attenuation is returned directly as the conductor-loss factor, not
-    disguised as a width. A per-unit-length series resistance is
-    $R = 2\alpha_c Z_c$, so the factor multiplying the surface impedance is
-    $$K_c = 2\frac{\alpha_c}{R_s}Z_c,$$
-    which is independent of $R_s$. The returned $W_e$ stays the genuine
+    Conductor loss is not produced here: this formulation returns no loss
+    factor, and Cohn's attenuation lives in
+    :class:`~pmrf.models.components.lines.current_distribution.CohnCurrentDistribution`,
+    which the line pairs with it by default. The returned $W_e$ is the genuine
     electromagnetic fringing width and is not reused for loss. Dielectric loss
     needs no separate term: $\varepsilon_e$ is complex, and carries it.
-
-    The formulas are the standard piecewise fits, discontinuous by a fraction of
-    a percent at $\sqrt{\varepsilon_r}Z_c = 120$; the branch is selected on the
-    real parts.
 
     **Validity**
 
@@ -816,11 +778,8 @@ class CohnStriplineFormulation(AbstractStriplineFormulation):
     there is no fit range on the permittivity and no modal dispersion below the
     first higher-order mode. The impedance expression is Cohn's zero-thickness
     result with a fringing correction whose two branches meet at $W/b = 0.35$;
-    the attenuation fit is piecewise in $\sqrt{\varepsilon_r} Z_c$ and is
-    discontinuous there by a fraction of a percent. Finite thickness must
-    satisfy $0 < T < b$, which is enforced, and the attenuation diverges
-    logarithmically as $T \to 0$, so a zero-thickness strip is given no
-    conductor loss rather than an infinite one.
+    finite thickness must satisfy $0 < T < b$, which is enforced. The impedance
+    itself does not depend on $T$.
 
     References
     ----------
@@ -844,36 +803,6 @@ class CohnStriplineFormulation(AbstractStriplineFormulation):
         return PlanarQuasiStaticResult(
             ep_eff, zc, w_e * ones, shunt_conductance_factor,
         )
-
-def _wheeler_conductor_loss_factor(w, zc):
-    r"""Wheeler's incremental-inductance rule, as a `conductor_loss_factor`.
-
-    $$k_c = \frac{2}{W}\exp\left[-1.2\left(\frac{\Re(Z_c)}{Z_0}\right)^{0.7}\right]$$
-
-    charges the sheet impedance over the physical trace width $W$, not the
-    dispersion-widened $W_{eff}$: the rule sums over every receded conductor
-    surface, and those terms do not vanish as $t\to0$, so the effective width
-    used to widen the current-carrying geometry is not the right one here.
-    $Z_c$ is the (possibly dispersed) characteristic impedance at the point in
-    the line's pipeline where the factor is evaluated; only its real part
-    enters, since the exponent is a lossless current-crowding correction.
-
-    This is the low-loss linearisation shared by both callers: charged
-    directly onto $\gamma$ it reproduces the rule's own $\alpha_c$, and
-    charged onto $Z$ through :meth:`PlanarQuasiStaticResult.to_immittance` it
-    reduces to the same $\alpha_c$ once $Z=\gamma Z_c$ is inverted, using
-    $\Re(\gamma) \approx \Re(Z_s k_c)/(2\Re(Z_c))$ for a small series
-    perturbation on an otherwise lossless line.
-
-    References
-    ----------
-    Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
-    IRE, 30(9), 412-424.
-    """
-    z0 = jnp.sqrt(mu_0 / epsilon_0)
-    current_distribution = jnp.exp(-1.2 * (jnp.real(zc) / z0) ** 0.7)
-    return 2 / w * current_distribution
-
 
 def _microstrip_conductance_factor(ep_r, ep_eff, zc):
     """Convert static substrate conductivity through the quasi-static fill."""

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -123,27 +123,32 @@ class PlanarQuasiStaticResult(eqx.Module):
         ----------
         Pozar, D. M. (2011). Microwave Engineering (4th ed.), Section 3.8. Wiley.
         """
-        w = freq.w
+        omega = freq.w
         sqrt_ep_eff_mu = jnp.sqrt(self.ep_eff * dielectric.mu_r)
         sqrt_ep_eff_over_mu = jnp.sqrt(self.ep_eff / dielectric.mu_r)
 
-        Z = 1j * w * self.zc * sqrt_ep_eff_mu / c
+        Z = 1j * omega * self.zc * sqrt_ep_eff_mu / c
         if current_distribution is None:
             if self.conductor_loss_factor is None:
                 raise ValueError("current_distribution is required")
             Z_cond = conductor.zs * self.conductor_loss_factor
         else:
+            # Cross-section dimensions reach the shape from the line's own
+            # geometry, and the weight the shape is about to be multiplied
+            # by travels with them: an entry whose dc floor is fixed in
+            # per-unit-length terms needs it to express that floor in this
+            # caller's normalisation. Every other entry ignores it.
             Z_cond = sum(
-                shape.impedance(w, conductor) * weight
+                shape.impedance(omega, conductor, weight=weight, **geometry) * weight
                 for shape, weight in current_distribution.distribute(
                     freq, zc=self.zc, **geometry
                 )
             )
         Z = Z + Z_cond
-        Y = 1j * w * sqrt_ep_eff_over_mu / (self.zc * c)
+        Y = 1j * omega * sqrt_ep_eff_over_mu / (self.zc * c)
         Y = Y + dielectric.sigma * self.shunt_conductance_factor
 
-        return ImmittanceResult(Z=Z, Y=Y, w=w)
+        return ImmittanceResult(Z=Z, Y=Y, w=omega)
 
 
 class AbstractCoaxialFormulation(eqx.Module):

--- a/pmrf/models/components/lines/formulations.py
+++ b/pmrf/models/components/lines/formulations.py
@@ -30,11 +30,8 @@ from pmrf.frequency import Frequency
 from pmrf.materials import ConductorProperties, DielectricProperties
 from pmrf.materials.conductor_shape import (
     AbstractConductorShape,
-    HalfSpaceShape,
     SchelkunoffRodShape,
     SchelkunoffTubeShape,
-    SchelkunoffCothTubeShape,
-    SchelkunoffInfiniteTubeShape,
     TescheRodShape,
     TescheTubeShape,
 )
@@ -188,12 +185,11 @@ class AbstractCoaxialFormulation(eqx.Module):
 
 
 def _coaxial_immittance(freq: Frequency, *, d_in, d_out, dielectric: DielectricProperties, conductor: ConductorProperties, outer_conductor: ConductorProperties | None, shield_thickness, inner_shape: AbstractConductorShape, shield_shape: AbstractConductorShape) -> ImmittanceResult:
-    """Assemble a coaxial line's immittance around a choice of inner-conductor shape.
+    """Assemble a coaxial line's immittance around a choice of cross-section shapes.
 
-    Everything but the inner rod is common to every coaxial formulation here:
-    the external inductance and the shunt admittance are pure geometry, and
-    the shield's contribution is selected from the cylindrical tube shapes. The formulations
-    differ only in how the solid centre conductor's cross-section is solved.
+    The external inductance and the shunt admittance are pure geometry and are
+    common to every coaxial formulation here; the two conductors differ only
+    in which cross-section shape solves them, which the formulation supplies.
     """
     eps = epsilon_0 * dielectric.ep_r
     mu = mu_0 * dielectric.mu_r
@@ -205,21 +201,13 @@ def _coaxial_immittance(freq: Frequency, *, d_in, d_out, dielectric: DielectricP
 
     L_ext = jnp.ones(freq.npoints) * mu / (2 * jnp.pi) * ln_b_over_a
 
-    rod_zs = inner_shape.impedance(w, conductor, a=a)
-    Z_int = rod_zs / (2 * jnp.pi * a)
-    # An unspecified wall is the infinite-wall cylindrical limit. A finite wall
-    # uses Schelkunoff's tube solution; its cheaper coth-plus-curvature sibling
-    # remains available as a public cross-section entry for large sweeps.
+    Z_int = inner_shape.impedance(w, conductor, a=a) / (2 * jnp.pi * a)
+    # An unmodelled wall is an infinitely thick one, which every tube shape
+    # takes analytically -- so the shield is one call whatever shape it is,
+    # with no branch on the shape's type or on whether a wall was given.
     shield_conductor = conductor if outer_conductor is None else outer_conductor
-    if shield_thickness is None:
-        if isinstance(shield_shape, HalfSpaceShape):
-            shield_zs = shield_shape.impedance(w, shield_conductor)
-        else:
-            shield_zs = shield_shape.impedance(w, shield_conductor, a=b)
-    else:
-        shield_zs = shield_shape.impedance(
-            w, shield_conductor, a=b, t=shield_thickness
-        )
+    wall = jnp.inf if shield_thickness is None else shield_thickness
+    shield_zs = shield_shape.impedance(w, shield_conductor, a=b, t=wall)
     Z_int = Z_int + shield_zs / (2 * jnp.pi * b)
 
     Z = 1j * w * L_ext + Z_int
@@ -246,12 +234,14 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     $G = -2\pi\omega\Im(\varepsilon)/\ln(b/a)$. Each conductor's series
     impedance is a shape's surface impedance charged over its circumference,
     $Z = Z_s/2\pi r$: the inner conductor is a
-    :class:`~pmrf.materials.conductor_shape.TescheRodShape`, and the outer
-    shield -- treated as infinitely thick because only its inner diameter is
-    part of :class:`CoaxialLine` -- is the
-    :class:`~pmrf.materials.conductor_shape.HalfSpaceShape` limit that Tesche's
-    tube circuit approaches as its wall thickens; the finite-wall form is
-    :class:`~pmrf.materials.conductor_shape.TescheTubeShape`.
+    :class:`~pmrf.materials.conductor_shape.TescheRodShape` by default and
+    the shield a :class:`~pmrf.materials.conductor_shape.TescheTubeShape`.
+    An unspecified ``shield_thickness`` is an infinite wall, which the tube
+    circuit takes analytically: its dc resistance vanishes and its internal
+    inductance diverges, leaving the
+    :class:`~pmrf.materials.conductor_shape.HalfSpaceShape` impedance
+    $\zeta_c$. Both shapes are fields, so either conductor's cross-section
+    can be swapped without subclassing.
 
     A magnetic filling needs no special case. With complex $\mu_r$ the external
     term $j\omega L'$ acquires the real part $\omega\mu''\ln(b/a)/2\pi$, so
@@ -282,12 +272,18 @@ class TescheCoaxialFormulation(AbstractCoaxialFormulation):
     Schelkunoff, S. A. (1934). The Electromagnetic Theory of Coaxial Transmission Lines
     and Cylindrical Shields. Bell System Technical Journal, 13(4), 532-579.
     """
+    #: Cross-section shape of the inner conductor
+    inner_shape: AbstractConductorShape = TescheRodShape()
+    #: Cross-section shape of the shield, called with the shield's inner
+    #: radius and its wall thickness, infinite when none is given
+    shield_shape: AbstractConductorShape = TescheTubeShape()
+
     def immittance(self, freq: Frequency, *, d_in, d_out, dielectric: DielectricProperties, conductor: ConductorProperties, outer_conductor=None, shield_thickness=None) -> ImmittanceResult:
         return _coaxial_immittance(
             freq, d_in=d_in, d_out=d_out, dielectric=dielectric,
             conductor=conductor, outer_conductor=outer_conductor,
-            shield_thickness=shield_thickness, inner_shape=TescheRodShape(),
-            shield_shape=(HalfSpaceShape() if shield_thickness is None else TescheTubeShape()),
+            shield_thickness=shield_thickness, inner_shape=self.inner_shape,
+            shield_shape=self.shield_shape,
         )
 
 
@@ -309,31 +305,40 @@ class SchelkunoffCoaxialFormulation(AbstractCoaxialFormulation):
     \frac{I_0(\gamma a)}{I_1(\gamma a)},\qquad
     \gamma = \sqrt{j\omega\mu\sigma}.$$
 
-    An unspecified shield thickness uses the matching infinite-wall tube
-    solution, $Z_{outer}=\zeta_c K_0(\gamma b)/(2\pi bK_1(\gamma b))$;
-    a specified thickness uses Schelkunoff's finite-tube equation.
+    The shield is a :class:`~pmrf.materials.conductor_shape.SchelkunoffTubeShape`,
+    Schelkunoff's eq. (74) referred to the tube's inner surface. An
+    unspecified ``shield_thickness`` is an infinite wall, which that
+    expression takes analytically, leaving
+    $Z_{outer}=\zeta_c K_0(\gamma b)/(2\pi bK_1(\gamma b))$. Both shapes
+    are fields, so either conductor's cross-section can be swapped without
+    subclassing.
 
     **Validity**
 
-    Exact for the inner conductor at every frequency, dc included, so unlike
+    Exact for both conductors at every frequency, dc included, so unlike
     Tesche it leaves no frequency-shaped residual for a conductivity fit to
-    absorb. The shield remains infinitely thick, since only its inner
-    diameter is part of :class:`CoaxialLine`. The transmission-line
-    description is still the outer limit: it assumes the TEM mode, so it
-    holds below the TE11 cutoff
+    absorb. The transmission-line description is still the outer limit: it
+    assumes the TEM mode, so it holds below the TE11 cutoff
     $f_c \approx c / \left[\pi (a + b) \sqrt{\varepsilon_r \mu_r}\right]$.
 
     References
     ----------
     Schelkunoff, S. A. (1934). The Electromagnetic Theory of Coaxial Transmission Lines
-    and Cylindrical Shields. Bell System Technical Journal, 13(4), 532-579. Eq. (65).
+    and Cylindrical Shields. Bell System Technical Journal, 13(4), 532-579.
+    Eq. (65), (74).
     """
+    #: Cross-section shape of the inner conductor
+    inner_shape: AbstractConductorShape = SchelkunoffRodShape()
+    #: Cross-section shape of the shield, called with the shield's inner
+    #: radius and its wall thickness, infinite when none is given
+    shield_shape: AbstractConductorShape = SchelkunoffTubeShape()
+
     def immittance(self, freq: Frequency, *, d_in, d_out, dielectric: DielectricProperties, conductor: ConductorProperties, outer_conductor=None, shield_thickness=None) -> ImmittanceResult:
         return _coaxial_immittance(
             freq, d_in=d_in, d_out=d_out, dielectric=dielectric,
             conductor=conductor, outer_conductor=outer_conductor,
-            shield_thickness=shield_thickness, inner_shape=SchelkunoffRodShape(),
-            shield_shape=(SchelkunoffInfiniteTubeShape() if shield_thickness is None else SchelkunoffTubeShape()),
+            shield_thickness=shield_thickness, inner_shape=self.inner_shape,
+            shield_shape=self.shield_shape,
         )
 
 

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -27,6 +27,7 @@ from pmrf.models.components.lines.formulations import (
     AbstractMicrostripFormulation,
     AbstractStriplineFormulation,
     CohnStriplineFormulation,
+    HammerstadJensenMicrostripFormulation,
     KirschningJansenMicrostripDispersion,
     PlanarQuasiStaticResult,
     SchelkunoffCoaxialFormulation,
@@ -273,7 +274,7 @@ class CoaxialLine(AbstractImmittanceLine):
         permeability. A scalar permittivity or an ``(ep_r, tand)`` tuple is
         coerced into a :class:`~pmrf.materials.ConstantDielectric`; a magnetic
         filling sets that material's ``mu_r``.
-        conductor : AbstractConductor, default=BulkConductor()
+    conductor : AbstractConductor, default=BulkConductor()
         The inner conductor material. A scalar conductivity in
         S/m is coerced into a :class:`~pmrf.materials.BulkConductor`.
     outer_conductor : AbstractConductor | None, default=None
@@ -335,7 +336,15 @@ class MicrostripLine(AbstractImmittanceLine):
     r"""
     Microstrip line defined by standard geometry and material modules.
     
-    Uses :class:`WheelerMicrostripFormulation` for the default mathematical formulation.
+    Uses :class:`HammerstadJensenMicrostripFormulation` for the default
+    mathematical formulation: it is thickness-aware, and the
+    Kirschning-Jansen dispersion it is paired with was itself fitted against
+    its effective width. :class:`WheelerMicrostripFormulation` (Wheeler 1977)
+    remains available and accepts a thickness, ignoring it in
+    $\varepsilon_e$ and $Z_c$. Neither choice touches the conductor-loss
+    rule, which is Wheeler's *1942* skin-effect result
+    (:class:`~pmrf.models.components.lines.current_distribution.WheelerCurrentDistribution`)
+    and is still the default ``current_distribution``.
 
     The quasi-static formulation returns a :class:`PlanarQuasiStaticResult`.
     :meth:`PlanarQuasiStaticResult.to_immittance` converts it directly whether
@@ -451,11 +460,14 @@ class MicrostripLine(AbstractImmittanceLine):
         Thickness of the conductor. ``None`` means the thickness is
         unspecified, not that it is zero: skin effect is assumed to be in
         operation regardless, and Wheeler's conductor-loss correction (which
-        does not depend on `t`) is applied unconditionally. Wheeler's
-        quasi-static formulation requires ``None``; thickness-aware
-        formulations such as Hammerstad--Jensen use a positive value to
-        refine the geometry.
-    formulation : AbstractMicrostripFormulation, default=WheelerMicrostripFormulation()
+        does not depend on `t`) is applied unconditionally. A positive value
+        gets a dc resistance floor $R_{dc}=1/(\sigma W t)$. Wheeler's
+        quasi-static formulation accepts a thickness and ignores it in
+        $\varepsilon_e$ and $Z_c$; thickness-aware
+        formulations such as Hammerstad--Jensen (the default) use a positive
+        value to refine the geometry; thickness reaches the conductor-loss
+        term regardless of which formulation is selected.
+    formulation : AbstractMicrostripFormulation, default=HammerstadJensenMicrostripFormulation()
         The closed-form physics used to compute the quasi-static solution.
     dispersion : AbstractMicrostripDispersion | None, default=KirschningJansenMicrostripDispersion()
         The modal-dispersion correction. ``None`` disables modal dispersion and
@@ -487,7 +499,9 @@ class MicrostripLine(AbstractImmittanceLine):
     substrate: Substrate = field(default_factory=Substrate, converter=as_substrate)
 
     #: The underlying physics formulation
-    formulation: AbstractMicrostripFormulation = field(default_factory=WheelerMicrostripFormulation)
+    formulation: AbstractMicrostripFormulation = field(
+        default_factory=HammerstadJensenMicrostripFormulation
+    )
 
     #: The modal-dispersion formulation, or None to disable it
     dispersion: AbstractMicrostripDispersion | None = field(
@@ -526,7 +540,7 @@ class MicrostripLine(AbstractImmittanceLine):
         self.w = w
         self.substrate = Substrate(**given) if substrate is None else substrate
         self.formulation = (
-            WheelerMicrostripFormulation() if formulation is None else formulation
+            HammerstadJensenMicrostripFormulation() if formulation is None else formulation
         )
         self.dispersion = (
             KirschningJansenMicrostripDispersion()

--- a/pmrf/models/components/lines/physical.py
+++ b/pmrf/models/components/lines/physical.py
@@ -33,6 +33,10 @@ from pmrf.models.components.lines.formulations import (
     TescheCoaxialFormulation,
     WheelerMicrostripFormulation,
 )
+from pmrf.models.components.lines.cross_section import (
+    MicrostripCrossSection,
+    StriplineCrossSection,
+)
 from pmrf.models.components.lines.current_distribution import (
     AbstractCurrentDistribution,
     CohnCurrentDistribution,
@@ -367,15 +371,17 @@ class MicrostripLine(AbstractImmittanceLine):
     is the exact loss perturbation of the effective-permittivity model, following
     Schneider's energy-perturbation derivation.
 
-    Wheeler's incremental-inductance rule (:func:`_wheeler_conductor_loss_factor`)
-    is the single conductor-loss term charged on both paths:
+    Wheeler's incremental-inductance rule
+    (:class:`~pmrf.models.components.lines.current_distribution.WheelerCurrentDistribution`,
+    the default ``current_distribution``) is the single conductor-loss term
+    charged on both paths:
     $$\alpha_c=\frac{\Re(Z_s)}{\Re(Z_{c,loss})W}
     \exp\left[-1.2\left(\frac{\Re(Z_{c,loss})}{Z_0}\right)^{0.7}\right],$$
     applied unconditionally, over the physical width $W$ rather than any
     thickness-widened one. So ``dispersion=None`` is a pure dispersion toggle:
-    the quasi-static formulation's own `conductor_loss_factor` charges the
-    same rule at $Z_{c,loss}=Z_{c,0}$, and the dispersion path charges it
-    again at the dispersed $Z_{c,loss}$. The rule contains no $t$: it sums
+    the distribution charges the same rule at $Z_{c,loss}=Z_{c,0}$ on the
+    quasi-static path and at the dispersed $Z_{c,loss}$ on the other, because
+    it reads $Z_c$ off whichever solved state it is handed. The rule contains no $t$: it sums
     over every receded conductor surface, and the broad-face terms do not
     vanish as $t\to0$. So $t=\text{None}$ ("thickness unspecified") is not
     the same input as $t=0$; it is read as skin effect being in operation
@@ -592,11 +598,11 @@ class MicrostripLine(AbstractImmittanceLine):
         substrate = self.substrate
         conductor = substrate.conductor.properties(freq)
         dielectric = substrate.dielectric.properties(freq)
-        t = substrate.t
+        cross_section = MicrostripCrossSection(w=self.w, h=substrate.h, t=substrate.t)
         return self._resolved_quasi_static(freq).to_immittance(
             freq, dielectric, conductor,
             current_distribution=self.current_distribution,
-            w=self.w, t=t,
+            cross_section=cross_section,
         )
 
     def ep_eff(self, freq: Frequency) -> jnp.ndarray:
@@ -754,5 +760,7 @@ class StriplineLine(AbstractImmittanceLine):
         return quasi_static.to_immittance(
             freq, dielectric, conductor,
             current_distribution=self.current_distribution,
-            w=self.w, b=self.b, t=self.t, ep_r=dielectric.ep_r,
+            cross_section=StriplineCrossSection(
+                w=self.w, b=self.b, t=self.t, ep_r=dielectric.ep_r
+            ),
         )

--- a/tests/test_materials/test_conductor_shape.py
+++ b/tests/test_materials/test_conductor_shape.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from scipy.constants import mu_0
-from scipy.special import ive
+from scipy.special import ive, kve
 
 from pmrf.frequency import Frequency
 from pmrf.materials import BulkConductor, ConductorProperties, RoughConductor
@@ -13,7 +13,6 @@ from pmrf.materials.conductor_shape import (
     RootSumSquareSlabShape,
     SchelkunoffRodShape,
     SchelkunoffTubeShape,
-    SchelkunoffCothTubeShape,
     TescheRodShape,
     TescheTubeShape,
 )
@@ -311,17 +310,134 @@ def test_schelkunoff_rod_is_lossless_for_a_perfect_conductor():
     assert jnp.all(zs == 0)
 
 
-def test_schelkunoff_tube_and_coth_approximation_agree_in_coax_band():
-    """The cheap shield entry tracks the cylindrical tube in the RF band."""
+def _schelkunoff_eq_74(w, sigma, a, t):
+    """Schelkunoff eq. (74) referred to the inner surface, from scipy.
+
+    Written in the paper's own grouping, with the exponential scaling of
+    ``ive``/``kve`` carried explicitly so that nothing overflows in strong
+    skin effect. ``ive(v, x) = I_v(x) e^{-|Re x|}`` and
+    ``kve(v, x) = K_v(x) e^{x}``, and the common factor
+    ``e^{|Re x_b| - x_a}`` cancels between numerator and denominator,
+    leaving the bounded ``s`` below.
+    """
+    gamma = np.sqrt(1j * w * mu_0 * sigma)
+    xa, xb = gamma * a, gamma * (a + t)
+    s = np.exp(np.abs(xa.real) + xa - np.abs(xb.real) - xb)
+    num = ive(0, xa) * kve(1, xb) * s + kve(0, xa) * ive(1, xb)
+    den = ive(1, xb) * kve(1, xa) - ive(1, xa) * kve(1, xb) * s
+    return (gamma / sigma) * num / den
+
+
+@pytest.mark.parametrize(
+    'f, t, rtol',
+    [
+        # Weak skin effect: the wall is a small fraction of a skin depth, so
+        # the two surfaces are strongly coupled and the dc sheet resistance
+        # dominates. This is the regime the previous strong-skin expression
+        # was 33-43% wrong in.
+        (1e3, 10e-6, 1e-12), (1e3, 50e-6, 1e-12), (1e3, 500e-6, 1e-12),
+        (1e5, 500e-6, 1e-7),
+        # Transition: wall and skin depth comparable.
+        (1e5, 10e-6, 1e-7), (1e6, 50e-6, 1e-9),
+        # Strong skin effect: the coupling term is exponentially small and
+        # the tube is a curved half-space.
+        (1e8, 10e-6, 1e-12), (1e10, 500e-6, 1e-12),
+    ],
+)
+def test_schelkunoff_tube_matches_scipy_evaluation_of_eq_74(f, t, rtol):
+    """The finite tube is eq. (74) itself, checked against scipy.
+
+    The tolerances are the Bessel numerics of :mod:`pmrf.math.bessel`, not a
+    physics allowance: 1e-7 is the seam of ``i0_over_i1`` at |x| = 20, which
+    the 100 kHz cases sit near, and the rest are at machine level.
+    """
+    sigma, a = 5.8e7, 1.6e-3
+    freq = Frequency.from_f(jnp.array([f]))
+    conductor = _conductor(freq, sigma)
+
+    zs = SchelkunoffTubeShape().impedance(freq.w, conductor, a=a, t=t)
+
+    expected = _schelkunoff_eq_74(np.asarray(freq.w), sigma, a, t)
+    assert np.allclose(zs, expected, rtol=rtol)
+
+
+def test_schelkunoff_tube_dc_limit_is_the_tube_resistance_and_is_continuous():
+    """The dc branch is the exact tube resistance the series limit reaches.
+
+    The shape factor is 2*pi*a times the tube's dc resistance per unit
+    length, 1/(sigma*pi*(b^2-a^2)) -- so 2a/(sigma*(b^2-a^2)), which is
+    1/(sigma*t) only in the thin-wall limit. The earlier expression returned
+    half of this from its series and the full 1/(sigma*t) from its dc
+    branch, a factor-two discontinuity at the first nonzero frequency; the
+    two must now agree.
+    """
+    sigma, a, t = 5.8e7, 1.6e-3, 50e-6
+    freq = Frequency.from_f(jnp.array([0.0, 1e-3]))
+    conductor = _conductor(freq, sigma)
+
+    zs = SchelkunoffTubeShape().impedance(freq.w, conductor, a=a, t=t)
+
+    exact_dc = 2 * a / (sigma * ((a + t) ** 2 - a**2))
+    assert np.allclose(np.real(zs), exact_dc, rtol=1e-9)
+    assert np.isclose(np.real(zs[1]), np.real(zs[0]), rtol=1e-9)
+    # Continuous *from above*: dissipation never falls below the dc value.
+    # The 1e-9 slack is the rounding of the two branches against each other,
+    # not a physical allowance -- the difference at 1 mHz is 4e-10 relative.
+    assert np.real(zs[1]) >= np.real(zs[0]) * (1 - 1e-9)
+
+
+def test_schelkunoff_tube_infinite_wall_is_the_infinite_wall_limit():
+    """An infinite wall decouples the surfaces: rho -> 0 leaves K0/K1."""
     freq = Frequency(start=10.0, stop=500.0, npoints=20, unit='MHz')
     conductor = _conductor(freq, 5.8e7)
-    exact = SchelkunoffTubeShape().impedance(
-        freq.w, conductor, a=1.475e-3, t=25e-6
-    )
-    cheap = SchelkunoffCothTubeShape().impedance(
-        freq.w, conductor, a=1.475e-3, t=25e-6
-    )
-    assert jnp.allclose(cheap, exact, rtol=2e-3)
+    a = 1.475e-3
+
+    infinite = SchelkunoffTubeShape().impedance(freq.w, conductor, a=a, t=jnp.inf)
+
+    # 30 mm of copper is more than 10^4 skin depths at 10 MHz, so a finite
+    # wall that thick must reproduce the analytic infinite-wall branch.
+    thick = SchelkunoffTubeShape().impedance(freq.w, conductor, a=a, t=30e-3)
+    assert jnp.all(jnp.isfinite(infinite))
+    assert jnp.allclose(infinite, thick, rtol=1e-12)
+
+
+def test_schelkunoff_tube_gradients_are_finite_at_dc_and_for_a_perfect_conductor():
+    """Both unevaluable arguments must leave a usable gradient behind.
+
+    dc sends gamma to zero and a perfect conductor sends it to infinity;
+    either one propagates a nan into the gradient unless both branches are
+    evaluated on safe arguments. As for the rod, the gradient is taken
+    through :class:`BulkConductor`, which owns the dc derivative of
+    $\zeta_c$ itself. A perfect conductor is checked on the shape alone:
+    $\zeta_c=\sqrt{j\omega\mu/\sigma}$ has a nan $\omega$-derivative at
+    $\sigma=\infty$ that every shape in this module inherits, so the
+    conductor record is built directly to isolate the shape's own arithmetic.
+    """
+    a, t = 1.6e-3, 25e-6
+
+    def resistance(sigma, f):
+        freq = Frequency.from_f(jnp.atleast_1d(f))
+        conductor = BulkConductor(sigma=sigma).properties(freq)
+        return jnp.real(SchelkunoffTubeShape().impedance(freq.w, conductor, a=a, t=t))[0]
+
+    for f in (0.0, 1e3, 1e9):
+        d_sigma, d_f = jax.grad(resistance, argnums=(0, 1))(5.8e7, f)
+        assert jnp.isfinite(d_sigma) and jnp.isfinite(d_f)
+        # A perfect conductor is lossless at every frequency, dc included,
+        # and the wall gradient there survives the infinite Bessel argument.
+        freq = Frequency.from_f(jnp.array([f]))
+        conductor = ConductorProperties(
+            jnp.zeros_like(freq.w, dtype=complex), jnp.inf, 1.0
+        )
+        assert jnp.all(
+            SchelkunoffTubeShape().impedance(freq.w, conductor, a=a, t=t) == 0
+        )
+        wall_gradient = jax.grad(
+            lambda wall: jnp.real(
+                SchelkunoffTubeShape().impedance(freq.w, conductor, a=a, t=wall)
+            )[0]
+        )(t)
+        assert jnp.isfinite(wall_gradient)
 
 
 @pytest.mark.parametrize(
@@ -330,7 +446,7 @@ def test_schelkunoff_tube_and_coth_approximation_agree_in_coax_band():
         (HollowayKuesterSlabShape(t=18e-6), {}),
         (SchelkunoffRodShape(), dict(a=20e-6)),
         (SchelkunoffTubeShape(), dict(a=1.475e-3, t=25e-6)),
-        (SchelkunoffCothTubeShape(), dict(a=1.475e-3, t=25e-6)),
+        (SchelkunoffTubeShape(), dict(a=1.475e-3, t=jnp.inf)),
     ],
 )
 def test_roughness_scales_the_prefactor_and_not_the_shape_factor(shape, geometry):

--- a/tests/test_materials/test_conductor_shape.py
+++ b/tests/test_materials/test_conductor_shape.py
@@ -16,7 +16,17 @@ from pmrf.materials.conductor_shape import (
     TescheRodShape,
     TescheTubeShape,
 )
+from pmrf.models.components.lines.cross_section import MicrostripCrossSection
 from pmrf.models.components.lines.current_distribution import WheelerCurrentDistribution
+from pmrf.models.components.lines.formulations import PlanarQuasiStaticResult
+
+
+def _solved(zc):
+    """A minimal solved state carrying only the impedance a strategy reads."""
+    ones = jnp.ones_like(zc)
+    return PlanarQuasiStaticResult(
+        ep_eff=ones, zc=zc, w_eff=ones, shunt_conductance_factor=ones
+    )
 
 
 @pytest.fixture
@@ -84,7 +94,9 @@ def test_root_sum_square_slab_reproduces_the_true_dc_resistance_under_its_weight
     freq = Frequency.from_f(jnp.array([0.0]))
     conductor = _conductor(freq, sigma)
     (shape, weight), = WheelerCurrentDistribution().distribute(
-        freq, zc=jnp.full(freq.f.shape, 50.0), w=w, t=t,
+        freq,
+        MicrostripCrossSection(w=w, h=1.6e-3, t=t),
+        _solved(jnp.full(freq.f.shape, 50.0)),
     )
 
     r_dc = shape.impedance(freq.w, conductor, w=w, t=t, weight=weight) * weight
@@ -106,7 +118,9 @@ def test_exact_slab_wants_a_different_weight_from_wheelers():
     freq = Frequency.from_f(jnp.array([0.0]))
     conductor = _conductor(freq, sigma)
     (_, wheeler_weight), = WheelerCurrentDistribution().distribute(
-        freq, zc=jnp.full(freq.f.shape, 50.0), w=w, t=t,
+        freq,
+        MicrostripCrossSection(w=w, h=1.6e-3, t=t),
+        _solved(jnp.full(freq.f.shape, 50.0)),
     )
     slab_weight = 1 / (2 * w)
 
@@ -177,15 +191,17 @@ def test_tabulated_planar_entries_record_transition_error(w, h, zc, expected, rt
     ohm/m at 10 and 50 MHz.  The literals were independently evaluated from
     Holloway--Kuester eq. (100) and Wheeler's published current weight using
     35 um copper with rho=1.68e-8 ohm m.  `h` records the complete tabulated
-    cross-section even though these planar entries depend on it only through
-    the supplied characteristic impedance.
+    cross-section: it reaches the distribution through the typed record even
+    though these planar entries depend on it only through the supplied
+    characteristic impedance.
     """
-    del h
     t, sigma = 35e-6, 1 / 1.68e-8
     freq = Frequency.from_f(jnp.array([10e6, 50e6]))
     conductor = _conductor(freq, sigma)
     blend, weight = WheelerCurrentDistribution().distribute(
-        freq, zc=jnp.full(freq.f.shape, zc), w=w, t=t,
+        freq,
+        MicrostripCrossSection(w=w, h=h, t=t),
+        _solved(jnp.full(freq.f.shape, zc)),
     )[0]
     geometry = dict(w=w, t=t, weight=weight)
 

--- a/tests/test_materials/test_conductor_shape.py
+++ b/tests/test_materials/test_conductor_shape.py
@@ -45,7 +45,7 @@ def test_holloway_kuester_slab_matches_half_thickness_coth():
     freq = Frequency.from_f(jnp.array([10e6, 30e6, 100e6, 500e6]))
     conductor = _conductor(freq, sigma)
 
-    actual = HollowayKuesterSlabShape(t=t).impedance(freq.w, conductor)
+    actual = HollowayKuesterSlabShape().impedance(freq.w, conductor, t=t)
 
     gamma = np.sqrt(1j * np.asarray(freq.w) * mu_0 * sigma)
     expected = np.asarray(conductor.zs) / np.tanh(gamma * t / 2)
@@ -58,24 +58,92 @@ def test_holloway_kuester_slab_has_dc_and_strong_skin_limits():
     freq = Frequency.from_f(jnp.array([0.0, 1e12]))
     conductor = _conductor(freq, sigma)
 
-    zs = HollowayKuesterSlabShape(t=t).impedance(freq.w, conductor)
+    zs = HollowayKuesterSlabShape().impedance(freq.w, conductor, t=t)
 
     assert jnp.allclose(zs[0], 2 / (sigma * t))
     assert jnp.allclose(zs[1], conductor.zs[1], rtol=1e-6)
 
 
-def test_root_sum_square_slab_preserves_the_paramrf_convention():
-    """The named compatibility entry blends resistance and retains half-space X."""
-    sigma, t = 5.8e7, 35e-6
+def test_root_sum_square_slab_blends_resistance_and_keeps_half_space_reactance():
+    """The blend takes its dimensions at call time and keeps the half-space X."""
+    sigma, w, t, weight = 5.8e7, 1.55e-3, 35e-6, 963.7
     freq = Frequency.from_f(jnp.array([0.0, 10e6, 500e6]))
     conductor = _conductor(freq, sigma)
 
-    r_dc_sq = 1 / (sigma * t)
-    zs = RootSumSquareSlabShape(dc_shape_factor=1 / t).impedance(freq.w, conductor)
+    zs = RootSumSquareSlabShape().impedance(freq.w, conductor, w=w, t=t, weight=weight)
 
+    r_dc_sq = 1 / (sigma * w * t * weight)
     expected_r = jnp.sqrt(r_dc_sq**2 + jnp.real(conductor.zs) ** 2)
     expected = expected_r + 1j * jnp.imag(conductor.zs)
     assert jnp.allclose(zs, expected)
+
+
+def test_root_sum_square_slab_reproduces_the_true_dc_resistance_under_its_weight():
+    """Charged with the caller's weight, the dc floor is 1/(sigma*W*t) exactly."""
+    sigma, w, t = 1 / 1.68e-8, 1.55e-3, 35e-6
+    freq = Frequency.from_f(jnp.array([0.0]))
+    conductor = _conductor(freq, sigma)
+    (shape, weight), = WheelerCurrentDistribution().distribute(
+        freq, zc=jnp.full(freq.f.shape, 50.0), w=w, t=t,
+    )
+
+    r_dc = shape.impedance(freq.w, conductor, w=w, t=t, weight=weight) * weight
+
+    assert jnp.allclose(jnp.real(r_dc), 1 / (sigma * w * t), rtol=1e-12)
+
+
+def test_exact_slab_wants_a_different_weight_from_wheelers():
+    """The 2.99 normalisation finding: the two decompositions do not share a weight.
+
+    The exact slab is referred to the total strip current, so its own weight
+    is 1/(2W): its dc value 2/(sigma*t) times 1/(2W) is the true
+    1/(sigma*W*t).  Wheeler's weight is larger because it covers the ground
+    plane and the edge crowding as well as the strip, so charging the slab
+    with it overstates the dc resistance by that same factor.  The literals
+    are 35 um copper, rho = 1.68e-8 ohm m, on a 1.55 mm 50 ohm trace.
+    """
+    sigma, w, t = 1 / 1.68e-8, 1.55e-3, 35e-6
+    freq = Frequency.from_f(jnp.array([0.0]))
+    conductor = _conductor(freq, sigma)
+    (_, wheeler_weight), = WheelerCurrentDistribution().distribute(
+        freq, zc=jnp.full(freq.f.shape, 50.0), w=w, t=t,
+    )
+    slab_weight = 1 / (2 * w)
+
+    assert jnp.allclose(wheeler_weight, 963.7, rtol=1e-4)
+    assert jnp.allclose(slab_weight, 322.6, rtol=1e-4)
+    assert jnp.allclose(wheeler_weight / slab_weight, 2.99, rtol=2e-3)
+
+    zs = HollowayKuesterSlabShape().impedance(freq.w, conductor, t=t)
+    assert jnp.allclose(zs * slab_weight, 1 / (sigma * w * t), rtol=1e-12)
+    assert jnp.allclose(zs * wheeler_weight, 0.925, rtol=2e-3)
+    assert jnp.allclose(1 / (sigma * w * t), 0.3097, rtol=2e-3)
+
+
+def test_root_sum_square_slab_overstates_internal_inductance_below_one_skin_depth():
+    """The blend keeps the half-space reactance, which the finite slab does not.
+
+    Below t ~ delta the true internal reactance saturates at omega*mu*t/6
+    while the blend's grows as sqrt(omega), so the entry is qualitatively
+    wrong on internal inductance there.  The ratios are weight-independent
+    -- both entries are charged with the same weight -- and are recorded
+    here as the measured size of that limitation for 35 um copper.
+    """
+    sigma, t = 1 / 1.68e-8, 35e-6
+    f = jnp.array([100e3, 1e6, 5e6, 10e6, 50e6])
+    freq = Frequency.from_f(f)
+    conductor = _conductor(freq, sigma)
+
+    delta = jnp.sqrt(2 / (freq.w * mu_0 * sigma))
+    # The tabulated t/delta and ratios are the measured values rounded to
+    # two decimals, so they are compared to within half of that last place.
+    assert jnp.allclose(t / delta, jnp.array([0.17, 0.54, 1.20, 1.70, 3.79]), atol=5e-3)
+
+    blend_x = jnp.imag(conductor.zs)
+    exact_x = jnp.imag(HollowayKuesterSlabShape().impedance(freq.w, conductor, t=t))
+
+    ratio = blend_x / exact_x
+    assert jnp.allclose(ratio, jnp.array([17.7, 5.6, 2.5, 1.8, 1.01]), atol=0.05)
 
 
 @pytest.mark.parametrize(
@@ -119,12 +187,16 @@ def test_tabulated_planar_entries_record_transition_error(w, h, zc, expected, rt
     blend, weight = WheelerCurrentDistribution().distribute(
         freq, zc=jnp.full(freq.f.shape, zc), w=w, t=t,
     )[0]
+    geometry = dict(w=w, t=t, weight=weight)
 
     actual = jnp.stack(
         [
-            jnp.real(HollowayKuesterSlabShape(t=t).impedance(freq.w, conductor) * weight),
-            jnp.real(HalfSpaceShape().impedance(freq.w, conductor) * weight),
-            jnp.real(blend.impedance(freq.w, conductor) * weight),
+            jnp.real(
+                HollowayKuesterSlabShape().impedance(freq.w, conductor, **geometry)
+                * weight
+            ),
+            jnp.real(HalfSpaceShape().impedance(freq.w, conductor, **geometry) * weight),
+            jnp.real(blend.impedance(freq.w, conductor, **geometry) * weight),
         ],
         axis=1,
     )
@@ -443,7 +515,7 @@ def test_schelkunoff_tube_gradients_are_finite_at_dc_and_for_a_perfect_conductor
 @pytest.mark.parametrize(
     'shape, geometry',
     [
-        (HollowayKuesterSlabShape(t=18e-6), {}),
+        (HollowayKuesterSlabShape(), dict(t=18e-6)),
         (SchelkunoffRodShape(), dict(a=20e-6)),
         (SchelkunoffTubeShape(), dict(a=1.475e-3, t=25e-6)),
         (SchelkunoffTubeShape(), dict(a=1.475e-3, t=jnp.inf)),

--- a/tests/test_materials/test_conductor_shape.py
+++ b/tests/test_materials/test_conductor_shape.py
@@ -6,7 +6,7 @@ from scipy.constants import mu_0
 from scipy.special import ive
 
 from pmrf.frequency import Frequency
-from pmrf.materials import BulkConductor, ConductorProperties
+from pmrf.materials import BulkConductor, ConductorProperties, RoughConductor
 from pmrf.materials.conductor_shape import (
     HalfSpaceShape,
     HollowayKuesterSlabShape,
@@ -322,3 +322,56 @@ def test_schelkunoff_tube_and_coth_approximation_agree_in_coax_band():
         freq.w, conductor, a=1.475e-3, t=25e-6
     )
     assert jnp.allclose(cheap, exact, rtol=2e-3)
+
+
+@pytest.mark.parametrize(
+    'shape, geometry',
+    [
+        (HollowayKuesterSlabShape(t=18e-6), {}),
+        (SchelkunoffRodShape(), dict(a=20e-6)),
+        (SchelkunoffTubeShape(), dict(a=1.475e-3, t=25e-6)),
+        (SchelkunoffCothTubeShape(), dict(a=1.475e-3, t=25e-6)),
+    ],
+)
+def test_roughness_scales_the_prefactor_and_not_the_shape_factor(shape, geometry):
+    """Surface texture roughens Z_s; it does not change bulk field diffusion.
+
+    A rough and a smooth conductor of the same bulk material must therefore
+    produce the same dimensionless shape factor Z_s/zeta_c, and differ only
+    by the roughness factor K on the prefactor. Deriving gamma as
+    ``sigma * zs`` inflates the shape's argument by K and breaks this.
+    """
+    freq = Frequency(start=1.0, stop=20.0, npoints=20, unit='GHz')
+    sigma = 5.8e7
+    smooth = BulkConductor(sigma=sigma).properties(freq)
+    rough = RoughConductor(sigma=sigma, roughness=2e-6).properties(freq)
+
+    k = rough.zs / smooth.zs
+    assert jnp.max(jnp.real(k)) > 1.5  # roughness is significant in this band
+    assert jnp.allclose(jnp.imag(k), 0.0, atol=1e-12)
+
+    smooth_factor = shape.impedance(freq.w, smooth, **geometry) / smooth.zs
+    rough_factor = shape.impedance(freq.w, rough, **geometry) / rough.zs
+
+    assert jnp.allclose(rough_factor, smooth_factor, rtol=1e-12)
+
+
+def test_metal_propagation_constant_is_the_inverse_complex_skin_depth():
+    """gamma = sqrt(j w mu sigma) = (1+j)/delta, with finite dc gradient."""
+    freq = Frequency.from_f(jnp.array([0.0, 1e6, 1e9]))
+    conductor = BulkConductor(sigma=5.8e7, mu_r=2.0).properties(freq)
+
+    gamma = conductor.gamma(freq.w)
+
+    w = np.asarray(freq.w)
+    expected = np.sqrt(1j * w * mu_0 * 2.0 * 5.8e7)
+    assert np.allclose(gamma, expected, rtol=1e-12)
+
+    grad = jax.grad(
+        lambda f: jnp.real(
+            BulkConductor(sigma=5.8e7)
+            .properties(Frequency.from_f(jnp.atleast_1d(f)))
+            .gamma(jnp.atleast_1d(2 * jnp.pi * f))
+        )[0]
+    )(0.0)
+    assert jnp.isfinite(grad)

--- a/tests/test_math/test_bessel.py
+++ b/tests/test_math/test_bessel.py
@@ -13,8 +13,11 @@ from scipy.special import ive, kve
 from pmrf.math.bessel import (
     I0_OVER_I1_SERIES_CUTOFF,
     K0_OVER_K1_SERIES_CUTOFF,
+    K1E_SERIES_CUTOFF,
     i0_over_i1,
+    i1e,
     k0_over_k1,
+    k1e,
 )
 
 
@@ -112,3 +115,75 @@ def test_k0_over_k1_gradient_is_finite_across_the_branch_switch():
     )
 
     assert jnp.all(jnp.isfinite(grads))
+
+
+@pytest.mark.parametrize(
+    "lo, hi, rtol",
+    [
+        (1e-3, 19.9, 1e-13),
+        (19.9, 20.1, 2e-8),
+        (20.1, 1e4, 2e-8),
+    ],
+)
+def test_i1e_matches_scipy_over_conductor_arguments(lo, hi, rtol):
+    """The scaled I1 is what keeps a thick tube wall evaluable.
+
+    ``scipy.special.ive`` scales by ``exp(-|Re x|)`` for complex arguments
+    while this module scales by ``exp(-x)``, so the reference carries the
+    remaining unit-magnitude phase factor.
+    """
+    magnitude = np.logspace(np.log10(lo), np.log10(hi), 400)
+    x = magnitude * np.exp(1j * np.pi / 4)
+
+    got = np.asarray(i1e(jnp.asarray(x)))
+    expected = ive(1, x) * np.exp(np.abs(x.real) - x)
+
+    assert np.abs(got / expected - 1).max() < rtol
+
+
+@pytest.mark.parametrize(
+    "lo, hi, rtol",
+    [
+        (1e-3, 11.9, 5e-8),
+        (11.9, 12.1, 1e-7),
+        (12.1, 1e4, 2e-9),
+    ],
+)
+def test_k1e_matches_scipy_over_conductor_arguments(lo, hi, rtol):
+    """The scaled K1 uses the same scaling convention as ``kve``.
+
+    The tolerance below the seam is the logarithmic series' own
+    cancellation, which grows to 3.5e-8 as |x| approaches 12; the ten-term
+    expansion above it is 1.3e-9. Both are the accuracy of the evaluation,
+    not a physics allowance.
+    """
+    magnitude = np.logspace(np.log10(lo), np.log10(hi), 400)
+    x = magnitude * np.exp(1j * np.pi / 4)
+
+    got = np.asarray(k1e(jnp.asarray(x)))
+    expected = kve(1, x)
+
+    assert np.abs(got / expected - 1).max() < rtol
+
+
+def test_scaled_bessels_do_not_overflow_for_a_thick_wall():
+    """Unscaled I1 overflows long before the physics stops making sense.
+
+    A 30 mm copper wall at 500 MHz is ~10^4 skin depths, where I1 is e^{1e4};
+    the scaled pair stays O(1) and their ratio is what the tube shape needs.
+    """
+    x = jnp.asarray(1e4 * np.exp(1j * np.pi / 4))
+
+    assert jnp.isfinite(i1e(x)) and i1e(x) != 0
+    assert jnp.isfinite(k1e(x)) and k1e(x) != 0
+
+
+def test_scaled_bessel_gradients_are_finite_across_the_branch_switch():
+    """Safe branch arguments prevent an unused series from poisoning gradients."""
+    magnitudes = jnp.asarray([1e-3, 1.0, K1E_SERIES_CUTOFF, I0_OVER_I1_SERIES_CUTOFF, 1e4])
+
+    for function in (i1e, k1e):
+        def real_part(m, function=function):
+            return jnp.real(function(m * jnp.exp(1j * jnp.pi / 4)))
+
+        assert jnp.all(jnp.isfinite(jax.vmap(jax.grad(real_part))(magnitudes)))

--- a/tests/test_models/test_current_distribution.py
+++ b/tests/test_models/test_current_distribution.py
@@ -1,7 +1,13 @@
 import jax.numpy as jnp
 
 from pmrf.frequency import Frequency
-from pmrf.materials import BulkConductor, ConstantDielectric, HalfSpaceShape
+from pmrf.materials import (
+    BulkConductor,
+    ConstantDielectric,
+    HalfSpaceShape,
+    HollowayKuesterSlabShape,
+    RootSumSquareSlabShape,
+)
 from pmrf.models import (
     CohnCurrentDistribution,
     HammerstadJensenMicrostripFormulation,
@@ -45,3 +51,30 @@ def test_cohn_distribution_uses_a_surface_pair():
     assert isinstance(pairs[0][0], HalfSpaceShape)
     assert pairs[0][1].shape == (1,)
     assert jnp.all(pairs[0][1] > 0)
+
+
+def test_wheeler_finite_thickness_slab_entry_is_a_selectable_field():
+    """Which slab entry charges a stated thickness is a field, not a literal.
+
+    The default is the root-sum-square blend, the only entry that satisfies
+    both asymptotes under this distribution's frequency-independent weight;
+    the exact strip-diffusion slab is reachable for a caller that supplies
+    its own normalisation.
+    """
+    freq = Frequency.from_f(jnp.array([10e6]))
+    zc = jnp.array([50.0])
+
+    assert isinstance(WheelerCurrentDistribution().slab_shape, RootSumSquareSlabShape)
+
+    default_shape, _ = WheelerCurrentDistribution().distribute(
+        freq, zc=zc, w=1.55e-3, t=35e-6
+    )[0]
+    assert isinstance(default_shape, RootSumSquareSlabShape)
+
+    chosen = WheelerCurrentDistribution(slab_shape=HollowayKuesterSlabShape())
+    chosen_shape, _ = chosen.distribute(freq, zc=zc, w=1.55e-3, t=35e-6)[0]
+    assert isinstance(chosen_shape, HollowayKuesterSlabShape)
+
+    # An unspecified thickness is still a half-space: there is no slab.
+    unspecified, _ = chosen.distribute(freq, zc=zc, w=1.55e-3)[0]
+    assert isinstance(unspecified, HalfSpaceShape)

--- a/tests/test_models/test_current_distribution.py
+++ b/tests/test_models/test_current_distribution.py
@@ -1,4 +1,6 @@
 import jax.numpy as jnp
+import pytest
+from scipy.constants import epsilon_0, mu_0
 
 from pmrf.frequency import Frequency
 from pmrf.materials import (
@@ -14,18 +16,34 @@ from pmrf.models import (
     MicrostripLine,
     WheelerCurrentDistribution,
 )
-from pmrf.models.components.lines.formulations import _wheeler_conductor_loss_factor
+from pmrf.models.components.lines.cross_section import (
+    MicrostripCrossSection,
+    StriplineCrossSection,
+)
+from pmrf.models.components.lines.formulations import PlanarQuasiStaticResult
+
+
+def _solved(zc):
+    """A minimal solved state carrying only the impedance a strategy reads."""
+    ones = jnp.ones_like(zc)
+    return PlanarQuasiStaticResult(
+        ep_eff=ones, zc=zc, w_eff=ones, shunt_conductance_factor=ones
+    )
 
 
 def test_wheeler_distribution_returns_a_shape_and_frequency_resolved_weight():
     freq = Frequency(start=1.0, stop=10.0, npoints=2, unit="GHz")
     zc = jnp.array([50.0, 60.0])
 
-    pairs = WheelerCurrentDistribution().distribute(freq, w=3e-3, zc=zc)
+    pairs = WheelerCurrentDistribution().distribute(
+        freq, MicrostripCrossSection(w=3e-3, h=1.6e-3), _solved(zc)
+    )
 
+    z0 = jnp.sqrt(mu_0 / epsilon_0)
+    expected = 2 / 3e-3 * jnp.exp(-1.2 * (zc / z0) ** 0.7)
     shape, weight = pairs[0]
     assert isinstance(shape, HalfSpaceShape)
-    assert jnp.allclose(weight, _wheeler_conductor_loss_factor(3e-3, zc))
+    assert jnp.allclose(weight, expected)
 
 
 def test_current_distribution_can_be_selected_independently_of_microstrip_formulation():
@@ -45,7 +63,9 @@ def test_cohn_distribution_uses_a_surface_pair():
     zc = jnp.array([50.0])
 
     pairs = CohnCurrentDistribution().distribute(
-        freq, zc=zc, w=2.655e-3, b=3.2e-3, t=35e-6, ep_r=jnp.array([2.2])
+        freq,
+        StriplineCrossSection(w=2.655e-3, b=3.2e-3, t=35e-6, ep_r=jnp.array([2.2])),
+        _solved(zc),
     )
 
     assert isinstance(pairs[0][0], HalfSpaceShape)
@@ -66,15 +86,56 @@ def test_wheeler_finite_thickness_slab_entry_is_a_selectable_field():
 
     assert isinstance(WheelerCurrentDistribution().slab_shape, RootSumSquareSlabShape)
 
+    cross_section = MicrostripCrossSection(w=1.55e-3, h=1.6e-3, t=35e-6)
     default_shape, _ = WheelerCurrentDistribution().distribute(
-        freq, zc=zc, w=1.55e-3, t=35e-6
+        freq, cross_section, _solved(zc)
     )[0]
     assert isinstance(default_shape, RootSumSquareSlabShape)
 
     chosen = WheelerCurrentDistribution(slab_shape=HollowayKuesterSlabShape())
-    chosen_shape, _ = chosen.distribute(freq, zc=zc, w=1.55e-3, t=35e-6)[0]
+    chosen_shape, _ = chosen.distribute(freq, cross_section, _solved(zc))[0]
     assert isinstance(chosen_shape, HollowayKuesterSlabShape)
 
     # An unspecified thickness is still a half-space: there is no slab.
-    unspecified, _ = chosen.distribute(freq, zc=zc, w=1.55e-3)[0]
+    unspecified, _ = chosen.distribute(
+        freq, MicrostripCrossSection(w=1.55e-3, h=1.6e-3), _solved(zc)
+    )[0]
     assert isinstance(unspecified, HalfSpaceShape)
+
+
+def test_pairing_a_distribution_with_the_wrong_family_is_a_typed_failure():
+    """A wrong-family pairing fails at the strategy boundary, not in binding.
+
+    The families do not share a cross-section record, so the check is a real
+    type check with a message naming both sides -- not a TypeError about a
+    missing or unexpected keyword argument deep inside the call.
+    """
+    freq = Frequency.from_f(jnp.array([10e9]))
+    solved = _solved(jnp.array([50.0]))
+    stripline = StriplineCrossSection(w=2.655e-3, b=3.2e-3, t=35e-6, ep_r=jnp.array([2.2]))
+    microstrip = MicrostripCrossSection(w=1.55e-3, h=1.6e-3, t=35e-6)
+
+    with pytest.raises(TypeError, match="MicrostripCrossSection strategy"):
+        WheelerCurrentDistribution().distribute(freq, stripline, solved)
+
+    with pytest.raises(TypeError, match="StriplineCrossSection strategy"):
+        CohnCurrentDistribution().distribute(freq, microstrip, solved)
+
+
+def test_substrate_height_reaches_the_microstrip_distribution():
+    """The record carries h, which edge-shape and ground-share models need."""
+    freq = Frequency.from_f(jnp.array([10e9]))
+    seen = {}
+
+    class RecordingDistribution(WheelerCurrentDistribution):
+        def _distribute(self, freq, cross_section, quasi_static):
+            seen["h"] = cross_section.h
+            return super()._distribute(freq, cross_section, quasi_static)
+
+    line = MicrostripLine(
+        w=1.55e-3, h=0.8e-3, length=0.1,
+        current_distribution=RecordingDistribution(),
+    )
+    line.immittance(freq)
+
+    assert seen["h"] == line.substrate.h

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -508,10 +508,8 @@ def test_dispersive_microstrip_routes_through_planar_quasi_static_to_immittance(
     construction bit for bit.
     """
     from pmrf.models import HammerstadJensenMicrostripFormulation, KirschningJansenMicrostripDispersion
-    from pmrf.models.components.lines.formulations import (
-        PlanarQuasiStaticResult,
-        _wheeler_conductor_loss_factor,
-    )
+    from pmrf.models.components.lines.cross_section import MicrostripCrossSection
+    from pmrf.models.components.lines.formulations import PlanarQuasiStaticResult
 
     freq = Frequency(start=1.0, stop=50.0, npoints=51, unit="GHz")
     formulation = HammerstadJensenMicrostripFormulation()
@@ -548,7 +546,9 @@ def test_dispersive_microstrip_routes_through_planar_quasi_static_to_immittance(
     ).to_immittance(
         freq, dielectric, conductor,
         current_distribution=line.current_distribution,
-        w=line.w, t=line.substrate.t,
+        cross_section=MicrostripCrossSection(
+            w=line.w, h=line.substrate.h, t=line.substrate.t
+        ),
     )
 
     actual = line.immittance(freq)
@@ -573,6 +573,8 @@ def test_microstrip_without_dispersion_preserves_quasi_static_immittance():
         length=0.1,
     )
 
+    from pmrf.models.components.lines.cross_section import MicrostripCrossSection
+
     ep_r = line.substrate.dielectric.properties(freq).ep_r
     zs = line.substrate.conductor.properties(freq).zs
     quasi_static = line.formulation.quasi_static(
@@ -584,6 +586,10 @@ def test_microstrip_without_dispersion_preserves_quasi_static_immittance():
         freq,
         line.substrate.dielectric.properties(freq),
         line.substrate.conductor.properties(freq),
+        current_distribution=line.current_distribution,
+        cross_section=MicrostripCrossSection(
+            w=line.w, h=line.substrate.h, t=line.substrate.t
+        ),
     )
     assert jnp.array_equal(actual.Z, expected.Z)
     assert jnp.array_equal(actual.Y, expected.Y)

--- a/tests/test_models/test_lines.py
+++ b/tests/test_models/test_lines.py
@@ -637,6 +637,69 @@ def test_microstrip_dispersion_is_a_pure_dispersion_toggle():
     assert jnp.allclose(alpha_quasi_static, alpha_identity_dispersion, rtol=1e-2)
 
 
+def test_microstrip_defaults_to_hammerstad_jensen():
+    """#117: the thickness-aware formulation is the microstrip default.
+
+    Hammerstad-Jensen quotes better than 0.2% on effective permittivity and
+    0.01-0.03% on impedance, and the default Kirschning-Jansen dispersion was
+    fitted against its effective width.
+    """
+    from pmrf.models import HammerstadJensenMicrostripFormulation
+
+    assert isinstance(
+        MicrostripLine(length=0.1).formulation, HammerstadJensenMicrostripFormulation
+    )
+
+
+def test_default_microstrip_finite_thickness_has_dc_resistance_floor():
+    """#117: thickness reaches conductor loss on a default-constructed line.
+
+    The issue's worked number: 35 um copper under a 1.55 mm trace gives
+    1/(sigma*W*t) = 0.31781 ohm/m, with no formulation passed by the user.
+    """
+    w, t, sigma = 1.55e-3, 35e-6, 5.8e7
+    line = MicrostripLine(
+        w=w, h=0.8e-3, t=t, conductor=BulkConductor(sigma=sigma), length=0.1
+    )
+    dc = Frequency.from_f(jnp.array([0.0]))
+
+    assert jnp.allclose(line.immittance(dc).R, 1 / (sigma * w * t), rtol=1e-9)
+
+
+def test_wheeler_formulation_accepts_and_ignores_thickness():
+    """#117: a zero-thickness-derived formulation declines t silently.
+
+    Wheeler 1977 is derived for a zero-thickness strip, so t enters neither
+    ep_eff nor zc; rejecting the input would stop the *loss* model from
+    seeing a thickness it can use, so the formulation ignores it instead.
+    """
+    from pmrf.models import WheelerMicrostripFormulation
+
+    ep_r = np.full(4, 4.3 - 0.086j)
+    kwargs = dict(w=3.0e-3, h=1.6e-3, ep_r=ep_r)
+
+    thin = WheelerMicrostripFormulation().quasi_static(t=None, **kwargs)
+    thick = WheelerMicrostripFormulation().quasi_static(t=35e-6, **kwargs)
+
+    assert jnp.allclose(thin.ep_eff, thick.ep_eff)
+    assert jnp.allclose(thin.zc, thick.zc)
+    assert jnp.allclose(thin.w_eff, thick.w_eff)
+
+
+def test_wheeler_microstrip_line_with_thickness_still_gets_dc_floor():
+    """#117: the loss floor is available whatever quasi-static choice is made."""
+    from pmrf.models import WheelerMicrostripFormulation
+
+    w, t, sigma = 1.55e-3, 35e-6, 5.8e7
+    line = MicrostripLine(
+        w=w, h=0.8e-3, t=t, conductor=BulkConductor(sigma=sigma),
+        formulation=WheelerMicrostripFormulation(), length=0.1,
+    )
+    dc = Frequency.from_f(jnp.array([0.0]))
+
+    assert jnp.allclose(line.immittance(dc).R, 1 / (sigma * w * t), rtol=1e-9)
+
+
 def test_microstrip_defaults_to_kirschning_jansen():
     """Modal dispersion is the accuracy-oriented microstrip default."""
     from pmrf.models import KirschningJansenMicrostripDispersion

--- a/tests/test_models/test_lines_skrf_matrix.py
+++ b/tests/test_models/test_lines_skrf_matrix.py
@@ -184,9 +184,16 @@ _COAX_MODELS = {
 }
 
 
-def _coax_pair(d_in, d_out, dielectric, rho, ep_r_of_f, model="tesche"):
-    """A ParamRF/scikit-rf builder pair for one coaxial geometry."""
+def _coax_pair(d_in, d_out, dielectric, rho, ep_r_of_f, model="tesche",
+               rho_shield=None, shield_thickness=None):
+    """A ParamRF/scikit-rf builder pair for one coaxial geometry.
+
+    ``rho_shield`` gives the shield a metal of its own, and
+    ``shield_thickness`` a finite wall; leaving either out keeps scikit-rf on
+    its own defaults, so the existing cases are unaffected.
+    """
     sigma = _sigma_of_rho(rho)
+    sigma_shield = None if rho_shield is None else _sigma_of_rho(rho_shield)
     formulation = _COAX_MODELS[model]()
 
     def line(length):
@@ -194,13 +201,25 @@ def _coax_pair(d_in, d_out, dielectric, rho, ep_r_of_f, model="tesche"):
             d_in=d_in, d_out=d_out, dielectric=dielectric,
             conductor=BulkConductor(sigma=sigma), length=length,
             formulation=formulation,
+            outer_conductor=(
+                None if sigma_shield is None else BulkConductor(sigma=sigma_shield)
+            ),
+            shield_thickness=shield_thickness,
         )
 
     def media(freq, z0_port=None):
+        conductors = {}
+        if sigma_shield is not None:
+            # scikit-rf warns unless both conductors are described together.
+            conductors = dict(
+                inner_conductor={"sigma": sigma},
+                outer_conductor={"sigma": sigma_shield},
+            )
         return Coaxial(
             freq, Dint=d_in, Dout=d_out, model=model, z0_port=z0_port,
-            sigma=sigma,
+            sigma=sigma, tout=shield_thickness,
             dielectric={"ep_r": ep_r_of_f(np.asarray(freq.f))},
+            **conductors,
         )
 
     return {"line": line, "media": media}
@@ -317,6 +336,33 @@ COAX_CASES += [
                     RHO_COPPER, lambda f: _coax_ep_r(1.2, 1e-4, f=f),
                     model="schelkunoff"),
         length=0.2, z0=75.0,
+        tol=_SCHELKUNOFF_EXACT,
+    ),
+    Case(
+        id="dissimilar_metals_finite_shield_schelkunoff",
+        purpose="The outstanding criterion of #98: a copper centre conductor "
+                "inside a 25 um stainless shield, so the two conductors carry "
+                "different metals and the shield's finite wall is in play. "
+                "This is the case that pins Schelkunoff's eq. (74) for the "
+                "tube, whose weak-skin limit the kilohertz end of the sweep "
+                "sits in -- the regime a strong-skin approximation gets wrong "
+                "by a factor approaching two.",
+        **_coax_pair(0.9e-3, 2.95e-3, ConstantDielectric(ep_r=2.25, tand=1e-3),
+                    RHO_COPPER, lambda f: _coax_ep_r(2.25, 1e-3, f=f),
+                    model="schelkunoff", rho_shield=RHO_STEEL,
+                    shield_thickness=25e-6),
+        length=0.5, z0=50.0,
+        tol=_SCHELKUNOFF_EXACT,
+    ),
+    Case(
+        id="thick_wall_shield_schelkunoff",
+        purpose="A 0.5 mm copper wall, thick enough that the shield is a "
+                "curved half-space above a megahertz and strongly coupled "
+                "below it, so the tube's transition is swept end to end.",
+        **_coax_pair(0.9e-3, 2.95e-3, ConstantDielectric(ep_r=2.25, tand=1e-3),
+                    RHO_COPPER, lambda f: _coax_ep_r(2.25, 1e-3, f=f),
+                    model="schelkunoff", shield_thickness=0.5e-3),
+        length=0.5, z0=50.0,
         tol=_SCHELKUNOFF_EXACT,
     ),
 ]


### PR DESCRIPTION
Implements the #113 stack in dependency order. Six commits, one per issue.

| Issue | Commit | What it does |
|---|---|---|
| #113 | `6e770377` | `ConductorProperties.gamma(omega)` becomes an explicit conductor property; no shape re-derives it from `sigma * zs` |
| #114 | `f5eb4cce` | Coax finite shield evaluates Schelkunoff eq. (74) referred to the inner surface, exponentially scaled; `inner_shape`/`shield_shape` become fields |
| #115 | `f4fdd006` | Planar cross-sections take geometry at call time; frequency renamed `omega`; the slab normalisation finding is recorded |
| #116 | `f589280c` | Typed per-family cross-section records replace the keyword bag; the legacy conductor-loss path is deleted |
| #117 | `7480b0c5` | Thickness reaches the current distribution whatever the formulation; Hammerstad–Jensen becomes the microstrip default |
| #118 | `f016ce6a` | `CONTEXT.md` and ADR 0001 record the vocabulary and the decisions |

Full suite: **550 passed, 28 skipped**.

## Three things to look at before merging

**#117 is a breaking numeric change.** Hammerstad–Jensen replaces Wheeler as the default microstrip formulation, with no compatibility shim — ADR 0001 is the migration note. No existing test regressed, because every scikit-rf comparison already passes `formulation=` explicitly.

**#114's DC limit is not the one the issue specified.** The issue asked for $1/(\sigma t)$; the exact eq. (74) limit is $2a/(\sigma(b^2-a^2))$, which is the thin-wall approximation of it — 1.5% apart at $t=25$ um, $a=1.6$ mm. The exact value is implemented so the DC branch and the series limit agree exactly, which is what the continuity criterion is after. Worth a nod.

**#115 criterion 3 is met in substance, not literally.** The blend's DC floor is per-unit-length while the cross-section layer returns ohm/sq, so $k Z_s$ reproduces $1/(\sigma W t)$ only if $Z_s$ carries $1/k$. No caller derives a number any more (width and thickness are the inputs), but the weight still rides to `RootSumSquareSlabShape` as an ordinary call-time argument that every other entry ignores. Folding it into the cross-section record would break the floor by ~1.5x; the reasoning is in the docstring and the test.

Closes #113, closes #114, closes #115, closes #116, closes #117, closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgLMLRzZCRjyuJSRLWz3og