### PR TITLE
Microstrip k_c: evaluate the incremental-inductance derivative

### DIFF
--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -100,6 +100,7 @@ from pmrf.models.components.lines.microstrip import (
     KirschningJansenMicrostripDispersion as KirschningJansenMicrostripDispersion,
     MicrostripCrossSection as MicrostripCrossSection,
     WheelerCurrentDistribution as WheelerCurrentDistribution,
+    IncrementalInductanceCurrentDistribution as IncrementalInductanceCurrentDistribution,
 )
 
 from pmrf.models.components.lines.stripline import (

--- a/pmrf/models/components/lines/__init__.py
+++ b/pmrf/models/components/lines/__init__.py
@@ -11,6 +11,7 @@ from pmrf.models.components.lines.planar import (
 from pmrf.models.components.lines.microstrip import (
     MicrostripCrossSection as MicrostripCrossSection,
     WheelerCurrentDistribution as WheelerCurrentDistribution,
+    IncrementalInductanceCurrentDistribution as IncrementalInductanceCurrentDistribution,
 )
 from pmrf.models.components.lines.stripline import (
     StriplineCrossSection as StriplineCrossSection,

--- a/pmrf/models/components/lines/microstrip.py
+++ b/pmrf/models/components/lines/microstrip.py
@@ -5,6 +5,7 @@ from abc import abstractmethod
 from typing import ClassVar
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 from scipy.constants import c, epsilon_0, mu_0
 
@@ -86,7 +87,20 @@ class WheelerCurrentDistribution(AbstractCurrentDistribution[MicrostripCrossSect
 
 
 class AbstractMicrostripFormulation(eqx.Module):
-    """Abstract base class for a closed-form microstrip formulation."""
+    """Abstract base class for a closed-form microstrip formulation.
+
+    :attr:`thickness_aware` declares whether ``quasi_static`` actually
+    responds to ``t``. It is opt-in: a formulation that ignores thickness
+    leaves it ``False``, which lets
+    :class:`IncrementalInductanceCurrentDistribution` refuse a pairing whose
+    recession derivative would silently miss the strip's top face and
+    sidewalls.
+    """
+
+    #: Whether ``quasi_static`` responds to the ``t`` argument. Opt-in: a
+    #: formulation derived for a zero-thickness strip leaves this ``False``.
+    thickness_aware: ClassVar[bool] = False
+
     @abstractmethod
     def quasi_static(self, *, w, h, t, ep_r) -> PlanarQuasiStaticResult:
         r"""
@@ -145,6 +159,10 @@ class WheelerMicrostripFormulation(AbstractMicrostripFormulation):
     Wheeler, H. A. (1977). Transmission-Line Properties of a Strip on a Dielectric Sheet on a Plane.
     IEEE Transactions on Microwave Theory and Techniques.
     """
+
+    #: The 1977 result is derived for a zero-thickness strip.
+    thickness_aware: ClassVar[bool] = False
+
     def quasi_static(self, *, w, h, t, ep_r) -> PlanarQuasiStaticResult:
         # t is accepted and ignored: the 1977 result is derived for a
         # zero-thickness strip, so thickness enters neither ep_eff nor zc. It
@@ -226,6 +244,9 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
     407-409.
     """
 
+    #: Finite thickness enters through the normalized-width corrections.
+    thickness_aware: ClassVar[bool] = True
+
     def quasi_static(self, *, w, h, t, ep_r) -> PlanarQuasiStaticResult:
         u = w / h
         thickness = None if t is None else t / h
@@ -263,6 +284,133 @@ class HammerstadJensenMicrostripFormulation(AbstractMicrostripFormulation):
         z0 = jnp.sqrt(mu_0 / epsilon_0)
         f_u = 6 + (2 * jnp.pi - 6) * jnp.exp(-(30.666 / u) ** 0.7528)
         return z0 / (2 * jnp.pi) * jnp.log(f_u / u + jnp.sqrt(1 + (2 / u) ** 2))
+
+
+class IncrementalInductanceCurrentDistribution(
+    AbstractCurrentDistribution[MicrostripCrossSection]
+):
+    r"""Wheeler's incremental-inductance rule, evaluated by autodiff.
+
+    This evaluates the rule itself rather than Wheeler's 1942 closed-form fit
+    to it, which is what :class:`WheelerCurrentDistribution` implements. It is
+    also distinct from :class:`WheelerMicrostripFormulation`, the 1977
+    quasi-static impedance approximation, which is a formulation and not a
+    current distribution.
+
+    **Mathematical Formulation**
+
+    The geometry weight is the rate of change of the air-filled impedance as
+    every conductor surface recedes into the metal by a distance $n$:
+
+    $$k_c = \frac{1}{Z_0}\frac{\partial}{\partial n}
+    Z_a(W-2n,\ H+2n,\ T-2n)\bigg|_{n=0}$$
+
+    The strip narrows by $2n$ and thins by $2n$, and the strip-to-ground gap
+    grows by $2n$ -- $n$ from the ground plane receding and $n$ from the
+    strip's underside. $Z_a$ is :attr:`formulation` evaluated at
+    $\varepsilon_r = 1$, so the derivative is taken on the same closed form
+    that supplies the line's impedance. It is taken with :func:`jax.grad`,
+    which is exact for a closed-form $Z_a$ and avoids the step-size problem a
+    finite difference would have here ($\partial Z_a/\partial n$ is of order
+    $10^5\ \Omega/\mathrm{m}$ against a $Z_a$ of order $10^2\ \Omega$).
+
+    The weight is real, frequency-independent, and differentiable in $W$, $H$
+    and $T$, exactly as Wheeler's fit is.
+
+    **Validity**
+
+    The derivative is taken on :attr:`formulation`'s own $Z_a$, so a
+    formulation that ignores $T$ cannot respond to the strip thinning and the
+    top face and sidewalls drop out of the weight entirely -- an
+    under-prediction of about 30% at $W/H = 2.5$. Both that pairing and an
+    unspecified thickness raise rather than degrade silently; supply a
+    thickness-aware formulation such as
+    :class:`HammerstadJensenMicrostripFormulation` and a cross-section with
+    ``t`` set.
+
+    **Departure from Wheeler's 1942 fit**
+
+    Against this derivative, the 1942 fit is *high*: 385.7 against 318.3 per
+    metre at $W/H = 2.5$ ($W$ = 4 mm, $H$ = 1.6 mm, $T$ = 35 um,
+    $\varepsilon_r$ = 4.335), a ratio of 0.825, closing to 0.958 by
+    $W/H = 50$. An independent 2D quasi-static field solve, a power-loss
+    surface-impedance integral, and a volumetric PEEC solve all land in
+    306-320 for that case.
+
+    This sign is disputed. A separate trace/ground current split, developed
+    from the same Holloway and Kuester source, reports the 1942 fit as 12-18%
+    *low* at strong skin effect. The two cannot both be right; the
+    contradiction is unresolved and is recorded rather than papered over.
+    Neither result changes the microstrip default, which remains
+    :class:`WheelerCurrentDistribution`.
+
+    Note also that the wide-line limit does not recover the $2/W$ prefactor of
+    the 1942 fit: at $W/H = 50$ the weight is 22.9 against $2/W$ = 25.0. The
+    $2/W$ argument assumes a zero-thickness strip and neglects fringing, and
+    with fringing $C_{air}$ is larger, so
+    $k_c = -\varepsilon_0 C^{-2}\,\partial C/\partial n$ falls below it.
+
+    References
+    ----------
+    Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
+    IRE, 30(9), 412-424.
+
+    Hammerstad, E., & Jensen, O. (1980). Accurate Models for Microstrip
+    Computer-Aided Design. IEEE MTT-S International Microwave Symposium
+    Digest, 407-409.
+    """
+
+    cross_section_type: ClassVar[type] = MicrostripCrossSection
+
+    #: The closed form supplying $Z_a$. It must be thickness-aware; see
+    #: **Validity**. This is deliberately a field of the distribution rather
+    #: than an argument of ``_distribute``, so that which $Z_a$ the derivative
+    #: is taken on is explicit.
+    formulation: AbstractMicrostripFormulation = eqx.field(
+        default_factory=HammerstadJensenMicrostripFormulation
+    )
+
+    #: Finite-thickness surface impedance. See
+    #: :class:`~pmrf.materials.surface_impedance.AbstractSurfaceImpedance` for
+    #: normalisation details.
+    slab_impedance: AbstractSurfaceImpedance = eqx.field(
+        default_factory=RootSumSquareSlabSurfaceImpedance
+    )
+
+    def _distribute(self, freq, cross_section, quasi_static):
+        if cross_section.t is None:
+            raise ValueError(
+                f"{type(self).__name__} needs a specified strip thickness: the "
+                "recession derivative is taken over the strip's top face and "
+                "sidewalls as well as its underside, and without t those "
+                "surfaces are absent from the weight (about 30% low at "
+                "w/h = 2.5). Set t on the cross-section, or use "
+                "WheelerCurrentDistribution."
+            )
+        if not type(self.formulation).thickness_aware:
+            raise ValueError(
+                f"{type(self).__name__} needs a thickness-aware formulation, "
+                f"but {type(self.formulation).__name__} ignores t, so the "
+                "recession derivative cannot see the strip thin (about 30% "
+                "low at w/h = 2.5). Use "
+                "HammerstadJensenMicrostripFormulation, or another "
+                "formulation declaring thickness_aware = True."
+            )
+
+        z0 = jnp.sqrt(mu_0 / epsilon_0)
+        w, h, t = cross_section.w, cross_section.h, cross_section.t
+        ones = jnp.ones_like(jnp.real(quasi_static.ep_eff))
+
+        def z_air(n):
+            # eps_r = 1 makes eps_eff = 1, so zc is Za, the air-filled
+            # impedance of the receded cross-section.
+            result = self.formulation.quasi_static(
+                w=w - 2 * n, h=h + 2 * n, t=t - 2 * n, ep_r=jnp.ones(())
+            )
+            return jnp.real(result.zc).reshape(-1)[0]
+
+        weight = jax.grad(z_air)(jnp.zeros(())) / z0
+        return ((self.slab_impedance, weight * ones),)
 
 
 class AbstractMicrostripDispersion(eqx.Module):

--- a/tests/test_models/test_current_distribution.py
+++ b/tests/test_models/test_current_distribution.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import pytest
 from scipy.constants import epsilon_0, mu_0
@@ -13,8 +14,10 @@ from pmrf.materials import (
 from pmrf.models import (
     CohnCurrentDistribution,
     HammerstadJensenMicrostripFormulation,
+    IncrementalInductanceCurrentDistribution,
     MicrostripLine,
     WheelerCurrentDistribution,
+    WheelerMicrostripFormulation,
 )
 from pmrf.models.components.lines.microstrip import MicrostripCrossSection
 from pmrf.models.components.lines.planar import PlanarQuasiStaticResult
@@ -137,3 +140,171 @@ def test_substrate_height_reaches_the_microstrip_distribution():
     line.immittance(freq)
 
     assert seen["h"] == line.substrate.h
+
+
+# The recession derivative against Wheeler's 1942 fit, at ep_r = 4.335,
+# h = 1.6 mm, t = 35 um, Hammerstad-Jensen. Columns are
+# (w/h, w, Re(Zc), Wheeler 1942 k_c, incremental-inductance k_c).
+_INCREMENTAL_INDUCTANCE_CASES = [
+    (2.5, 4.0e-3, 42.28, 385.69, 318.34),
+    (5.0, 8.0e-3, 25.96, 207.89, 178.62),
+    (10.0, 16.0e-3, 14.83, 110.35, 98.47),
+    (20.0, 32.0e-3, 8.06, 57.62, 53.24),
+    (50.0, 80.0e-3, 3.43, 23.91, 22.91),
+]
+
+
+def _incremental_inductance_weights(w, h=1.6e-3, t=35e-6, ep_r=4.335):
+    """Return ``(Re(Zc), Wheeler 1942 weight, recession-derivative weight)``."""
+    freq = Frequency.from_f(jnp.array([1e9]))
+    formulation = HammerstadJensenMicrostripFormulation()
+    quasi_static = formulation.quasi_static(
+        w=w, h=h, t=t, ep_r=jnp.array([ep_r + 0j])
+    )
+    cross_section = MicrostripCrossSection(
+        w=jnp.asarray(w), h=jnp.asarray(h), t=jnp.asarray(t)
+    )
+    (_, wheeler), = WheelerCurrentDistribution().distribute(
+        freq, cross_section, quasi_static
+    )
+    (_, incremental), = IncrementalInductanceCurrentDistribution(
+        formulation=formulation
+    ).distribute(freq, cross_section, quasi_static)
+    return jnp.real(quasi_static.zc)[0], wheeler[0], incremental[0]
+
+
+@pytest.mark.parametrize(
+    "w_over_h, w, zc_real, wheeler_kc, incremental_kc",
+    _INCREMENTAL_INDUCTANCE_CASES,
+)
+def test_incremental_inductance_reproduces_the_recession_derivative_table(
+    w_over_h, w, zc_real, wheeler_kc, incremental_kc
+):
+    """The derivative is evaluated, not fitted, so each case is exact.
+
+    Both columns are closed-form functions of the geometry, so the tolerance
+    is a rounding tolerance on the tabulated digits rather than a physics
+    allowance: each expected value is quoted to two decimals, so half a unit
+    in the last place is the whole budget. An independent 2D quasi-static
+    field solve agrees with the right-hand column to within 0.76% across
+    these five cases -- recorded here, not asserted, because it cannot be
+    reproduced in-repo.
+    """
+    zc, wheeler, incremental = _incremental_inductance_weights(w)
+
+    assert jnp.abs(zc - zc_real) <= 0.005
+    assert jnp.abs(wheeler - wheeler_kc) <= 0.005
+    assert jnp.abs(incremental - incremental_kc) <= 0.005
+
+    # Wheeler's 1942 fit is high against the derivative, by 21% at w/h = 2.5
+    # closing to 4% at w/h = 50. Recorded with its sign: a separate
+    # trace/ground split reports the opposite sign, and that contradiction is
+    # unresolved.
+    assert incremental < wheeler
+
+
+def test_incremental_inductance_wide_line_does_not_approach_two_over_w():
+    """The wide-line limit is not Wheeler's 2/W prefactor, and should not be.
+
+    2/W assumes a zero-thickness strip and neglects fringing. With fringing
+    the air-filled capacitance is larger, so
+    k_c = -eps_0 C^-2 dC/dn falls below 2/W. At w/h = 50 the ratio is 0.916
+    and it is still falling, so a test that asserted convergence to 2/W would
+    be asserting the wrong physics.
+    """
+    _, _, incremental = _incremental_inductance_weights(80.0e-3)
+
+    ratio = incremental / (2 / 80.0e-3)
+    assert 0.90 < ratio < 0.93
+    assert jnp.abs(ratio - 0.9165) <= 0.001
+
+
+def test_incremental_inductance_weight_is_differentiable_in_w_h_and_t():
+    """The fitting path needs gradients through the geometry weight itself."""
+    freq = Frequency.from_f(jnp.array([1e9]))
+    distribution = IncrementalInductanceCurrentDistribution()
+
+    def weight(w, h, t):
+        quasi_static = HammerstadJensenMicrostripFormulation().quasi_static(
+            w=w, h=h, t=t, ep_r=jnp.array([4.335 + 0j])
+        )
+        cross_section = MicrostripCrossSection(w=w, h=h, t=t)
+        (_, value), = distribution.distribute(freq, cross_section, quasi_static)
+        return value[0]
+
+    args = (jnp.asarray(4.0e-3), jnp.asarray(1.6e-3), jnp.asarray(35e-6))
+    grads = jax.grad(weight, argnums=(0, 1, 2))(*args)
+
+    assert all(jnp.isfinite(g) for g in grads)
+    # A wider strip spreads the current, so the weight falls with w.
+    assert grads[0] < 0
+
+    # And the derivative is a real one: a 1% step in w moves the weight by
+    # what the gradient predicts, to better than 1%.
+    step = 0.01 * args[0]
+    predicted = weight(*args) + grads[0] * step
+    actual = weight(args[0] + step, args[1], args[2])
+    assert jnp.abs(predicted - actual) < 0.01 * jnp.abs(actual - weight(*args))
+
+
+def test_incremental_inductance_refuses_a_thickness_blind_pairing():
+    """A formulation that ignores t cannot see the strip thin.
+
+    The top face and sidewalls would drop out of the weight entirely -- about
+    30% low at w/h = 2.5, an error of similar size to the one this
+    distribution exists to fix, and equally invisible behind a free sigma.
+    """
+    freq = Frequency.from_f(jnp.array([1e9]))
+    quasi_static = HammerstadJensenMicrostripFormulation().quasi_static(
+        w=4e-3, h=1.6e-3, t=35e-6, ep_r=jnp.array([4.335 + 0j])
+    )
+    cross_section = MicrostripCrossSection(w=4e-3, h=1.6e-3, t=35e-6)
+
+    with pytest.raises(ValueError, match="thickness-aware formulation"):
+        IncrementalInductanceCurrentDistribution(
+            formulation=WheelerMicrostripFormulation()
+        ).distribute(freq, cross_section, quasi_static)
+
+    assert HammerstadJensenMicrostripFormulation.thickness_aware
+    assert not WheelerMicrostripFormulation.thickness_aware
+
+
+def test_incremental_inductance_refuses_an_unspecified_thickness():
+    """Without t there is no top face or sidewall to recede."""
+    freq = Frequency.from_f(jnp.array([1e9]))
+    quasi_static = HammerstadJensenMicrostripFormulation().quasi_static(
+        w=4e-3, h=1.6e-3, t=None, ep_r=jnp.array([4.335 + 0j])
+    )
+
+    with pytest.raises(ValueError, match="specified strip thickness"):
+        IncrementalInductanceCurrentDistribution().distribute(
+            freq, MicrostripCrossSection(w=4e-3, h=1.6e-3), quasi_static
+        )
+
+
+def test_incremental_inductance_is_selectable_on_a_line_without_changing_the_default():
+    """It ships as a peer; WheelerCurrentDistribution stays the default."""
+    freq = Frequency.from_f(jnp.array([1e9]))
+
+    assert isinstance(
+        MicrostripLine(length=0.1).current_distribution, WheelerCurrentDistribution
+    )
+
+    line = MicrostripLine(
+        w=4e-3, h=1.6e-3, t=35e-6, length=0.1,
+        current_distribution=IncrementalInductanceCurrentDistribution(),
+    )
+    default = MicrostripLine(w=4e-3, h=1.6e-3, t=35e-6, length=0.1)
+
+    assert isinstance(
+        line.current_distribution, IncrementalInductanceCurrentDistribution
+    )
+    assert isinstance(
+        IncrementalInductanceCurrentDistribution().slab_impedance,
+        RootSumSquareSlabSurfaceImpedance,
+    )
+
+    # Lower k_c means lower conductor loss than the 1942 fit gives.
+    assert jnp.all(
+        jnp.real(line.immittance(freq).Z) < jnp.real(default.immittance(freq).Z)
+    )


### PR DESCRIPTION
Adds `IncrementalInductanceCurrentDistribution`, a peer of `WheelerCurrentDistribution` that evaluates Wheeler's incremental-inductance rule directly by `jax.grad` on the air-filled cross-section rather than using his 1942 closed-form fit. The microstrip default is unchanged.

- Own `formulation` field; weight is `grad(Re Zc(w-2n, h+2n, t-2n, ep_r=1))|_{n=0} / Z_0`.
- Raises on a thickness-blind formulation (new `thickness_aware` class flag) and on unspecified `t`, rather than silently under-predicting by 30%.
- Docstring records the departure from the 1942 fit **with its sign**, and the unresolved sign contradiction with #101.
- Tests: the five-row acceptance table with per-case tolerances, the wide-line non-`2/W` assertion with its reason, differentiability in `w`, `h`, `t`, and both raise paths.

Full suite: 560 passed, 28 skipped.

First PR in the chain for #122; stacks on `main`.

Closes #120