### PR TITLE
Trace/ground current split as a current-distribution strategy

### DIFF
--- a/pmrf/materials/surface_impedance.py
+++ b/pmrf/materials/surface_impedance.py
@@ -38,8 +38,10 @@ class AbstractSurfaceImpedance(eqx.Module):
     cannot reproduce both the dc resistance and strong-skin asymptote.
     :class:`RootSumSquareSlabSurfaceImpedance` uses the optional ``weight`` argument to
     match both limits and is therefore the planar default. A full
-    Holloway--Kuester treatment would require separate strip and ground-plane
-    weights, which ParamRF does not implement.
+    Holloway--Kuester treatment charges the strip and the ground plane on
+    separate weights; that is
+    :class:`~pmrf.models.components.lines.microstrip.TraceGroundCurrentDistribution`,
+    which emits one pair per surface.
     """
     @abstractmethod
     def impedance(self, omega, conductor: ConductorProperties, **geometry) -> jnp.ndarray:

--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -101,6 +101,8 @@ from pmrf.models.components.lines.microstrip import (
     MicrostripCrossSection as MicrostripCrossSection,
     WheelerCurrentDistribution as WheelerCurrentDistribution,
     IncrementalInductanceCurrentDistribution as IncrementalInductanceCurrentDistribution,
+    TraceGroundCurrentDistribution as TraceGroundCurrentDistribution,
+    microstrip_ground_effective_width as microstrip_ground_effective_width,
 )
 
 from pmrf.models.components.lines.stripline import (

--- a/pmrf/models/__init__.py
+++ b/pmrf/models/__init__.py
@@ -102,7 +102,6 @@ from pmrf.models.components.lines.microstrip import (
     WheelerCurrentDistribution as WheelerCurrentDistribution,
     IncrementalInductanceCurrentDistribution as IncrementalInductanceCurrentDistribution,
     TraceGroundCurrentDistribution as TraceGroundCurrentDistribution,
-    microstrip_ground_effective_width as microstrip_ground_effective_width,
 )
 
 from pmrf.models.components.lines.stripline import (

--- a/pmrf/models/components/lines/__init__.py
+++ b/pmrf/models/components/lines/__init__.py
@@ -12,6 +12,8 @@ from pmrf.models.components.lines.microstrip import (
     MicrostripCrossSection as MicrostripCrossSection,
     WheelerCurrentDistribution as WheelerCurrentDistribution,
     IncrementalInductanceCurrentDistribution as IncrementalInductanceCurrentDistribution,
+    TraceGroundCurrentDistribution as TraceGroundCurrentDistribution,
+    microstrip_ground_effective_width as microstrip_ground_effective_width,
 )
 from pmrf.models.components.lines.stripline import (
     StriplineCrossSection as StriplineCrossSection,

--- a/pmrf/models/components/lines/__init__.py
+++ b/pmrf/models/components/lines/__init__.py
@@ -13,7 +13,6 @@ from pmrf.models.components.lines.microstrip import (
     WheelerCurrentDistribution as WheelerCurrentDistribution,
     IncrementalInductanceCurrentDistribution as IncrementalInductanceCurrentDistribution,
     TraceGroundCurrentDistribution as TraceGroundCurrentDistribution,
-    microstrip_ground_effective_width as microstrip_ground_effective_width,
 )
 from pmrf.models.components.lines.stripline import (
     StriplineCrossSection as StriplineCrossSection,

--- a/pmrf/models/components/lines/microstrip.py
+++ b/pmrf/models/components/lines/microstrip.py
@@ -337,8 +337,9 @@ class IncrementalInductanceCurrentDistribution(
     surface-impedance integral, and a volumetric PEEC solve all land in
     306-320 for that case.
 
-    This sign is disputed. A separate trace/ground current split, developed
-    from the same Holloway and Kuester source, reports the 1942 fit as 12-18%
+    This sign is disputed. :class:`TraceGroundCurrentDistribution`, a
+    trace/ground current split developed from the same Holloway and Kuester
+    source, reports the 1942 fit as 12-18%
     *low* at strong skin effect. The two cannot both be right; the
     contradiction is unresolved and is recorded rather than papered over.
     Neither result changes the microstrip default, which remains
@@ -411,6 +412,186 @@ class IncrementalInductanceCurrentDistribution(
 
         weight = jax.grad(z_air)(jnp.zeros(())) / z0
         return ((self.slab_impedance, weight * ones),)
+
+
+def microstrip_ground_effective_width(w, h):
+    r"""Effective width of the ground-plane return current, in metres.
+
+    **Mathematical Formulation**
+
+    Holloway and Kuester's quasi-static ground-plane current density for a
+    strip of width $W$ at height $H$ is the strip's own current convolved
+    with the image-filament kernel $\,[\pi H(1+(x/H)^2)]^{-1}$. Referring the
+    ground loss to the total line current defines an effective width
+    $W_g = I^2\big/\!\int J_g^2\,\mathrm{d}x$, which Parseval's theorem
+    reduces in closed form. With $u = W/H$,
+
+    $$\frac{W_g}{W} = \frac{\pi u}
+    {2\left[u\arctan(u/2) - \ln\!\left(1 + u^2/4\right)\right]}.$$
+
+    The limits are $W_g \to 2\pi H$ for a narrow strip -- the filament result,
+    independent of $W$ -- and $W_g \to W$ for a wide one, where the return
+    current is confined under the trace. Representative values are
+    $W_g/W$ = 3.667, 3.896 and 14.394 at $u$ = 1.94, 1.80 and 0.44.
+
+    Parameters
+    ----------
+    w : ArrayLike
+        Width of the strip in meters.
+    h : ArrayLike
+        Substrate height in meters.
+
+    Returns
+    -------
+    jnp.ndarray
+        Effective ground-plane width in meters.
+
+    References
+    ----------
+    Holloway, C. L., & Kuester, E. F. (1994). Edge shape effects and
+    quasi-closed form expressions for the conductor loss of microstrip
+    lines. Radio Science, 29(3), 539-559.
+    """
+    u = w / h
+    return jnp.pi * w * u / (
+        2 * (u * jnp.arctan(u / 2) - jnp.log1p(u**2 / 4))
+    )
+
+
+class TraceGroundCurrentDistribution(
+    AbstractCurrentDistribution[MicrostripCrossSection]
+):
+    r"""Trace and ground plane charged as separate surfaces.
+
+    Wheeler's rule bundles the strip faces, the edge-current crowding and the
+    ground plane into a single geometry weight, so the ground plane's share of
+    conductor loss is invisible inside it. This strategy emits one
+    ``(impedance, weight)`` pair per surface -- the trace and the ground plane
+    -- each with its own surface impedance and its own width scaling, so the
+    two can carry different frequency behaviour and different dc limits.
+
+    It is a **peer** of :class:`WheelerCurrentDistribution` and of
+    :class:`IncrementalInductanceCurrentDistribution`, not a correction of
+    either, and it is not the microstrip default; see **Departures** below.
+
+    **Mathematical Formulation**
+
+    The trace keeps Wheeler's incremental-inductance weight, which is the
+    quantity his exponential was fitted for,
+
+    $$k_t = \frac{2}{W}K_i,\qquad
+    K_i = \exp\left[-1.2\left(\frac{\Re(Z_c)}{Z_0}\right)^{0.7}\right],$$
+
+    paired with :attr:`slab_impedance`, whose dc floor is expressed in the
+    caller's normalisation and therefore returns the trace's exact dc
+    resistance $1/(\sigma W T)$ whatever $k_t$ is.
+
+    The ground plane is charged separately at
+
+    $$k_g = \frac{1}{W_g},$$
+
+    with $W_g$ the effective width of the ground-plane return current from
+    :func:`microstrip_ground_effective_width`. The two pairs are summed by the
+    caller, so the total weight is $k_t + k_g$.
+
+    **Resolved choice: $K_i$ is applied to the trace only**
+
+    Wheeler's exponential is a fit to current crowding at the *strip's* edges,
+    so applying it to the ground plane would be convenient rather than
+    justified. It is therefore not applied there. The choice is worth about
+    4-5% of the total weight: at $\Re(Z_c)$ = 48.9 ohm the total is
+    $1.773/W$ as implemented against $1.705/W$ with $K_i$ on both terms.
+
+    **Resolved choice: the ground term has no dc limit of its own**
+
+    The trace anchors cleanly at $1/(\sigma W T)$. The ground plane does not:
+    at dc the return current spreads over the whole plane rather than over the
+    substrate-height-scale distribution above, so its dc resistance depends on
+    the plane's extent and copper weight, neither of which is an input to a
+    microstrip cross-section. The ground term is therefore held at its
+    strong-skin form -- :class:`HalfSpaceSurfaceImpedance` by default, which
+    vanishes as $\sqrt{\omega}$ and contributes nothing at dc. The dc limit of
+    the default configuration is exactly the trace's dc resistance. A user who
+    knows the plane geometry can supply a different
+    :attr:`ground_impedance`. This choice only became visible once the weight
+    was split; it was previously hidden inside Wheeler's constant.
+
+    **Departures, with their signs**
+
+    At $W$ = 4 mm, $H$ = 1.6 mm, $T$ = 35 um, $\varepsilon_r$ = 4.335
+    ($W/H$ = 2.5, $\Re(Z_c)$ = 42.28 ohm), the strong-skin weights are
+
+    - this split, $k_t + k_g$: 468.4 per metre
+    - :class:`WheelerCurrentDistribution` (the 1942 fit): 385.7 per metre, so
+      the split is 21.4% **high** against it
+    - :class:`IncrementalInductanceCurrentDistribution` (the recession
+      derivative): 318.3 per metre, so the split is 47.1% **high** against it
+
+    So this split reports Wheeler's fit as *low* at strong skin effect,
+    consistent with Holloway and Kuester's reported 12-30% underprediction of
+    measured loss, while
+    :class:`IncrementalInductanceCurrentDistribution` -- developed from the
+    same source, and backed by an independent 2D field solve, a power-loss
+    surface-impedance integral and a volumetric PEEC solve -- reports it as
+    *high*. **The two cannot both be right.** The contradiction is recorded
+    rather than resolved, neither strategy is described as more accurate than
+    the other, and the microstrip default remains
+    :class:`WheelerCurrentDistribution` until it is settled.
+
+    **Validity**
+
+    $W_g$ is quasi-static and assumes a uniform strip current, so it degrades
+    where the strip's own edge singularity dominates the ground distribution.
+    The ground term carries no dc physics at all; see above. An unspecified
+    thickness falls back to :class:`HalfSpaceSurfaceImpedance` on the trace,
+    which removes the dc floor with it.
+
+    References
+    ----------
+    Holloway, C. L., & Kuester, E. F. (1994). Edge shape effects and
+    quasi-closed form expressions for the conductor loss of microstrip
+    lines. Radio Science, 29(3), 539-559.
+
+    Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
+    IRE, 30(9), 412-424.
+    """
+
+    cross_section_type: ClassVar[type] = MicrostripCrossSection
+
+    #: Finite-thickness surface impedance for the trace. Its dc floor is what
+    #: anchors the default configuration's dc resistance at $1/(\sigma WT)$.
+    slab_impedance: AbstractSurfaceImpedance = eqx.field(
+        default_factory=RootSumSquareSlabSurfaceImpedance
+    )
+
+    #: Surface impedance of the ground plane. The default is the strong-skin
+    #: half-space, which carries no dc floor -- a deliberate choice, since the
+    #: plane's dc resistance is not a function of the cross-section.
+    ground_impedance: AbstractSurfaceImpedance = eqx.field(
+        default_factory=HalfSpaceSurfaceImpedance
+    )
+
+    def _distribute(self, freq, cross_section, quasi_static):
+        z0 = jnp.sqrt(mu_0 / epsilon_0)
+        w, h = cross_section.w, cross_section.h
+
+        # K_i is a strip-edge crowding fit and is deliberately not applied to
+        # the ground term; see the class docstring.
+        crowding = jnp.exp(-1.2 * (jnp.real(quasi_static.zc) / z0) ** 0.7)
+        trace_weight = 2 / w * crowding
+        ground_weight = jnp.ones_like(trace_weight) / (
+            microstrip_ground_effective_width(w, h)
+        )
+
+        trace_impedance = (
+            HalfSpaceSurfaceImpedance()
+            if cross_section.t is None
+            else self.slab_impedance
+        )
+        return (
+            (trace_impedance, trace_weight),
+            (self.ground_impedance, ground_weight),
+        )
 
 
 class AbstractMicrostripDispersion(eqx.Module):

--- a/pmrf/models/components/lines/microstrip.py
+++ b/pmrf/models/components/lines/microstrip.py
@@ -414,7 +414,7 @@ class IncrementalInductanceCurrentDistribution(
         return ((self.slab_impedance, weight * ones),)
 
 
-def microstrip_ground_effective_width(w, h):
+def _ground_return_effective_width(w, h):
     r"""Effective width of the ground-plane return current, in metres.
 
     **Mathematical Formulation**
@@ -491,51 +491,41 @@ class TraceGroundCurrentDistribution(
     $$k_g = \frac{1}{W_g},$$
 
     with $W_g$ the effective width of the ground-plane return current from
-    :func:`microstrip_ground_effective_width`. The two pairs are summed by the
+    :func:`_ground_return_effective_width`. The two pairs are summed by the
     caller, so the total weight is $k_t + k_g$.
 
-    **Resolved choice: $K_i$ is applied to the trace only**
+    **Resolved choices**
 
-    Wheeler's exponential is a fit to current crowding at the *strip's* edges,
-    so applying it to the ground plane would be convenient rather than
-    justified. It is therefore not applied there. The choice is worth about
-    4-5% of the total weight: at $\Re(Z_c)$ = 48.9 ohm the total is
-    $1.773/W$ as implemented against $1.705/W$ with $K_i$ on both terms.
+    $K_i$ is applied to the trace only: Wheeler's exponential is a fit to
+    crowding at the *strip's* edges, so charging the ground plane with it
+    would be convenient rather than justified. It is worth 4-5% of the total
+    weight -- at $\Re(Z_c)$ = 48.9 ohm, $1.773/W$ as implemented against
+    $1.705/W$ with $K_i$ on both terms.
 
-    **Resolved choice: the ground term has no dc limit of its own**
-
-    The trace anchors cleanly at $1/(\sigma W T)$. The ground plane does not:
-    at dc the return current spreads over the whole plane rather than over the
-    substrate-height-scale distribution above, so its dc resistance depends on
-    the plane's extent and copper weight, neither of which is an input to a
-    microstrip cross-section. The ground term is therefore held at its
-    strong-skin form -- :class:`HalfSpaceSurfaceImpedance` by default, which
-    vanishes as $\sqrt{\omega}$ and contributes nothing at dc. The dc limit of
-    the default configuration is exactly the trace's dc resistance. A user who
-    knows the plane geometry can supply a different
-    :attr:`ground_impedance`. This choice only became visible once the weight
-    was split; it was previously hidden inside Wheeler's constant.
+    The ground term has no dc limit of its own. At dc the return current
+    spreads over the whole plane, so its resistance depends on the plane's
+    extent and copper weight, neither of which is a cross-section input. It is
+    therefore held at its strong-skin form -- :class:`HalfSpaceSurfaceImpedance`
+    by default, which vanishes as $\sqrt{\omega}$ -- making the dc limit
+    exactly the trace's. Supply a different :attr:`ground_impedance` if the
+    plane geometry is known.
 
     **Departures, with their signs**
 
     At $W$ = 4 mm, $H$ = 1.6 mm, $T$ = 35 um, $\varepsilon_r$ = 4.335
-    ($W/H$ = 2.5, $\Re(Z_c)$ = 42.28 ohm), the strong-skin weights are
+    ($W/H$ = 2.5), the strong-skin weights are 468.4 per metre for this split,
+    385.7 for :class:`WheelerCurrentDistribution` and 318.3 for
+    :class:`IncrementalInductanceCurrentDistribution` -- so the split is 21.4%
+    **high** against Wheeler's 1942 fit and 47.1% **high** against the
+    recession derivative.
 
-    - this split, $k_t + k_g$: 468.4 per metre
-    - :class:`WheelerCurrentDistribution` (the 1942 fit): 385.7 per metre, so
-      the split is 21.4% **high** against it
-    - :class:`IncrementalInductanceCurrentDistribution` (the recession
-      derivative): 318.3 per metre, so the split is 47.1% **high** against it
-
-    So this split reports Wheeler's fit as *low* at strong skin effect,
-    consistent with Holloway and Kuester's reported 12-30% underprediction of
-    measured loss, while
-    :class:`IncrementalInductanceCurrentDistribution` -- developed from the
-    same source, and backed by an independent 2D field solve, a power-loss
-    surface-impedance integral and a volumetric PEEC solve -- reports it as
-    *high*. **The two cannot both be right.** The contradiction is recorded
-    rather than resolved, neither strategy is described as more accurate than
-    the other, and the microstrip default remains
+    This split therefore reports Wheeler's fit as *low*, consistent with
+    Holloway and Kuester's reported 12-30% underprediction of measured loss,
+    while :class:`IncrementalInductanceCurrentDistribution` -- from the same
+    source, backed by an independent 2D field solve, a power-loss integral and
+    a volumetric PEEC solve -- reports it as *high*. **The two cannot both be
+    right.** The contradiction is recorded rather than resolved; neither is
+    described as the more accurate, and the microstrip default remains
     :class:`WheelerCurrentDistribution` until it is settled.
 
     **Validity**
@@ -580,7 +570,7 @@ class TraceGroundCurrentDistribution(
         crowding = jnp.exp(-1.2 * (jnp.real(quasi_static.zc) / z0) ** 0.7)
         trace_weight = 2 / w * crowding
         ground_weight = jnp.ones_like(trace_weight) / (
-            microstrip_ground_effective_width(w, h)
+            _ground_return_effective_width(w, h)
         )
 
         trace_impedance = (

--- a/tests/test_models/test_current_distribution.py
+++ b/tests/test_models/test_current_distribution.py
@@ -16,8 +16,10 @@ from pmrf.models import (
     HammerstadJensenMicrostripFormulation,
     IncrementalInductanceCurrentDistribution,
     MicrostripLine,
+    TraceGroundCurrentDistribution,
     WheelerCurrentDistribution,
     WheelerMicrostripFormulation,
+    microstrip_ground_effective_width,
 )
 from pmrf.models.components.lines.microstrip import MicrostripCrossSection
 from pmrf.models.components.lines.planar import PlanarQuasiStaticResult
@@ -308,3 +310,236 @@ def test_incremental_inductance_is_selectable_on_a_line_without_changing_the_def
     assert jnp.all(
         jnp.real(line.immittance(freq).Z) < jnp.real(default.immittance(freq).Z)
     )
+
+
+# ---------------------------------------------------------------------------
+# Trace/ground split (issue #101)
+# ---------------------------------------------------------------------------
+
+#: ``(u, W_g/W, relative tolerance)``. The first two entries are quoted to
+#: three significant figures and the closed form reproduces them exactly; the
+#: third is quoted as 14.5 against 14.394, which is a rounding of the source
+#: table rather than a disagreement, so it carries its own looser tolerance
+#: instead of the global one being widened.
+_GROUND_WIDTH_CASES = [
+    (1.94, 3.67, 2e-3),
+    (1.80, 3.90, 2e-3),
+    (0.44, 14.5, 8e-3),
+]
+
+
+@pytest.mark.parametrize("u, wg_over_w, rtol", _GROUND_WIDTH_CASES)
+def test_ground_effective_width_reproduces_the_holloway_kuester_table(
+    u, wg_over_w, rtol
+):
+    """W_g follows from Holloway and Kuester's ground-plane current density.
+
+    The closed form is the Parseval reduction of
+    ``W_g = I^2 / int J_g^2 dx`` for the strip's current convolved with the
+    image-filament kernel. A direct numerical convolution and quadrature of
+    that integral agrees with it to five significant figures.
+    """
+    h = 1.6e-3
+    ratio = microstrip_ground_effective_width(u * h, h) / (u * h)
+
+    assert jnp.abs(ratio / wg_over_w - 1) <= rtol
+
+
+def test_ground_effective_width_has_the_right_narrow_and_wide_limits():
+    """Filament at 2*pi*H when narrow; confined to the trace when wide."""
+    h = 1.6e-3
+
+    narrow = microstrip_ground_effective_width(1e-4 * h, h)
+    assert jnp.abs(narrow / (2 * jnp.pi * h) - 1) <= 1e-6
+
+    # Convergence to W is only logarithmic -- the residual is
+    # 4 ln(u/2)/(pi u), still 1.2e-3 at u = 1e4 -- so the limit is checked
+    # where that residual is small rather than by loosening the tolerance.
+    wide = microstrip_ground_effective_width(1e6 * h, h)
+    assert jnp.abs(wide / (1e6 * h) - 1) <= 3e-5
+
+
+def test_trace_ground_emits_one_pair_per_surface_with_independent_weights():
+    """Two surfaces, two surface impedances, two weights."""
+    freq = Frequency(start=1.0, stop=10.0, npoints=2, unit="GHz")
+    zc = jnp.array([50.0, 60.0])
+    cross_section = MicrostripCrossSection(w=3e-3, h=1.6e-3, t=35e-6)
+
+    pairs = TraceGroundCurrentDistribution().distribute(
+        freq, cross_section, _solved(zc)
+    )
+
+    assert len(pairs) == 2
+    (trace_impedance, trace_weight), (ground_impedance, ground_weight) = pairs
+
+    z0 = jnp.sqrt(mu_0 / epsilon_0)
+    crowding = jnp.exp(-1.2 * (zc / z0) ** 0.7)
+    assert jnp.allclose(trace_weight, 2 / 3e-3 * crowding)
+
+    # K_i is a strip-edge fit and is deliberately not applied to the ground
+    # term, so the ground weight is flat in Zc where the trace weight is not.
+    expected_ground = 1 / microstrip_ground_effective_width(3e-3, 1.6e-3)
+    assert jnp.allclose(ground_weight, expected_ground)
+    assert not jnp.allclose(ground_weight[0], ground_weight[0] * crowding[0])
+
+    assert isinstance(trace_impedance, RootSumSquareSlabSurfaceImpedance)
+    assert isinstance(ground_impedance, HalfSpaceSurfaceImpedance)
+    assert trace_impedance is not ground_impedance
+
+
+def test_trace_ground_surface_impedances_are_independently_selectable():
+    """Each surface carries its own formulation, not a shared one."""
+    freq = Frequency.from_f(jnp.array([1e9]))
+    distribution = TraceGroundCurrentDistribution(
+        slab_impedance=HollowayKuesterSlabSurfaceImpedance(),
+        ground_impedance=RootSumSquareSlabSurfaceImpedance(),
+    )
+
+    pairs = distribution.distribute(
+        freq,
+        MicrostripCrossSection(w=3e-3, h=1.6e-3, t=35e-6),
+        _solved(jnp.array([50.0])),
+    )
+
+    assert isinstance(pairs[0][0], HollowayKuesterSlabSurfaceImpedance)
+    assert isinstance(pairs[1][0], RootSumSquareSlabSurfaceImpedance)
+
+
+def test_trace_ground_dc_limit_is_the_traces_true_dc_resistance():
+    """The default configuration anchors at 1/(sigma*W*t), exactly.
+
+    The trace's root-sum-square slab expresses its dc floor in the caller's
+    normalisation, so the trace term returns the true dc resistance whatever
+    its weight is. The ground term is deliberately held at its strong-skin
+    form -- the plane's dc resistance depends on its extent and copper weight,
+    which are not cross-section inputs -- and a half-space impedance vanishes
+    at dc, so it contributes nothing here.
+    """
+    w, t, sigma = 4e-3, 35e-6, 5.8e7
+    freq = Frequency(start=0.0, stop=1e9, npoints=3, unit="Hz")
+    line = MicrostripLine(
+        w=w, h=1.6e-3, t=t, length=1.0,
+        dielectric=ConstantDielectric(ep_r=4.335),
+        conductor=BulkConductor(sigma=sigma),
+        current_distribution=TraceGroundCurrentDistribution(),
+    )
+
+    r_dc = jnp.real(line.immittance(freq).Z)[0]
+
+    assert jnp.abs(r_dc / (1 / (sigma * w * t)) - 1) <= 1e-12
+
+
+def test_trace_ground_strong_skin_departs_from_wheeler_and_the_derivative():
+    """Recorded with its sign against both peers, and against neither's favour.
+
+    This split reports Wheeler's 1942 fit as *low* at strong skin effect,
+    consistent with Holloway and Kuester's reported 12-30% underprediction of
+    measured loss. IncrementalInductanceCurrentDistribution, developed from
+    the same source, reports it as *high*. The two cannot both be right; the
+    contradiction is unresolved and is asserted here rather than papered over.
+    """
+    w, h, t = 4.0e-3, 1.6e-3, 35e-6
+    freq = Frequency.from_f(jnp.array([1e9]))
+    formulation = HammerstadJensenMicrostripFormulation()
+    quasi_static = formulation.quasi_static(
+        w=w, h=h, t=t, ep_r=jnp.array([4.335 + 0j])
+    )
+    cross_section = MicrostripCrossSection(
+        w=jnp.asarray(w), h=jnp.asarray(h), t=jnp.asarray(t)
+    )
+
+    pairs = TraceGroundCurrentDistribution().distribute(
+        freq, cross_section, quasi_static
+    )
+    split = sum(weight[0] for _, weight in pairs)
+
+    (_, wheeler), = WheelerCurrentDistribution().distribute(
+        freq, cross_section, quasi_static
+    )
+    (_, incremental), = IncrementalInductanceCurrentDistribution(
+        formulation=formulation
+    ).distribute(freq, cross_section, quasi_static)
+
+    # Each value is a closed form of the geometry, so the tolerance is a
+    # rounding tolerance on the digits recorded in the docstring.
+    assert jnp.abs(split - 468.4) <= 0.05
+    assert jnp.abs(wheeler[0] - 385.69) <= 0.005
+    assert jnp.abs(incremental[0] - 318.34) <= 0.005
+
+    # The signs, which is the whole point of this test.
+    assert jnp.abs(split / wheeler[0] - 1.214) <= 1e-3
+    assert jnp.abs(split / incremental[0] - 1.471) <= 1e-3
+    assert split > wheeler[0] > incremental[0]
+
+
+def test_trace_ground_is_selectable_and_is_not_the_microstrip_default():
+    """It ships as a peer; WheelerCurrentDistribution stays the default."""
+    assert isinstance(
+        MicrostripLine(length=0.1).current_distribution, WheelerCurrentDistribution
+    )
+
+    line = MicrostripLine(
+        w=4e-3, h=1.6e-3, t=35e-6, length=0.1,
+        current_distribution=TraceGroundCurrentDistribution(),
+    )
+
+    assert isinstance(
+        line.current_distribution, TraceGroundCurrentDistribution
+    )
+    assert isinstance(
+        TraceGroundCurrentDistribution().slab_impedance,
+        RootSumSquareSlabSurfaceImpedance,
+    )
+    assert isinstance(
+        TraceGroundCurrentDistribution().ground_impedance,
+        HalfSpaceSurfaceImpedance,
+    )
+
+
+def test_frequency_dependent_weights_reach_the_series_impedance():
+    """A per-surface weight may vary with frequency, end to end.
+
+    The split's own weights are frequency-independent, but the pair interface
+    permits frequency dependence and the line has to honour it. A weight that
+    doubles across the sweep must double that surface's contribution to Z.
+    """
+    freq = Frequency.from_f(jnp.array([1e9, 2e9]))
+    scale = jnp.array([1.0, 2.0])
+
+    class ScaledGround(TraceGroundCurrentDistribution):
+        def _distribute(self, freq, cross_section, quasi_static):
+            trace, (impedance, weight) = super()._distribute(
+                freq, cross_section, quasi_static
+            )
+            return (trace, (impedance, weight * scale))
+
+    kwargs = dict(
+        w=4e-3, h=1.6e-3, t=35e-6, length=1.0,
+        dielectric=ConstantDielectric(ep_r=4.335),
+        conductor=BulkConductor(sigma=5.8e7),
+    )
+    flat = MicrostripLine(
+        current_distribution=TraceGroundCurrentDistribution(), **kwargs
+    )
+    scaled = MicrostripLine(current_distribution=ScaledGround(), **kwargs)
+
+    pairs = TraceGroundCurrentDistribution().distribute(
+        freq,
+        MicrostripCrossSection(w=4e-3, h=1.6e-3, t=35e-6),
+        HammerstadJensenMicrostripFormulation().quasi_static(
+            w=4e-3, h=1.6e-3, t=35e-6, ep_r=jnp.array([4.335 + 0j, 4.335 + 0j])
+        ),
+    )
+    ground_impedance, ground_weight = pairs[1]
+    conductor = BulkConductor(sigma=5.8e7).properties(freq)
+    ground_term = jnp.real(
+        ground_impedance.impedance(
+            freq.w, conductor, w=4e-3, t=35e-6, weight=ground_weight
+        )
+        * ground_weight
+    )
+
+    difference = jnp.real(scaled.immittance(freq).Z - flat.immittance(freq).Z)
+
+    assert jnp.abs(difference[0]) <= 1e-9 * ground_term[0]
+    assert jnp.abs(difference[1] / ground_term[1] - 1.0) <= 1e-9

--- a/tests/test_models/test_current_distribution.py
+++ b/tests/test_models/test_current_distribution.py
@@ -19,9 +19,11 @@ from pmrf.models import (
     TraceGroundCurrentDistribution,
     WheelerCurrentDistribution,
     WheelerMicrostripFormulation,
-    microstrip_ground_effective_width,
 )
-from pmrf.models.components.lines.microstrip import MicrostripCrossSection
+from pmrf.models.components.lines.microstrip import (
+    MicrostripCrossSection,
+    _ground_return_effective_width,
+)
 from pmrf.models.components.lines.planar import PlanarQuasiStaticResult
 from pmrf.models.components.lines.stripline import StriplineCrossSection
 
@@ -340,7 +342,7 @@ def test_ground_effective_width_reproduces_the_holloway_kuester_table(
     that integral agrees with it to five significant figures.
     """
     h = 1.6e-3
-    ratio = microstrip_ground_effective_width(u * h, h) / (u * h)
+    ratio = _ground_return_effective_width(u * h, h) / (u * h)
 
     assert jnp.abs(ratio / wg_over_w - 1) <= rtol
 
@@ -349,13 +351,13 @@ def test_ground_effective_width_has_the_right_narrow_and_wide_limits():
     """Filament at 2*pi*H when narrow; confined to the trace when wide."""
     h = 1.6e-3
 
-    narrow = microstrip_ground_effective_width(1e-4 * h, h)
+    narrow = _ground_return_effective_width(1e-4 * h, h)
     assert jnp.abs(narrow / (2 * jnp.pi * h) - 1) <= 1e-6
 
     # Convergence to W is only logarithmic -- the residual is
     # 4 ln(u/2)/(pi u), still 1.2e-3 at u = 1e4 -- so the limit is checked
     # where that residual is small rather than by loosening the tolerance.
-    wide = microstrip_ground_effective_width(1e6 * h, h)
+    wide = _ground_return_effective_width(1e6 * h, h)
     assert jnp.abs(wide / (1e6 * h) - 1) <= 3e-5
 
 
@@ -378,7 +380,7 @@ def test_trace_ground_emits_one_pair_per_surface_with_independent_weights():
 
     # K_i is a strip-edge fit and is deliberately not applied to the ground
     # term, so the ground weight is flat in Zc where the trace weight is not.
-    expected_ground = 1 / microstrip_ground_effective_width(3e-3, 1.6e-3)
+    expected_ground = 1 / _ground_return_effective_width(3e-3, 1.6e-3)
     assert jnp.allclose(ground_weight, expected_ground)
     assert not jnp.allclose(ground_weight[0], ground_weight[0] * crowding[0])
 


### PR DESCRIPTION
Adds `TraceGroundCurrentDistribution`, a microstrip strategy that charges the trace and the ground plane separately, each with its own surface impedance and width scaling. It ships **selectable**; `WheelerCurrentDistribution` remains the microstrip default.

- `microstrip_ground_effective_width(w, h)` gives the Holloway & Kuester ground-plane return-current effective width in closed form; the tabulated `W_g/W` values are reproduced as a test with per-case tolerances.
- Trace weight is Wheeler's `2K_i/W`; `K_i` is applied to the trace only, with the reason and the 4-5% cost of the alternative documented.
- The ground term has no dc limit of its own (`HalfSpaceSurfaceImpedance` by default, which vanishes at dc), so the dc limit is exactly the trace's `1/(sigma W t)`. Documented as deliberate, with the `ground_impedance` escape hatch.
- Strong-skin departures are recorded **with their sign**: at `w/h = 2.5` the split is 21.4% high against Wheeler and 47.1% high against #120's incremental-inductance derivative. Neither is described as more accurate; #103 carries the record.

Full suite: 570 passed, 28 skipped.

Stacks on #125 (#120).

Closes #101