### PR TITLE
Document the slab surface-impedance default against half-space external solvers

### DIFF
--- a/pmrf/models/components/lines/microstrip.py
+++ b/pmrf/models/components/lines/microstrip.py
@@ -62,6 +62,28 @@ class WheelerCurrentDistribution(AbstractCurrentDistribution[MicrostripCrossSect
     :class:`HalfSpaceSurfaceImpedance`; otherwise, the distribution uses
     :attr:`slab_impedance`. The returned weight is in inverse metres.
 
+    **Validating against an external 3D solver**
+
+    :attr:`slab_impedance` defaults to
+    :class:`RootSumSquareSlabSurfaceImpedance`, which corrects for finite
+    strip thickness. At least one widely used commercial 3D solver applies a
+    plain half-space
+
+    $$Z_s = (1+j)\sqrt{\pi f \mu_0 / \sigma}$$
+
+    and ignores thickness entirely. Over $t/\delta$ = 3.7-6.0 the two models
+    differ by 2-5%, so a cross-tool comparison that leaves the default in
+    place charges the solver for a thickness correction it never applied and
+    attributes the resulting 2-5% discrepancy to one tool or the other when it
+    is purely a difference in surface-impedance model. Pass
+    ``slab_impedance=HalfSpaceSurfaceImpedance()`` explicitly for such a
+    comparison, and check where your band sits relative to that
+    $t/\delta$ range before deciding whether it matters.
+
+    This is not a defect in the default:
+    :class:`RootSumSquareSlabSurfaceImpedance` is the more defensible physics
+    and remains the default. It is a trap only for cross-tool validation.
+
     References
     ----------
     Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
@@ -71,7 +93,9 @@ class WheelerCurrentDistribution(AbstractCurrentDistribution[MicrostripCrossSect
     cross_section_type: ClassVar[type] = MicrostripCrossSection
 
     #: Finite-thickness surface impedance. The default matches the dc and
-    #: strong-skin limits under Wheeler's geometry weight. See
+    #: strong-skin limits under Wheeler's geometry weight. Validating against
+    #: an external half-space solver needs ``HalfSpaceSurfaceImpedance()``
+    #: passed here explicitly; see the class docstring. See
     #: :class:`~pmrf.materials.surface_impedance.AbstractSurfaceImpedance` for
     #: normalisation details.
     slab_impedance: AbstractSurfaceImpedance = eqx.field(
@@ -351,6 +375,19 @@ class IncrementalInductanceCurrentDistribution(
     with fringing $C_{air}$ is larger, so
     $k_c = -\varepsilon_0 C^{-2}\,\partial C/\partial n$ falls below it.
 
+    **Validating against an external 3D solver**
+
+    :attr:`slab_impedance` defaults to
+    :class:`RootSumSquareSlabSurfaceImpedance`, which corrects for finite
+    strip thickness, while at least one widely used commercial 3D solver
+    applies a plain half-space $Z_s$ and ignores thickness entirely. The two
+    differ by 2-5% over $t/\delta$ = 3.7-6.0, so a cross-tool comparison that
+    leaves the default in place attributes that 2-5% to one tool or the other
+    when it is purely a difference in surface-impedance model. Pass
+    ``slab_impedance=HalfSpaceSurfaceImpedance()`` explicitly for such a
+    comparison. See :class:`WheelerCurrentDistribution` for the full note; the
+    default is unchanged here.
+
     References
     ----------
     Wheeler, H. A. (1942). Formulas for the Skin Effect. Proceedings of the
@@ -371,7 +408,9 @@ class IncrementalInductanceCurrentDistribution(
         default_factory=HammerstadJensenMicrostripFormulation
     )
 
-    #: Finite-thickness surface impedance. See
+    #: Finite-thickness surface impedance. Validating against an external
+    #: half-space solver needs ``HalfSpaceSurfaceImpedance()`` passed here
+    #: explicitly; see **Validating against an external 3D solver**. See
     #: :class:`~pmrf.materials.surface_impedance.AbstractSurfaceImpedance` for
     #: normalisation details.
     slab_impedance: AbstractSurfaceImpedance = eqx.field(
@@ -528,6 +567,19 @@ class TraceGroundCurrentDistribution(
     described as the more accurate, and the microstrip default remains
     :class:`WheelerCurrentDistribution` until it is settled.
 
+    **Validating against an external 3D solver**
+
+    The trace's :attr:`slab_impedance` defaults to
+    :class:`RootSumSquareSlabSurfaceImpedance`, which corrects for finite
+    strip thickness, while at least one widely used commercial 3D solver
+    applies a plain half-space $Z_s$ and ignores thickness entirely. The two
+    differ by 2-5% over $t/\delta$ = 3.7-6.0, so a cross-tool comparison that
+    leaves the default in place attributes that 2-5% to one tool or the other
+    when it is purely a difference in surface-impedance model. Pass
+    ``slab_impedance=HalfSpaceSurfaceImpedance()`` explicitly for such a
+    comparison. See :class:`WheelerCurrentDistribution` for the full note; the
+    default is unchanged here.
+
     **Validity**
 
     $W_g$ is quasi-static and assumes a uniform strip current, so it degrades
@@ -550,6 +602,9 @@ class TraceGroundCurrentDistribution(
 
     #: Finite-thickness surface impedance for the trace. Its dc floor is what
     #: anchors the default configuration's dc resistance at $1/(\sigma WT)$.
+    #: Validating against an external half-space solver needs
+    #: ``HalfSpaceSurfaceImpedance()`` passed here explicitly; see
+    #: **Validating against an external 3D solver**.
     slab_impedance: AbstractSurfaceImpedance = eqx.field(
         default_factory=RootSumSquareSlabSurfaceImpedance
     )

--- a/pmrf/models/components/lines/microstrip.py
+++ b/pmrf/models/components/lines/microstrip.py
@@ -66,16 +66,20 @@ class WheelerCurrentDistribution(AbstractCurrentDistribution[MicrostripCrossSect
 
     :attr:`slab_impedance` defaults to
     :class:`RootSumSquareSlabSurfaceImpedance`, which corrects for finite
-    strip thickness. At least one widely used commercial 3D solver applies a
-    plain half-space
+    strip thickness. 3D solvers commonly run with a skin-effect approximation
+    that neglects thickness in the current distribution, applying a plain
+    half-space
 
     $$Z_s = (1+j)\sqrt{\pi f \mu_0 / \sigma}$$
 
-    and ignores thickness entirely. Over $t/\delta$ = 3.7-6.0 the two models
-    differ by 2-5%, so a cross-tool comparison that leaves the default in
-    place charges the solver for a thickness correction it never applied and
-    attributes the resulting 2-5% discrepancy to one tool or the other when it
-    is purely a difference in surface-impedance model. Pass
+    instead; this has been confirmed on the exported surface impedance of at
+    least one widely used commercial tool. It is not universal, and most
+    solvers allow the approximation to be turned off, so check what the tool
+    was actually run with. Where it is in force, over $t/\delta$ = 3.7-6.0 the
+    two models differ by 2-5%, so a cross-tool comparison that leaves the
+    default in place charges the solver for a thickness correction it never
+    applied and attributes the resulting 2-5% discrepancy to one tool or the
+    other when it is purely a difference in surface-impedance model. Pass
     ``slab_impedance=HalfSpaceSurfaceImpedance()`` explicitly for such a
     comparison, and check where your band sits relative to that
     $t/\delta$ range before deciding whether it matters.
@@ -379,11 +383,13 @@ class IncrementalInductanceCurrentDistribution(
 
     :attr:`slab_impedance` defaults to
     :class:`RootSumSquareSlabSurfaceImpedance`, which corrects for finite
-    strip thickness, while at least one widely used commercial 3D solver
-    applies a plain half-space $Z_s$ and ignores thickness entirely. The two
-    differ by 2-5% over $t/\delta$ = 3.7-6.0, so a cross-tool comparison that
-    leaves the default in place attributes that 2-5% to one tool or the other
-    when it is purely a difference in surface-impedance model. Pass
+    strip thickness, while a 3D solver run with its skin-effect approximation
+    neglects thickness in the current distribution and applies a plain
+    half-space $Z_s$ instead. Most solvers allow that approximation to be
+    turned off, so check what the tool was run with. Where it is in force the
+    two differ by 2-5% over $t/\delta$ = 3.7-6.0, so a cross-tool comparison
+    that leaves the default in place attributes that 2-5% to one tool or the
+    other when it is purely a difference in surface-impedance model. Pass
     ``slab_impedance=HalfSpaceSurfaceImpedance()`` explicitly for such a
     comparison. See :class:`WheelerCurrentDistribution` for the full note; the
     default is unchanged here.
@@ -571,11 +577,13 @@ class TraceGroundCurrentDistribution(
 
     The trace's :attr:`slab_impedance` defaults to
     :class:`RootSumSquareSlabSurfaceImpedance`, which corrects for finite
-    strip thickness, while at least one widely used commercial 3D solver
-    applies a plain half-space $Z_s$ and ignores thickness entirely. The two
-    differ by 2-5% over $t/\delta$ = 3.7-6.0, so a cross-tool comparison that
-    leaves the default in place attributes that 2-5% to one tool or the other
-    when it is purely a difference in surface-impedance model. Pass
+    strip thickness, while a 3D solver run with its skin-effect approximation
+    neglects thickness in the current distribution and applies a plain
+    half-space $Z_s$ instead. Most solvers allow that approximation to be
+    turned off, so check what the tool was run with. Where it is in force the
+    two differ by 2-5% over $t/\delta$ = 3.7-6.0, so a cross-tool comparison
+    that leaves the default in place attributes that 2-5% to one tool or the
+    other when it is purely a difference in surface-impedance model. Pass
     ``slab_impedance=HalfSpaceSurfaceImpedance()`` explicitly for such a
     comparison. See :class:`WheelerCurrentDistribution` for the full note; the
     default is unchanged here.


### PR DESCRIPTION
Documentation only. Adds a note telling anyone validating ParamRF against an external 3D solver that they must pass `slab_impedance=HalfSpaceSurfaceImpedance()` explicitly, or the comparison charges the solver for a thickness correction it never applied.

- `WheelerCurrentDistribution` carries the full **Validating against an external 3D solver** section: the solver's plain half-space `Z_s = (1+j)sqrt(pi f mu_0 / sigma)`, the 2-5% difference, and the `t/delta` = 3.7-6.0 range it applies over.
- `IncrementalInductanceCurrentDistribution` and `TraceGroundCurrentDistribution` carry a condensed version keeping both figures inline, so a reader landing on either can judge their own band without a jump.
- `#:` field comments on all three `slab_impedance` fields point at it.
- No default changes: `RootSumSquareSlabSurfaceImpedance` stays the default everywhere.

Full suite: 570 passed, 28 skipped.

Stacks on #126 (#101).

Closes #121